### PR TITLE
Rename PlayerViewModel to PlayerState

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlaybackControls.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlaybackControls.kt
@@ -34,19 +34,19 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
+import ch.srgssr.pillarbox.player.PlayerState
 import ch.srgssr.pillarbox.player.canPlayPause
 import ch.srgssr.pillarbox.player.canSeek
 import ch.srgssr.pillarbox.player.canSeekBack
 import ch.srgssr.pillarbox.player.canSeekForward
 import ch.srgssr.pillarbox.player.canSeekToNext
 import ch.srgssr.pillarbox.player.canSeekToPrevious
-import ch.srgssr.pillarbox.player.viewmodel.PlayerViewModel
-import ch.srgssr.pillarbox.ui.viewmodel.availableCommands
-import ch.srgssr.pillarbox.ui.viewmodel.currentPosition
-import ch.srgssr.pillarbox.ui.viewmodel.duration
-import ch.srgssr.pillarbox.ui.viewmodel.isPlaying
-import ch.srgssr.pillarbox.ui.viewmodel.playbackState
-import ch.srgssr.pillarbox.ui.viewmodel.rememberPlayerViewModel
+import ch.srgssr.pillarbox.ui.availableCommands
+import ch.srgssr.pillarbox.ui.currentPosition
+import ch.srgssr.pillarbox.ui.duration
+import ch.srgssr.pillarbox.ui.isPlaying
+import ch.srgssr.pillarbox.ui.playbackState
+import ch.srgssr.pillarbox.ui.rememberPlayerState
 
 /**
  * Demo controls
@@ -59,20 +59,20 @@ fun DemoPlaybackControls(
     player: Player,
     modifier: Modifier = Modifier
 ) {
-    val playerViewModel: PlayerViewModel = rememberPlayerViewModel(player = player)
+    val playerState: PlayerState = rememberPlayerState(player = player)
     Box(modifier = modifier) {
-        if (playerViewModel.playbackState() == Player.STATE_BUFFERING) {
+        if (playerState.playbackState() == Player.STATE_BUFFERING) {
             CircularProgressIndicator(modifier = Modifier.align(Alignment.Center), color = Color.White)
         }
-        PlaybackButtonRow(player = player, playerViewModel = playerViewModel, modifier = Modifier.align(Alignment.Center))
+        PlaybackButtonRow(player = player, playerState = playerState, modifier = Modifier.align(Alignment.Center))
         TimeSlider(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .fillMaxWidth()
                 .padding(8.dp),
-            position = playerViewModel.currentPosition(),
-            duration = playerViewModel.duration(),
-            enabled = playerViewModel.availableCommands().canSeek(),
+            position = playerState.currentPosition(),
+            duration = playerState.duration(),
+            enabled = playerState.availableCommands().canSeek(),
             onSeek = { positionMs, finished ->
                 if (finished) {
                     player.seekTo(positionMs)
@@ -83,8 +83,8 @@ fun DemoPlaybackControls(
 }
 
 @Composable
-private fun PlaybackButtonRow(player: Player, playerViewModel: PlayerViewModel, modifier: Modifier = Modifier) {
-    val availableCommands = playerViewModel.availableCommands()
+private fun PlaybackButtonRow(player: Player, playerState: PlayerState, modifier: Modifier = Modifier) {
+    val availableCommands = playerState.availableCommands()
     val togglePlaybackFunction = remember {
         {
             if (player.playbackState == Player.STATE_ENDED) {
@@ -108,7 +108,7 @@ private fun PlaybackButtonRow(player: Player, playerViewModel: PlayerViewModel, 
             isEnabled = availableCommands.canSeekBack(),
             onClick = player::seekBack
         )
-        val isPlaying = playerViewModel.isPlaying()
+        val isPlaying = playerState.isPlaying()
         Button(
             isEnabled = availableCommands.canPlayPause(),
             icon = if (isPlaying) Icons.Default.Pause else Icons.Default.PlayArrow,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerDisposable.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerDisposable.kt
@@ -2,7 +2,7 @@
  * Copyright (c) 2023. SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.player.viewmodel
+package ch.srgssr.pillarbox.player
 
 /**
  * Player disposable with a dispose method to clear events listening.

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerState.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerState.kt
@@ -4,7 +4,7 @@
  */
 @file:Suppress("MemberVisibilityCanBePrivate")
 
-package ch.srgssr.pillarbox.player.viewmodel
+package ch.srgssr.pillarbox.player
 
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
@@ -20,17 +20,17 @@ import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.isActive
 
 /**
- * PlayerViewModel provides Flow's to receive [Player] events like playback state or current position.
- * Don't forget to call [PlayerViewModel.dispose] when it is no more needed.
+ * PlayerState provides Flow's to receive [Player] events like playback state or current position.
+ * Don't forget to call [PlayerState.dispose] when it is no more needed.
  *
- * Sample with ViewModel integration :
+ * Sample with PlayerState integration :
  *
  *      SamplePlayerViewModel(player:Player) : ViewModel(){
- *          val playerViewModel = PlayerViewModel(player)
+ *          val playerState = PlayerState(player)
  *
  *          @Override
  *          fun onCleared(){
- *              playerViewModel.dispose()
+ *              playerState.dispose()
  *          }
  *      }
  *
@@ -38,19 +38,19 @@ import kotlinx.coroutines.isActive
  *
  *      @Composable
  *      fun DemoPlayer(player:Player) {
- *          val playerViewModel = remember(player) {
- *              PlayerViewModel(player)
+ *          val playerState = remember(player) {
+ *              PlayerState(player)
  *          }
  *          DisposableEffect(states) {
  *              onDispose {
- *                  playerViewModel.dispose()
+ *                  playerState.dispose()
  *              }
  *          }
  *      }
  *
  * @property player The Player to observe.
  */
