### PR TITLE
49 integration with mediasession

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,8 +6,8 @@ import io.gitlab.arturbosch.detekt.Detekt
 
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "7.2.1" apply false
-    id("com.android.library") version "7.2.1" apply false
+    id("com.android.application") version "7.3.1" apply false
+    id("com.android.library") version "7.3.1" apply false
     id("org.jetbrains.kotlin.android") version "1.7.20" apply false
     // https://github.com/detekt/detekt
     id("io.gitlab.arturbosch.detekt").version("1.21.0")

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 object AppConfig {
     const val minSdk = 21
-    const val targetSdk = 32
+    const val targetSdk = 33
     const val compileSdk = 33
 
     @Suppress("SimpleDateFormat")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Jul 29 12:32:30 CEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/pillarbox-analytics/build.gradle.kts
+++ b/pillarbox-analytics/build.gradle.kts
@@ -41,6 +41,7 @@ android {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions
         abortOnError = false
     }
+    namespace = "ch.srgssr.pillarbox.analytics"
     publishing {
         singleVariant("release") {
             withSourcesJar()

--- a/pillarbox-analytics/src/main/AndroidManifest.xml
+++ b/pillarbox-analytics/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
   ~ Copyright (c) 2022. SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ch.srgssr.pillarbox.analytics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/pillarbox-core-business/build.gradle.kts
+++ b/pillarbox-core-business/build.gradle.kts
@@ -47,6 +47,7 @@ android {
     testOptions {
         unitTests.isReturnDefaultValues = true
     }
+    namespace = "ch.srg.pillarbox.core.business"
 }
 
 dependencies {

--- a/pillarbox-core-business/src/main/AndroidManifest.xml
+++ b/pillarbox-core-business/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
   ~ Copyright (c) 2022. SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ch.srg.pillarbox.core.business">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -73,6 +73,7 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    namespace = "ch.srgssr.pillarbox.demo"
 }
 
 dependencies {

--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
     implementation("androidx.core:core-ktx:${Dependencies.ktxVersion}")
     implementation("androidx.appcompat:appcompat:${Dependencies.appCompatVersion}")
     implementation("com.google.android.material:material:${Dependencies.materialVersion}")
+
     implementation("androidx.fragment:fragment-ktx:${Dependencies.fragmentVersion}")
     implementation("androidx.navigation:navigation-ui-ktx:${Dependencies.navigationVersion}")
     implementation("androidx.navigation:navigation-fragment-ktx:${Dependencies.navigationVersion}")
@@ -92,8 +93,9 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:${Dependencies.androidTestVersion}")
     androidTestImplementation("androidx.test.espresso:espresso-core:${Dependencies.espressoVersion}")
 
-    implementation("androidx.compose.material:material:1.3.0")
-    implementation("androidx.compose.ui:ui:1.3.0")
+    implementation("androidx.compose.material:material:1.3.1")
+    implementation("androidx.compose.material:material-icons-extended:1.3.1")
+    implementation("androidx.compose.ui:ui:1.3.1")
     implementation("androidx.activity:activity-compose:1.6.1")
     implementation("androidx.navigation:navigation-compose:${Dependencies.navigationVersion}")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:${Dependencies.lifecycleVersion}")

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -26,9 +26,8 @@
         <activity
             android:name=".ui.player.SimplePlayerActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
-            android:excludeFromRecents="true"
             android:exported="true"
-            android:launchMode="singleInstance"
+            android:launchMode="singleTask"
             android:supportsPictureInPicture="true" />
     </application>
 

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="ch.srgssr.pillarbox.demo">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <application
         android:allowBackup="true"

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -26,7 +26,10 @@
         <activity
             android:name=".ui.player.SimplePlayerActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
-            android:exported="true" />
+            android:excludeFromRecents="true"
+            android:exported="true"
+            android:launchMode="singleInstance"
+            android:supportsPictureInPicture="true" />
     </application>
 
 </manifest>

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
@@ -4,16 +4,21 @@
  */
 package ch.srgssr.pillarbox.demo.ui.player
 
+import android.app.Activity
+import android.view.WindowManager
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.Button
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import androidx.lifecycle.LifecycleOwner
-import androidx.media3.ui.PlayerView
+import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.ui.SRGErrorMessageProvider
 
 /**
@@ -25,34 +30,54 @@ import ch.srgssr.pillarbox.demo.ui.SRGErrorMessageProvider
  */
 @Composable
 fun DemoPlayerView(playerViewModel: SimplePlayerViewModel) {
-    val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
+    val pauseOnBackground = playerViewModel.pauseOnBackground.collectAsState()
+    Column(modifier = Modifier.fillMaxSize()) {
+        PlayerView(
+            player = playerViewModel.player,
+            modifier = Modifier
+                .fillMaxWidth()
+                .wrapContentHeight()
+        )
+        Button(onClick = { playerViewModel.togglePauseOnBackground() }) {
+            Text(text = if (pauseOnBackground.value) "Pause on background" else "Continue on background")
+        }
+    }
+}
+
+@Composable
+private fun PlayerView(player: Player, modifier: Modifier = Modifier) {
+    ScreenOnKeeper()
     AndroidView(
-        modifier = Modifier.fillMaxSize(),
+        modifier = modifier,
         factory = { context ->
-            PlayerView(context).also { view ->
+            androidx.media3.ui.PlayerView(context).also { view ->
+                // Seems not working with Compose
+                // view.keepScreenOn = true
                 view.controllerAutoShow = true
                 view.useController = true
-                view.setShowBuffering(PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
+                view.setShowBuffering(androidx.media3.ui.PlayerView.SHOW_BUFFERING_WHEN_PLAYING)
                 view.setErrorMessageProvider(SRGErrorMessageProvider())
             }
         },
         update = { view ->
-            view.player = playerViewModel.player
+            view.player = player
         }
     )
-    DisposableEffect(lifecycleOwner) {
-        val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) {
-                playerViewModel.resumePlayback()
-            } else if (event == Lifecycle.Event.ON_STOP) {
-                playerViewModel.pausePlayback()
-            }
-        }
-        lifecycleOwner.lifecycle.addObserver(observer)
+}
 
-        // When the effect leaves the Composition, remove the observer
+/**
+ * Screen on keeper
+ *
+ * source : https://stackoverflow.com/questions/69039723/is-there-a-jetpack-compose-equivalent-for-androidkeepscreenon-to-keep-screen-al
+ */
+@Composable
+fun ScreenOnKeeper() {
+    val activity = LocalContext.current as Activity
+
+    DisposableEffect(Unit) {
+        activity.window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         onDispose {
-            lifecycleOwner.lifecycle.removeObserver(observer)
+            activity.window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
         }
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
@@ -10,18 +10,24 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material.Button
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Switch
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PictureInPicture
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.ui.SRGErrorMessageProvider
@@ -39,7 +45,6 @@ fun DemoPlayerView(
     playerViewModel: SimplePlayerViewModel,
     pipClick: () -> Unit = {}
 ) {
-    val pauseOnBackground = playerViewModel.pauseOnBackground.collectAsState()
     val hideUi = playerViewModel.pictureInPictureEnabled.collectAsState()
     Column(modifier = Modifier.fillMaxSize()) {
         PlayerView(
@@ -50,14 +55,37 @@ fun DemoPlayerView(
                 .wrapContentHeight()
         )
         if (!hideUi.value) {
-            Row(modifier = Modifier.fillMaxWidth()) {
-                Button(onClick = { playerViewModel.togglePauseOnBackground() }) {
-                    Text(text = if (pauseOnBackground.value) "Pause on background" else "Continue on background")
-                }
-                IconButton(onClick = pipClick) {
-                    Icon(imageVector = Icons.Default.PictureInPicture, contentDescription = "Go in picture in picture")
-                }
+            DemoControlView(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
+                playerViewModel = playerViewModel, pipClick = pipClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun DemoControlView(
+    modifier: Modifier = Modifier,
+    playerViewModel: SimplePlayerViewModel,
+    pipClick: () -> Unit = {}
+) {
+    val pauseOnBackground = playerViewModel.pauseOnBackground.collectAsState()
+    Column(modifier = modifier) {
+        Row {
+            IconButton(onClick = pipClick) {
+                Icon(imageVector = Icons.Default.PictureInPicture, contentDescription = "Go in picture in picture")
             }
+        }
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                modifier = Modifier.wrapContentWidth(),
+                text = "Background playback",
+                style = MaterialTheme.typography.caption,
+                fontWeight = FontWeight.Bold
+            )
+            Switch(checked = !pauseOnBackground.value, onCheckedChange = { playerViewModel.togglePauseOnBackground() })
         }
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -22,9 +22,10 @@ import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import kotlinx.coroutines.flow.collectLatest
 
 /**
- * Simple player activity using a SimplePlayerFragment
+ * Simple player activity that can handle picture in picture.
  *
- * @constructor Create empty Simple player activity
+ * For this demo, only the picture in picture button can enable picture in picture.
+ * But feel free to call [startPictureInPicture] whenever you decide, for example when [onUserLeaveHint]
  */
 class SimplePlayerActivity : ComponentActivity() {
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -15,6 +15,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.annotation.RequiresApi
+import androidx.compose.material.Surface
 import androidx.lifecycle.lifecycleScope
 import ch.srgssr.pillarbox.demo.data.DemoItem
 import ch.srgssr.pillarbox.demo.data.Playlist
@@ -58,11 +59,13 @@ class SimplePlayerActivity : ComponentActivity() {
 
         setContent {
             PillarboxTheme {
-                DemoPlayerView(playerViewModel = playerViewModel) {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                        startPictureInPicture()
-                    } else {
-                        Toast.makeText(this, "PiP not supported", Toast.LENGTH_LONG).show()
+                Surface {
+                    DemoPlayerView(playerViewModel = playerViewModel) {
+                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                            startPictureInPicture()
+                        } else {
+                            Toast.makeText(this, "PiP not supported", Toast.LENGTH_LONG).show()
+                        }
                     }
                 }
             }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -4,16 +4,22 @@
  */
 package ch.srgssr.pillarbox.demo.ui.player
 
+import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.Intent
+import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.annotation.RequiresApi
+import androidx.lifecycle.lifecycleScope
 import ch.srgssr.pillarbox.demo.data.DemoItem
 import ch.srgssr.pillarbox.demo.data.Playlist
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import kotlinx.coroutines.flow.collectLatest
 
 /**
  * Simple player activity using a SimplePlayerFragment
@@ -24,23 +30,66 @@ class SimplePlayerActivity : ComponentActivity() {
 
     private val playerViewModel: SimplePlayerViewModel by viewModels()
 
+    private fun playFromIntent(intent: Intent) {
+        intent.extras?.let {
+            val playlist: Playlist = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                it.getSerializable(ARG_PLAYLIST, Playlist::class.java)!!
+            } else {
+                it.getSerializable(ARG_PLAYLIST) as Playlist
+            }
+            playerViewModel.playUri(playlist.items)
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        if (savedInstanceState == null) {
-            intent.extras?.let {
-                val playlist: Playlist = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                    it.getSerializable(ARG_PLAYLIST, Playlist::class.java)!!
-                } else {
-                    it.getSerializable(ARG_PLAYLIST) as Playlist
+        playFromIntent(intent)
+        lifecycleScope.launchWhenCreated {
+            playerViewModel.pictureInPictureRatio.collectLatest {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && playerViewModel.pictureInPictureEnabled.value) {
+                    val params = PictureInPictureParams.Builder()
+                        .setAspectRatio(playerViewModel.pictureInPictureRatio.value)
+                        .build()
+                    setPictureInPictureParams(params)
                 }
-                playerViewModel.playUri(playlist.items)
             }
         }
+
         setContent {
             PillarboxTheme {
-                DemoPlayerView(playerViewModel = playerViewModel)
+                DemoPlayerView(playerViewModel = playerViewModel) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                        startPictureInPicture()
+                    } else {
+                        Toast.makeText(this, "PiP not supported", Toast.LENGTH_LONG).show()
+                    }
+                }
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent?) {
+        super.onNewIntent(intent)
+        intent?.let {
+            playFromIntent(it)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun startPictureInPicture() {
+        val params = PictureInPictureParams.Builder()
+            .setAspectRatio(playerViewModel.pictureInPictureRatio.value)
+            .build()
+        enterPictureInPictureMode(params)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: Configuration
+    ) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        playerViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
     }
 
     override fun onStart() {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -43,6 +43,18 @@ class SimplePlayerActivity : ComponentActivity() {
         }
     }
 
+    override fun onStart() {
+        super.onStart()
+        playerViewModel.player.play()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        if (playerViewModel.pauseOnBackground.value) {
+            playerViewModel.player.pause()
+        }
+    }
+
     companion object {
         private const val ARG_PLAYLIST = "ARG_PLAYLIST"
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
@@ -5,6 +5,9 @@
 package ch.srgssr.pillarbox.demo.ui.player
 
 import android.app.Application
+import android.app.PendingIntent
+import android.content.Intent
+import android.os.Build
 import android.util.Log
 import android.util.Rational
 import androidx.lifecycle.AndroidViewModel
@@ -47,7 +50,9 @@ class SimplePlayerViewModel(application: Application) : AndroidViewModel(applica
     /**
      * Hold the Media session with the same lifecycle of this ViewModel and by extension the [player]
      */
-    private val mediaSession = MediaSession.Builder(application, player).build()
+    private val mediaSession = MediaSession.Builder(application, player)
+        .setSessionActivity(sessionActivity())
+        .build()
     private val _pauseOnBackground = MutableStateFlow(true)
 
     /**
@@ -177,6 +182,20 @@ class SimplePlayerViewModel(application: Application) : AndroidViewModel(applica
 
     override fun onPlaybackParametersChanged(playbackParameters: PlaybackParameters) {
         Log.d(TAG, "onPlaybackParametersChanged ${playbackParameters.speed}")
+    }
+
+    private fun sessionActivity(): PendingIntent {
+        val intent = Intent(getApplication(), SimplePlayerActivity::class.java)
+        val flags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        else
+            PendingIntent.FLAG_UPDATE_CURRENT
+        return PendingIntent.getActivity(
+            getApplication(),
+            0,
+            intent,
+            flags
+        )
     }
 
     companion object {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.demo.ui.player
 
 import android.app.Application
 import android.util.Log
+import android.util.Rational
 import androidx.lifecycle.AndroidViewModel
 import androidx.media3.common.C
 import androidx.media3.common.MediaMetadata
@@ -13,6 +14,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.VideoSize
 import androidx.media3.session.MediaSession
 import ch.srg.pillarbox.core.business.MediaCompositionMediaItemSource
 import ch.srg.pillarbox.core.business.akamai.AkamaiTokenDataSource
@@ -54,6 +56,16 @@ class SimplePlayerViewModel(application: Application) : AndroidViewModel(applica
      */
     val pauseOnBackground: StateFlow<Boolean> = _pauseOnBackground
 
+    /**
+     * Picture in picture enabled
+     */
+    val pictureInPictureEnabled = MutableStateFlow(false)
+
+    /**
+     * Picture in picture aspect ratio
+     */
+    var pictureInPictureRatio = MutableStateFlow(Rational(1, 1))
+
     init {
         player.addListener(this)
         /*
@@ -81,7 +93,7 @@ class SimplePlayerViewModel(application: Application) : AndroidViewModel(applica
      * @param items to play
      */
     fun playUri(items: List<DemoItem>) {
-        player.addMediaItems(items.map { it.toMediaItem() })
+        player.setMediaItems(items.map { it.toMediaItem() })
         player.prepare()
         player.play()
     }
@@ -98,6 +110,15 @@ class SimplePlayerViewModel(application: Application) : AndroidViewModel(applica
         player.release()
         player.removeListener(this)
         mediaSession.release()
+    }
+
+    override fun onVideoSizeChanged(videoSize: VideoSize) {
+        val rational = if (videoSize == VideoSize.UNKNOWN) {
+            Rational(1, 1)
+        } else {
+            Rational(videoSize.width, videoSize.height)
+        }
+        pictureInPictureRatio.value = rational
     }
 
     override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation("androidx.core:core-ktx:${Dependencies.ktxVersion}")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:${Dependencies.coroutinesVersion}")
     api("androidx.media3:media3-exoplayer:${Dependencies.media3Version}")
+    api("androidx.media3:media3-session:${Dependencies.media3Version}")
     implementation("androidx.media3:media3-exoplayer-dash:${Dependencies.media3Version}")
     implementation("androidx.media3:media3-exoplayer-hls:${Dependencies.media3Version}")
     testImplementation("junit:junit:${Dependencies.testVersion}")

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -41,6 +41,7 @@ android {
         // https://developer.android.com/reference/tools/gradle-api/4.1/com/android/build/api/dsl/LintOptions
         abortOnError = false
     }
+    namespace = "ch.srgssr.pillarbox.player"
     publishing {
         singleVariant("release") {
             withSourcesJar()

--- a/pillarbox-player/docs/README.md
+++ b/pillarbox-player/docs/README.md
@@ -91,6 +91,20 @@ that_**.
 player.release()
 ```
 
+### Connect the player to the MediaSession
+
+```kotlin
+val mediaSession = MediaSession.Builder(application, player).build()
+```
+
+Don't forget to release the `MediaSession` when you no longer need it or when releasing the player with
+
+```kotlin
+mediaSession.release()
+```
+
+More information about `MediaSession` is available [here](https://developer.android.com/guide/topics/media/media3/getting-started/mediasession)
+
 ## Exoplayer
 
 As `PillarboxPlayer` extending an _Exoplayer_ `Player`, all documentation related to Exoplayer is valid for Pillarbox.

--- a/pillarbox-player/src/main/AndroidManifest.xml
+++ b/pillarbox-player/src/main/AndroidManifest.xml
@@ -3,8 +3,7 @@
   ~ Copyright (c) 2022. SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="ch.srgssr.pillarbox.player">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -53,6 +53,14 @@ class PillarboxPlayer private constructor(private val exoPlayer: ExoPlayer) :
             .build()
     )
 
+    /**
+     * Handle audio focus with currently set AudioAttributes
+     * @param handleAudioFocus true if the player should handle audio focus, false otherwise.
+     */
+    fun setHandleAudioFocus(handleAudioFocus: Boolean) {
+        setAudioAttributes(audioAttributes, handleAudioFocus)
+    }
+
     private inner class ComponentListener : Player.Listener {
 
         override fun onPlayerError(error: PlaybackException) {


### PR DESCRIPTION
# Pull request

## Description

Add `MediaSession` integration with Pillarbox. We basically can directly use the media3 `MediaSession`.

To inspect the MediaSession is correctly integrated, we improve the demo to handle

- Continue playback when the Activity is in background. Stop playback when we quite the PlayerActivity.
- Integrate a basic example of Picture in picture.
 
## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
