### PR TITLE
AspectRatio nullable instead of 0.0f

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/Extensions.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/Extensions.kt
@@ -11,6 +11,6 @@ import androidx.media3.common.VideoSize
  *
  * @param unknownAspectRatioValue
  */
-fun VideoSize.computeAspectRatio(unknownAspectRatioValue: Float): Float {
+fun VideoSize.computeAspectRatio(unknownAspectRatioValue: Float?): Float? {
     return if (height == 0 || width == 0) unknownAspectRatioValue else width * this.pixelWidthHeightRatio / height
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestAspectRatio.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestAspectRatio.kt
@@ -15,6 +15,13 @@ import org.junit.Test
 class TestAspectRatio {
 
     @Test
+    fun testUnknownVideoSizeNullAspectRatio() {
+        val input = VideoSize.UNKNOWN
+        val unknownAspectRatio = null
+        Assert.assertNull(input.computeAspectRatio(unknownAspectRatio))
+    }
+
+    @Test
     fun testUnknownVideoSize() {
         val input = VideoSize.UNKNOWN
         val expectedAspectRatio = 0.0f

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/AspectRatioBox.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/AspectRatioBox.kt
@@ -28,7 +28,7 @@ import kotlin.math.roundToInt
 @Composable
 fun AspectRatioBox(
     modifier: Modifier = Modifier,
-    aspectRatio: Float = 0.0f,
+    aspectRatio: Float? = null,
     scaleMode: ScaleMode = ScaleMode.Fit,
     contentAlignment: Alignment = Alignment.Center,
     content: @Composable () -> Unit
@@ -42,8 +42,8 @@ fun AspectRatioBox(
     Layout(measurePolicy = measurePolicy, content = content, modifier = internalModifier)
 }
 
-internal fun getContentConstraints(constraints: Constraints, aspectRatio: Float, scaleMode: ScaleMode): Constraints {
-    if (aspectRatio == 0.0f) {
+internal fun getContentConstraints(constraints: Constraints, aspectRatio: Float?, scaleMode: ScaleMode): Constraints {
+    if (aspectRatio == null || aspectRatio == 0.0f) {
         return constraints
     }
     val width = constraints.minWidth.coerceAtLeast(constraints.maxWidth)
@@ -77,7 +77,7 @@ internal fun getContentConstraints(constraints: Constraints, aspectRatio: Float,
     }
 }
 
-internal fun contentViewMeasurePolicy(aspectRatio: Float, scaleMode: ScaleMode, contentAlignment: Alignment) =
+internal fun contentViewMeasurePolicy(aspectRatio: Float?, scaleMode: ScaleMode, contentAlignment: Alignment) =
     MeasurePolicy { measurables, constraints ->
         val contentConstraints = getContentConstraints(constraints, aspectRatio, scaleMode)
         val placeables = measurables.map { measurable -> measurable.measure(contentConstraints) }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurface.kt
@@ -26,7 +26,7 @@ import okhttp3.internal.toImmutableList
  * @param modifier The modifier to be applied to the layout.
  * @param scaleMode The scale mode to use.
  * @param contentAlignment The "letterboxing" content alignment inside the parent.
- * @param defaultAspectRatio The aspect ratio to use while video is loading or for audio content. 0.0f
+ * @param defaultAspectRatio The aspect ratio to use while video is loading or for audio content.
  * @param content The Composable content to display on top of the Surface.
  */
 @Composable
@@ -35,7 +35,7 @@ fun PlayerSurface(
     modifier: Modifier = Modifier,
     scaleMode: ScaleMode = ScaleMode.Fit,
     contentAlignment: Alignment = Alignment.Center,
-    defaultAspectRatio: Float = 0.0f,
+    defaultAspectRatio: Float? = null,
     content: @Composable () -> Unit = {}
 ) {
     val playerSize = rememberPlayerSize(player = player)


### PR DESCRIPTION
## Description

Default aspect ratio, meaning the aspect ratio to use when playing a non video content to use, has a nullable value. Null value to disable aspect ratio while loading or for audio content.

## Changes made

DefaultAspectRatio value is nullable now and by default is set to null. Before it was 0.0f.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
