### PR TITLE
29 improve livestream handling

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -5,6 +5,7 @@
 package ch.srgssr.pillarbox.player
 
 import android.content.Context
+import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
@@ -22,11 +23,11 @@ import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
  * @constructor Create empty Pillarbox player
  */
 class PillarboxPlayer private constructor(private val exoPlayer: ExoPlayer) :
-    ExoPlayer by exoPlayer, Player.Listener {
+    ExoPlayer by exoPlayer {
 
     init {
         addAnalyticsListener(EventLogger())
-        addListener(this)
+        addListener(ComponentListener())
     }
 
     constructor(context: Context, mediaItemSource: MediaItemSource) : this(
@@ -44,4 +45,14 @@ class PillarboxPlayer private constructor(private val exoPlayer: ExoPlayer) :
             )
             .build()
     )
+
+    private inner class ComponentListener : Player.Listener {
+
+        override fun onPlayerError(error: PlaybackException) {
+            if (error.errorCode == PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW) {
+                seekToDefaultPosition()
+                prepare()
+            }
+        }
+    }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
@@ -132,7 +132,6 @@ class PillarboxMediaSource(
 
         override fun getWindow(windowIndex: Int, window: Window, defaultPositionProjectionUs: Long): Window {
             val internalWindow = timeline.getWindow(windowIndex, window, defaultPositionProjectionUs)
-            // Live window with window duration less than LIVE_DVR_MIN_DURATION_MS cannot be seekable (Live only)
             if (internalWindow.isLive()) {
                 internalWindow.isSeekable = internalWindow.durationMs >= LIVE_DVR_MIN_DURATION_MS
             }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
@@ -14,6 +14,7 @@ import androidx.media3.exoplayer.source.MediaPeriod
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.Allocator
 import ch.srgssr.pillarbox.player.data.MediaItemSource
+import ch.srgssr.pillarbox.player.source.PillarboxMediaSource.PillarboxTimeline.Companion.LIVE_DVR_MIN_DURATION_MS
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
@@ -112,12 +113,51 @@ class PillarboxMediaSource(
         timeline: Timeline
     ) {
         Log.d(TAG, "onChildSourceInfoRefreshed: $id")
-        refreshSourceInfo(timeline)
+        refreshSourceInfo(PillarboxTimeline(timeline))
     }
 
     private fun handleException(exception: Throwable) {
         Log.e(TAG, "error while preparing source", exception)
         pendingError = exception
+    }
+
+    /**
+     * Pillarbox timeline wrap the underlying Timeline to suite Pillarbox needs.
+     *  - Live stream with a window duration <= [LIVE_DVR_MIN_DURATION_MS] are not seekable.
+     */
+    private class PillarboxTimeline(private val timeline: Timeline) : Timeline() {
+        override fun getWindowCount(): Int {
+            return timeline.windowCount
+        }
+
+        override fun getWindow(windowIndex: Int, window: Window, defaultPositionProjectionUs: Long): Window {
+            val internalWindow = timeline.getWindow(windowIndex, window, defaultPositionProjectionUs)
+            // Live window with window duration less than LIVE_DVR_MIN_DURATION_MS cannot be seekable (Live only)
+            if (internalWindow.isLive()) {
+                internalWindow.isSeekable = internalWindow.durationMs >= LIVE_DVR_MIN_DURATION_MS
+            }
+            return internalWindow
+        }
+
+        override fun getPeriodCount(): Int {
+            return timeline.periodCount
+        }
+
+        override fun getPeriod(periodIndex: Int, period: Period, setIds: Boolean): Period {
+            return timeline.getPeriod(periodIndex, period, setIds)
+        }
+
+        override fun getIndexOfPeriod(uid: Any): Int {
+            return timeline.getIndexOfPeriod(uid)
+        }
+
+        override fun getUidOfPeriod(periodIndex: Int): Any {
+            return timeline.getUidOfPeriod(periodIndex)
+        }
+
+        companion object {
+            private const val LIVE_DVR_MIN_DURATION_MS = 60000L // 60s
+        }
     }
 
     companion object {


### PR DESCRIPTION
# Pull request

## Description

Enhancement live stream playback after a pause like suggested by [Exoplayer](https://exoplayer.dev/live-streaming.html)

## Changes made

- SeekToDefaultPosition and prepare after a `BehindLiveWindowException` playback exception.
- Make live stream with window duration <= 60s as not seekable.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] All pull request status checks pass.