-open class PlayerViewModel(val player: Player) : PlayerDisposable {
+open class PlayerState(val player: Player) : PlayerDisposable {
     private val playerListener = PlayerListener()
     private val _isPlaying = MutableStateFlow(player.isPlaying)
     private val _isLoading = MutableStateFlow(player.isLoading)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/viewmodel/TestPlayerState.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/viewmodel/TestPlayerState.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import ch.srgssr.pillarbox.player.PlayerListenerCommander
+import ch.srgssr.pillarbox.player.PlayerState
 import io.mockk.*
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.TimeoutCancellationException
@@ -25,7 +26,7 @@ import org.junit.Before
 import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class TestPlayerViewModel {
+class TestPlayerState {
 
     private lateinit var player: Player
 
@@ -56,7 +57,7 @@ class TestPlayerViewModel {
         every { player.playerError } returns error
         every { player.availableCommands } returns availableCommands
 
-        val viewModel = PlayerViewModel(player)
+        val viewModel = PlayerState(player)
 
         val isPlayingValue = viewModel.isPlaying.take(1).first()
         val isLoadingValue = viewModel.isLoading.take(1).first()
@@ -79,7 +80,7 @@ class TestPlayerViewModel {
     fun periodicTickerWhilePlaying() = runTest {
         every { player.isPlaying } returns true
         every { player.currentPosition } returnsMany listOf(12_000L, 13_000L, 14_000L)
-        val viewModel = PlayerViewModel(player)
+        val viewModel = PlayerState(player)
         val currentPositionValues = viewModel.currentPosition.take(3).toList()
 
         Assert.assertEquals(listOf(12_000L, 13_000L, 14_000L), currentPositionValues)
@@ -92,7 +93,7 @@ class TestPlayerViewModel {
     fun periodicTickerWhenNotPlaying() = runTest {
         every { player.isPlaying } returns false
         every { player.currentPosition } returnsMany listOf(12_000L, 13_000L, 14_000L)
-        val viewModel = PlayerViewModel(player)
+        val viewModel = PlayerState(player)
         withTimeout(2_000) {
             viewModel.currentPosition.take(2).toList() // emit only once because ticker not started.
         }
@@ -102,7 +103,7 @@ class TestPlayerViewModel {
     fun isPlaying() = runTest {
         every { player.isPlaying } returns false
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
         launch {
             delay(100)
@@ -119,7 +120,7 @@ class TestPlayerViewModel {
     fun isLoading() = runTest {
         every { player.isLoading } returns false
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
         launch {
             delay(100)
@@ -137,7 +138,7 @@ class TestPlayerViewModel {
         every { player.playbackState } returns Player.STATE_IDLE
         val playbackStates = listOf(Player.STATE_IDLE, Player.STATE_BUFFERING, Player.STATE_READY, Player.STATE_BUFFERING, Player.STATE_ENDED)
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
         launch {
             for (state in playbackStates) {
@@ -155,7 +156,7 @@ class TestPlayerViewModel {
         val durations = listOf(C.TIME_UNSET, 30_000, 40_000)
         every { player.duration } returnsMany durations
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
         launch {
             delay(100)
@@ -175,7 +176,7 @@ class TestPlayerViewModel {
         val errors = listOf(null, mockk<PlaybackException>(), null)
         every { player.playerError } returnsMany errors
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
         launch {
             for (error in errors) {
@@ -196,7 +197,7 @@ class TestPlayerViewModel {
         val availableCommands = listOf(command1, command2)
         every { player.availableCommands } returnsMany availableCommands
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
         launch {
             for (command in availableCommands) {
@@ -215,7 +216,7 @@ class TestPlayerViewModel {
         every { player.currentPosition } returnsMany positions
         every { player.isPlaying } returns false
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
         launch {
             for (position in positions) {
@@ -238,7 +239,7 @@ class TestPlayerViewModel {
         every { player.currentPosition } returnsMany positions
         every { player.isPlaying } returns true
         val playerListenerCommander = PlayerListenerCommander(player)
-        val viewModel = PlayerViewModel(playerListenerCommander)
+        val viewModel = PlayerState(playerListenerCommander)
         Assert.assertTrue(playerListenerCommander.hasListeners)
 
         val currentPositionValues = viewModel.currentPosition.take(positions.size).toList()

--- a/pillarbox-ui/docs/README.md
+++ b/pillarbox-ui/docs/README.md
@@ -70,16 +70,16 @@ In this example we use `ScaleMode.Fit` to fit the content to the parent containe
 
 ### Listen to player states
 
-To listen to player states _Pillarbox_ provides some tools, `PlayerViewModel` and some Compose extensions.
+To listen to player states _Pillarbox_ provides some tools, `PlayerState` and some Compose extensions.
 
 ```kotlin
-// Pillarbox PlayerViewModel extensions
+// Pillarbox PlayerState extensions
 import ch.srgssr.pillarbox.ui.viewmodel.currentPosition
 import ch.srgssr.pillarbox.ui.viewmodel.duration
 import ch.srgssr.pillarbox.ui.viewmodel.isPlaying
 
 @Composable
-fun MyPlayer(player: Player) {
+fun MyPlayerView(player: Player) {
     val defaultAspectRatio = 1.0f
     Box(
         modifier = Modifier
@@ -94,16 +94,16 @@ fun MyPlayer(player: Player) {
             scaleMode = ScaleMode.Fit,
             defaultAspectRatio = defaultAspectRatio
         )
-        val playerViewModel = rememberPlayerViewModel(player)
+        val playerState = rememberPlayerState(player)
         
         // Displays current position periodically
-        val currentPosition = playerViewModel.currentPosition()
+        val currentPosition = playerState.currentPosition()
         Text(text = "Position = $currentPosition ms", modifier = Modifier.align(Alignment.TopStart))
         
-        val duration = playerViewModel.duration()
+        val duration = playerState.duration()
         Text(text = "Duration = $duration ms", modifier = Modifier.align(Alignment.TopEnd))
         
-        val isPlaying = playerViewModel.isPlaying()
+        val isPlaying = playerState.isPlaying()
         Button(modifier = Modifier = Modififer.align(Alignement.Center), onClick = { togglePlayingBack() }){
             Text(text = if(isPlaying) "Pause" else "Play")
         }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ComposablePlayerState.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ComposablePlayerState.kt
@@ -2,60 +2,60 @@
  * Copyright (c) 2023. SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.ui.viewmodel
+package ch.srgssr.pillarbox.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
 import androidx.media3.common.Player
-import ch.srgssr.pillarbox.player.viewmodel.PlayerDisposable
-import ch.srgssr.pillarbox.player.viewmodel.PlayerViewModel
+import ch.srgssr.pillarbox.player.PlayerDisposable
+import ch.srgssr.pillarbox.player.PlayerState
 
 /**
  * Is playing [Player.isPlaying]
  */
 @Composable
-fun PlayerViewModel.isPlaying(): Boolean = isPlaying.collectAsState().value
+fun PlayerState.isPlaying(): Boolean = isPlaying.collectAsState().value
 
 /**
  * Is playing [Player.isLoading]
  */
 @Composable
-fun PlayerViewModel.isLoading() = isLoading.collectAsState().value
+fun PlayerState.isLoading() = isLoading.collectAsState().value
 
 /**
  * Is playing [Player.getPlaybackState]
  */
 @Composable
-fun PlayerViewModel.playbackState() = playbackState.collectAsState().value
+fun PlayerState.playbackState() = playbackState.collectAsState().value
 
 /**
  * Is playing [Player.getCurrentPosition]
  */
 @Composable
-fun PlayerViewModel.currentPosition() = currentPosition.collectAsState(player.currentPosition).value
+fun PlayerState.currentPosition() = currentPosition.collectAsState(player.currentPosition).value
 
 /**
  * Is playing [Player.getDuration]
  */
 @Composable
-fun PlayerViewModel.duration() = duration.collectAsState().value
+fun PlayerState.duration() = duration.collectAsState().value
 
 /**
  * Available commands [Player.getAvailableCommands]
  */
 @Composable
-fun PlayerViewModel.availableCommands() = availableCommands.collectAsState().value
+fun PlayerState.availableCommands() = availableCommands.collectAsState().value
 
 /**
- * Create a remember a PlayerViewModel
+ * Create a remember a [PlayerState]
  *
- * @param player Player to create a PlayerViewModel
+ * @param player Player to create a [PlayerState]
  */
 @Composable
-fun rememberPlayerViewModel(player: Player): PlayerViewModel {
-    return rememberPlayerViewModel(player = player) { PlayerViewModel(it) }
+fun rememberPlayerState(player: Player): PlayerState {
+    return rememberPlayerState(player = player) { PlayerState(it) }
 }
 
 /**
@@ -67,7 +67,7 @@ fun rememberPlayerViewModel(player: Player): PlayerViewModel {
  * @param factory The factory to create a instance of T from P.
  */
 @Composable
-fun <T : PlayerDisposable, P : Player> rememberPlayerViewModel(player: P, factory: (P) -> T): T {
+fun <T : PlayerDisposable, P : Player> rememberPlayerState(player: P, factory: (P) -> T): T {
     val states = remember(player) {
         factory(player)
     }


### PR DESCRIPTION
## Description

Rename `PlayerViewModel` to `PlayerState` to avoid confusion with Android ViewModel and better representing the purpose of this classe.

## Changes made

- Rename `PlayerViewModel` to `PlayerState`

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] All pull request status checks pass.
