### PR TITLE
84 generic tracker api updatable

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/MediaCompositionMediaItemSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/MediaCompositionMediaItemSource.kt
@@ -16,7 +16,9 @@ import ch.srg.pillarbox.core.business.integrationlayer.data.Resource
 import ch.srg.pillarbox.core.business.integrationlayer.data.ResourceNotFoundException
 import ch.srg.pillarbox.core.business.integrationlayer.service.MediaCompositionDataSource
 import ch.srg.pillarbox.core.business.integrationlayer.service.RemoteResult
+import ch.srg.pillarbox.core.business.tracker.SRGEventLoggerTracker
 import ch.srgssr.pillarbox.player.data.MediaItemSource
+import ch.srgssr.pillarbox.player.getTrackers
 
 /**
  * Load [MediaItem] playable from a [ch.srg.pillarbox.core.business.integrationlayer.data.MediaComposition]
@@ -67,10 +69,14 @@ class MediaCompositionMediaItemSource(private val mediaCompositionDataSource: Me
                 if (resource.tokenType == Resource.TokenType.AKAMAI) {
                     uri = appendTokenQueryToUri(uri)
                 }
+                val trackers = mediaItem.getTrackers()
+                if (BuildConfig.DEBUG) {
+                    trackers.append(SRGEventLoggerTracker())
+                }
                 return mediaItem.buildUpon()
                     .setMediaMetadata(fillMetaData(mediaItem.mediaMetadata, chapter))
                     .setDrmConfiguration(fillDrmConfiguration(resource))
-                    .setTag(result)
+                    .setTag(trackers)
                     .setUri(uri)
                     .build()
             }

--- a/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/MediaCompositionMediaItemSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/MediaCompositionMediaItemSource.kt
@@ -18,7 +18,8 @@ import ch.srg.pillarbox.core.business.integrationlayer.service.MediaCompositionD
 import ch.srg.pillarbox.core.business.integrationlayer.service.RemoteResult
 import ch.srg.pillarbox.core.business.tracker.SRGEventLoggerTracker
 import ch.srgssr.pillarbox.player.data.MediaItemSource
-import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
+import ch.srgssr.pillarbox.player.getMediaItemTrackerData
+import ch.srgssr.pillarbox.player.setTrackerData
 
 /**
  * Load [MediaItem] playable from a [ch.srg.pillarbox.core.business.integrationlayer.data.MediaComposition]
@@ -69,12 +70,12 @@ class MediaCompositionMediaItemSource(private val mediaCompositionDataSource: Me
                 if (resource.tokenType == Resource.TokenType.AKAMAI) {
                     uri = appendTokenQueryToUri(uri)
                 }
-                val trackers = MediaItemTrackerData()
-                trackers.putData(SRGEventLoggerTracker::class.java, null)
+                val trackerData = mediaItem.getMediaItemTrackerData()
+                trackerData.putData(SRGEventLoggerTracker::class.java, null)
                 return mediaItem.buildUpon()
                     .setMediaMetadata(fillMetaData(mediaItem.mediaMetadata, chapter))
                     .setDrmConfiguration(fillDrmConfiguration(resource))
-                    .setTag(trackers)
+                    .setTrackerData(trackerData)
                     .setUri(uri)
                     .build()
             }

--- a/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/MediaCompositionMediaItemSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/MediaCompositionMediaItemSource.kt
@@ -18,7 +18,7 @@ import ch.srg.pillarbox.core.business.integrationlayer.service.MediaCompositionD
 import ch.srg.pillarbox.core.business.integrationlayer.service.RemoteResult
 import ch.srg.pillarbox.core.business.tracker.SRGEventLoggerTracker
 import ch.srgssr.pillarbox.player.data.MediaItemSource
-import ch.srgssr.pillarbox.player.getTrackers
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
 
 /**
  * Load [MediaItem] playable from a [ch.srg.pillarbox.core.business.integrationlayer.data.MediaComposition]
@@ -69,10 +69,8 @@ class MediaCompositionMediaItemSource(private val mediaCompositionDataSource: Me
                 if (resource.tokenType == Resource.TokenType.AKAMAI) {
                     uri = appendTokenQueryToUri(uri)
                 }
-                val trackers = mediaItem.getTrackers()
-                if (BuildConfig.DEBUG) {
-                    trackers.append(SRGEventLoggerTracker())
-                }
+                val trackers = MediaItemTrackerData()
+                trackers.putData(SRGEventLoggerTracker::class.java, null)
                 return mediaItem.buildUpon()
                     .setMediaMetadata(fillMetaData(mediaItem.mediaMetadata, chapter))
                     .setDrmConfiguration(fillDrmConfiguration(resource))

--- a/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
@@ -25,6 +25,10 @@ class SRGEventLoggerTracker : MediaItemTracker {
         player.removeAnalyticsListener(eventLogger)
     }
 
+    override fun update(data: Any) {
+        Log.w(TAG, "---- Update data = $data")
+    }
+
     /**
      * Factory for a [SRGEventLoggerTracker]
      */

--- a/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
@@ -16,13 +16,23 @@ class SRGEventLoggerTracker : MediaItemTracker {
     private val eventLogger = EventLogger(TAG)
 
     override fun start(player: ExoPlayer) {
-        Log.d(TAG, "---- Start")
+        Log.w(TAG, "---- Start")
         player.addAnalyticsListener(eventLogger)
     }
 
     override fun stop(player: ExoPlayer) {
-        Log.d(TAG, "---- Stop")
+        Log.w(TAG, "---- Stop")
         player.removeAnalyticsListener(eventLogger)
+    }
+
+    /**
+     * Factory for a [SRGEventLoggerTracker]
+     */
+    class Factory : MediaItemTracker.Factory {
+
+        override fun create(): MediaItemTracker {
+            return SRGEventLoggerTracker()
+        }
     }
 
     companion object {

--- a/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srg/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srg.pillarbox.core.business.tracker
+
+import android.util.Log
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.util.EventLogger
+import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+
+/**
+ * Enable/Disable EventLogger when item is currently active.
+ */
+class SRGEventLoggerTracker : MediaItemTracker {
+    private val eventLogger = EventLogger(TAG)
+
+    override fun start(player: ExoPlayer) {
+        Log.d(TAG, "---- Start")
+        player.addAnalyticsListener(eventLogger)
+    }
+
+    override fun stop(player: ExoPlayer) {
+        Log.d(TAG, "---- Stop")
+        player.removeAnalyticsListener(eventLogger)
+    }
+
+    companion object {
+        private const val TAG = "SRGLogger"
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Dependencies.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Dependencies.kt
@@ -9,7 +9,9 @@ import ch.srg.pillarbox.core.business.MediaCompositionMediaItemSource
 import ch.srg.pillarbox.core.business.akamai.AkamaiTokenDataSource
 import ch.srg.pillarbox.core.business.integrationlayer.service.IlHost
 import ch.srg.pillarbox.core.business.integrationlayer.service.MediaCompositionDataSourceImpl
+import ch.srg.pillarbox.core.business.tracker.SRGEventLoggerTracker
 import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
 
 /**
  * Dependencies to make custom Dependency Injection
@@ -36,7 +38,10 @@ object Dependencies {
             /**
              * Optional, only needed if you plan to play akamai token protected content
              */
-            dataSourceFactory = AkamaiTokenDataSource.Factory()
+            dataSourceFactory = AkamaiTokenDataSource.Factory(),
+            mediaItemTrackerProvider = MediaItemMediaItemTrackerRepository().apply {
+                registerFactory(SRGEventLoggerTracker::class.java, SRGEventLoggerTracker.Factory())
+            }
         )
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Dependencies.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Dependencies.kt
@@ -11,7 +11,7 @@ import ch.srg.pillarbox.core.business.integrationlayer.service.IlHost
 import ch.srg.pillarbox.core.business.integrationlayer.service.MediaCompositionDataSourceImpl
 import ch.srg.pillarbox.core.business.tracker.SRGEventLoggerTracker
 import ch.srgssr.pillarbox.player.PillarboxPlayer
-import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
 
 /**
  * Dependencies to make custom Dependency Injection
@@ -39,7 +39,7 @@ object Dependencies {
              * Optional, only needed if you plan to play akamai token protected content
              */
             dataSourceFactory = AkamaiTokenDataSource.Factory(),
-            mediaItemTrackerProvider = MediaItemMediaItemTrackerRepository().apply {
+            mediaItemTrackerProvider = MediaItemTrackerRepository().apply {
                 registerFactory(SRGEventLoggerTracker::class.java, SRGEventLoggerTracker.Factory())
             }
         )

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -49,6 +49,9 @@ android {
             withJavadocJar()
         }
     }
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -71,6 +74,7 @@ dependencies {
     testImplementation(Dependencies.Test.junit)
     testImplementation(Dependencies.Coroutines.test)
     testImplementation(Dependencies.Test.mockk)
+
     androidTestImplementation(Dependencies.Test.androidJunit)
     androidTestImplementation(Dependencies.Test.espressoCore)
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/MediaItemExtensions.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/MediaItemExtensions.kt
@@ -5,40 +5,36 @@
 package ch.srgssr.pillarbox.player
 
 import androidx.media3.common.MediaItem
-import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
-import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerList
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
 
 /**
- * Get trackers or null
+ * Get [MediaItemTrackerData] or null if not set.
  *
- * @return null if localConfiguration.tag is null or tag is not a [MediaItemTrackerList].
+ * @return null if localConfiguration.tag is null or tag is not a [MediaItemTrackerData].
  */
 @Suppress("SwallowedException")
-fun MediaItem.getTrackersOrNull(): MediaItemTrackerList? {
+fun MediaItem.getMediaItemTrackerDataOrNull(): MediaItemTrackerData? {
     return try {
-        return localConfiguration?.tag as MediaItemTrackerList?
+        return localConfiguration?.tag as MediaItemTrackerData?
     } catch (e: ClassCastException) {
         null
     }
 }
 
 /**
- * Get existing Trackers
- *
- * @return existing Trackers or create new empty one.
+ * @return current [MediaItemTrackerData] or create.
  */
-fun MediaItem.getTrackers(): MediaItemTrackerList {
-    return getTrackersOrNull() ?: MediaItemTrackerList()
+fun MediaItem.getMediaItemTrackerData(): MediaItemTrackerData {
+    return getMediaItemTrackerDataOrNull() ?: MediaItemTrackerData()
 }
 
 /**
- * Append trackers and create a new Mediaitem. MediaItem is a immutable object.
- *
- * @param listTracker List of [MediaItemTracker] to append.
- * @return a new MediaItem with appended trackers to it.
+ * Set tracker data.
+ * @see MediaItem.Builder.setTag
+ * @param trackerData Set trackerData to [MediaItem.Builder.setTag].
+ * @return [MediaItem.Builder] for convenience
  */
-fun MediaItem.appendTrackers(vararg listTracker: MediaItemTracker): MediaItem {
-    val trackers = getTrackers()
-    trackers.appends(*listTracker)
-    return buildUpon().setTag(trackers).build()
+fun MediaItem.Builder.setTrackerData(trackerData: MediaItemTrackerData): MediaItem.Builder {
+    setTag(trackerData)
+    return this
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/MediaItemExtensions.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/MediaItemExtensions.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import androidx.media3.common.MediaItem
+import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerList
+
+/**
+ * Get trackers or null
+ *
+ * @return null if localConfiguration.tag is null or tag is not a [MediaItemTrackerList].
+ */
+@Suppress("SwallowedException")
+fun MediaItem.getTrackersOrNull(): MediaItemTrackerList? {
+    return try {
+        return localConfiguration?.tag as MediaItemTrackerList?
+    } catch (e: ClassCastException) {
+        null
+    }
+}
+
+/**
+ * Get existing Trackers
+ *
+ * @return existing Trackers or create new empty one.
+ */
+fun MediaItem.getTrackers(): MediaItemTrackerList {
+    return getTrackersOrNull() ?: MediaItemTrackerList()
+}
+
+/**
+ * Append trackers and create a new Mediaitem. MediaItem is a immutable object.
+ *
+ * @param listTracker List of [MediaItemTracker] to append.
+ * @return a new MediaItem with appended trackers to it.
+ */
+fun MediaItem.appendTrackers(vararg listTracker: MediaItemTracker): MediaItem {
+    val trackers = getTrackers()
+    trackers.appends(*listTracker)
+    return buildUpon().setTag(trackers).build()
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -18,8 +18,8 @@ import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import ch.srgssr.pillarbox.player.data.MediaItemSource
 import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
-import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerProvider
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
 
 /**
  * Pillarbox player
@@ -47,7 +47,7 @@ class PillarboxPlayer internal constructor(
         mediaItemSource: MediaItemSource,
         dataSourceFactory: DataSource.Factory = DefaultHttpDataSource.Factory(),
         loadControl: LoadControl = DefaultLoadControl(),
-        mediaItemTrackerProvider: MediaItemTrackerProvider = MediaItemMediaItemTrackerRepository()
+        mediaItemTrackerProvider: MediaItemTrackerProvider = MediaItemTrackerRepository()
     ) : this(
         ExoPlayer.Builder(context)
             .setUsePlatformDiagnostics(false)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -29,7 +29,6 @@ class PillarboxPlayer internal constructor(private val exoPlayer: ExoPlayer) :
     ExoPlayer by exoPlayer {
 
     init {
-        // addAnalyticsListener(EventLogger())
         addListener(ComponentListener())
         CurrentMediaItemTracker(this)
     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -15,9 +15,9 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.LoadControl
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
-import androidx.media3.exoplayer.util.EventLogger
 import ch.srgssr.pillarbox.player.data.MediaItemSource
 import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
+import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
 
 /**
  * Pillarbox player wrapping and configuring a Exoplayer instance.
@@ -25,12 +25,13 @@ import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
  * @property exoPlayer underlying Exoplayer instance used by the wrapper.
  * @constructor Create empty Pillarbox player
  */
-class PillarboxPlayer private constructor(private val exoPlayer: ExoPlayer) :
+class PillarboxPlayer internal constructor(private val exoPlayer: ExoPlayer) :
     ExoPlayer by exoPlayer {
 
     init {
-        addAnalyticsListener(EventLogger())
+        // addAnalyticsListener(EventLogger())
         addListener(ComponentListener())
+        CurrentMediaItemTracker(this)
     }
 
     constructor(

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -18,26 +18,36 @@ import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import ch.srgssr.pillarbox.player.data.MediaItemSource
 import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
+import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerProvider
 
 /**
- * Pillarbox player wrapping and configuring a Exoplayer instance.
+ * Pillarbox player
  *
- * @property exoPlayer underlying Exoplayer instance used by the wrapper.
- * @constructor Create empty Pillarbox player
+ * @property exoPlayer
+ * @constructor
+ *
+ * @param mediaItemTrackerProvider
  */
-class PillarboxPlayer internal constructor(private val exoPlayer: ExoPlayer) :
+class PillarboxPlayer internal constructor(
+    private val exoPlayer: ExoPlayer,
+    mediaItemTrackerProvider: MediaItemTrackerProvider? = null
+) :
     ExoPlayer by exoPlayer {
 
     init {
         addListener(ComponentListener())
-        CurrentMediaItemTracker(this)
+        mediaItemTrackerProvider?.let {
+            CurrentMediaItemTracker(this, it)
+        }
     }
 
     constructor(
         context: Context,
         mediaItemSource: MediaItemSource,
         dataSourceFactory: DataSource.Factory = DefaultHttpDataSource.Factory(),
-        loadControl: LoadControl = DefaultLoadControl()
+        loadControl: LoadControl = DefaultLoadControl(),
+        mediaItemTrackerProvider: MediaItemTrackerProvider = MediaItemMediaItemTrackerRepository()
     ) : this(
         ExoPlayer.Builder(context)
             .setUsePlatformDiagnostics(false)
@@ -56,7 +66,8 @@ class PillarboxPlayer internal constructor(private val exoPlayer: ExoPlayer) :
                     defaultMediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
                 )
             )
-            .build()
+            .build(),
+        mediaItemTrackerProvider = mediaItemTrackerProvider
     )
 
     /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -12,6 +12,7 @@ import androidx.media3.common.Timeline.Window
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import ch.srgssr.pillarbox.player.BuildConfig
+import ch.srgssr.pillarbox.player.getMediaItemTrackerDataOrNull
 import ch.srgssr.pillarbox.player.utils.StringUtil
 
 /**
@@ -80,7 +81,7 @@ internal class CurrentMediaItemTracker internal constructor(
     private fun updateSession(mediaItem: MediaItem) {
         trackers?.let {
             for (tracker in it.list) {
-                mediaItem.getTrackData()?.getData(tracker)?.let { data ->
+                mediaItem.getMediaItemTrackerDataOrNull()?.getData(tracker)?.let { data ->
                     tracker.update(data)
                 }
             }
@@ -89,7 +90,7 @@ internal class CurrentMediaItemTracker internal constructor(
 
     private fun startSession(mediaItem: MediaItem) {
         require(trackers == null)
-        mediaItem.getTrackData()?.let {
+        mediaItem.getMediaItemTrackerDataOrNull()?.let {
             val trackers = MediaItemTrackerList()
             // Create each tracker for this new MediaItem
             for (trackerType in it.trackers) {
@@ -188,10 +189,6 @@ internal class CurrentMediaItemTracker internal constructor(
         fun areEquals(m1: MediaItem?, m2: MediaItem?): Boolean {
             if (m1 == null && m2 == null) return true
             return m1?.getIdentifier() == m2?.getIdentifier()
-        }
-
-        private fun MediaItem.getTrackData(): MediaItemTrackerData? {
-            return localConfiguration?.tag as MediaItemTrackerData?
         }
 
         private fun MediaItem?.isLoaded(): Boolean {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -7,8 +7,8 @@ package ch.srgssr.pillarbox.player.tracker
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline.Window
+import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
-import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.getTrackersOrNull
 
 /**
@@ -16,7 +16,7 @@ import ch.srgssr.pillarbox.player.getTrackersOrNull
  *
  * @property player The Player to track current media item
  */
-class CurrentMediaItemTracker internal constructor(private val player: PillarboxPlayer) : AnalyticsListener {
+class CurrentMediaItemTracker internal constructor(private val player: ExoPlayer) : AnalyticsListener {
 
     private var currentMediaItem: MediaItem? = null
         set(value) {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -9,23 +9,37 @@ import androidx.media3.common.Player
 import androidx.media3.common.Timeline.Window
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
-import ch.srgssr.pillarbox.player.getTrackersOrNull
 
 /**
  * Current media item tracker
  *
- * @property player The Player to track current media item
+ * @property player The Player to track current media item.
+ * @property mediaItemTrackerProvider The MediaItemTrackerProvider that provide new instance of [MediaItemTracker].
  */
-class CurrentMediaItemTracker internal constructor(private val player: ExoPlayer) : AnalyticsListener {
+internal class CurrentMediaItemTracker internal constructor(
+    private val player: ExoPlayer,
+    private val mediaItemTrackerProvider: MediaItemTrackerProvider
+) : AnalyticsListener {
 
-    private var currentMediaItem: MediaItem? = null
+    private var trackers: MediaItemTrackerList? = null
+
+    private var currentMediaItem: MediaItem? = player.currentMediaItem
         set(value) {
-            if (value != field) {
-                field?.let { stopSession(it) }
+            if (!areEquals(value, field)) {
+                field?.let { stopSession() }
                 field = value
                 field?.let { startSession(it) }
+            } else {
+                trackers?.let {
+                    for (tracker in it.list) {
+                        field?.getTrackData()?.getData(tracker)?.let { data ->
+                            tracker.update(data)
+                        }
+                    }
+                }
             }
         }
+
     private val window = Window()
 
     init {
@@ -33,20 +47,45 @@ class CurrentMediaItemTracker internal constructor(private val player: ExoPlayer
         currentMediaItem = player.currentMediaItem
     }
 
+    private fun MediaItem.getTrackData(): MediaItemTrackerData? {
+        return localConfiguration?.tag as MediaItemTrackerData?
+    }
+
+    /**
+     * Are equals only checks mediaId and localConfiguration.uri
+     *
+     * @param m1
+     * @param m2
+     * @return
+     */
+    private fun areEquals(m1: MediaItem?, m2: MediaItem?): Boolean {
+        if (m1 == null && m2 == null) return true
+        return m1?.mediaId == m2?.mediaId && m1?.localConfiguration?.uri == m2?.localConfiguration?.uri
+    }
+
     private fun startSession(mediaItem: MediaItem) {
-        mediaItem.getTrackersOrNull()?.let {
-            for (tracker in it) {
+        mediaItem.getTrackData()?.let {
+            val trackers = MediaItemTrackerList()
+            // Create each tracker for this new MediaItem
+            for (trackerType in it.trackers) {
+                val tracker = mediaItemTrackerProvider.getMediaItemTrackerFactory(trackerType).create()
+                trackers.append(tracker)
                 tracker.start(player)
+                it.getData(tracker)?.let { data ->
+                    tracker.update(data)
+                }
             }
+            this.trackers = trackers
         }
     }
 
-    private fun stopSession(mediaItem: MediaItem) {
-        mediaItem.getTrackersOrNull()?.let {
-            for (tracker in it) {
+    private fun stopSession() {
+        trackers?.let {
+            for (tracker in it.list) {
                 tracker.stop(player)
             }
         }
+        trackers = null
     }
 
     override fun onTimelineChanged(eventTime: AnalyticsListener.EventTime, reason: Int) {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.tracker
+
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline.Window
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.getTrackersOrNull
+
+/**
+ * Current media item tracker
+ *
+ * @property player The Player to track current media item
+ */
+class CurrentMediaItemTracker internal constructor(private val player: PillarboxPlayer) : AnalyticsListener {
+
+    private var currentMediaItem: MediaItem? = null
+        set(value) {
+            if (value != field) {
+                field?.let { stopSession(it) }
+                field = value
+                field?.let { startSession(it) }
+            }
+        }
+    private val window = Window()
+
+    init {
+        player.addAnalyticsListener(this)
+        currentMediaItem = player.currentMediaItem
+    }
+
+    private fun startSession(mediaItem: MediaItem) {
+        mediaItem.getTrackersOrNull()?.let {
+            for (tracker in it) {
+                tracker.start(player)
+            }
+        }
+    }
+
+    private fun stopSession(mediaItem: MediaItem) {
+        mediaItem.getTrackersOrNull()?.let {
+            for (tracker in it) {
+                tracker.stop(player)
+            }
+        }
+    }
+
+    override fun onTimelineChanged(eventTime: AnalyticsListener.EventTime, reason: Int) {
+        eventTime.timeline.getWindow(eventTime.windowIndex, window)
+        val mediaItem = window.mediaItem
+        currentMediaItem = mediaItem
+    }
+
+    override fun onMediaItemTransition(eventTime: AnalyticsListener.EventTime, mediaItem: MediaItem?, reason: Int) {
+        currentMediaItem = mediaItem
+    }
+
+    override fun onPlaybackStateChanged(eventTime: AnalyticsListener.EventTime, state: Int) {
+        when (state) {
+            Player.STATE_IDLE, Player.STATE_ENDED -> currentMediaItem = null
+            Player.STATE_READY -> {
+                currentMediaItem = eventTime.timeline.getWindow(eventTime.windowIndex, window).mediaItem
+            }
+        }
+    }
+
+    override fun onPositionDiscontinuity(
+        eventTime: AnalyticsListener.EventTime,
+        oldPosition: Player.PositionInfo,
+        newPosition: Player.PositionInfo,
+        reason: Int
+    ) {
+        eventTime.timeline.getWindow(eventTime.windowIndex, window)
+        val mediaItem = window.mediaItem
+        currentMediaItem = mediaItem
+    }
+
+    override fun onPlayerReleased(eventTime: AnalyticsListener.EventTime) {
+        currentMediaItem = null
+        player.removeAnalyticsListener(this)
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemMediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemMediaItemTrackerRepository.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.tracker
+
+/**
+ * Media item media item tracker repository
+ *
+ * @constructor Create empty Media item media item tracker repository
+ */
+class MediaItemMediaItemTrackerRepository : MediaItemTrackerProvider {
+    private val map = HashMap<Class<*>, MediaItemTracker.Factory>()
+
+    /**
+     * Register factory
+     *
+     * @param T Class type extends [MediaItemTracker]
+     * @param clazz The class the trackerFactory create. Clazz must extends MediaItemTracker.
+     * @param trackerFactory The tracker factory associated with clazz.
+     */
+    fun <T : MediaItemTracker> registerFactory(clazz: Class<T>, trackerFactory: MediaItemTracker.Factory) {
+        map[clazz] = trackerFactory
+    }
+
+    override fun getMediaItemTrackerFactory(clazz: Class<*>): MediaItemTracker.Factory {
+        assert(map.contains(clazz)) { "No MediaItemTracker.Factory found for $clazz" }
+        return map[clazz]!!
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.tracker
+
+import ch.srgssr.pillarbox.player.PillarboxPlayer
+
+/**
+ * Media item tracker
+ */
+interface MediaItemTracker {
+
+    /**
+     * Start Media tracking.
+     *
+     * @param player The player to track.
+     */
+    fun start(player: PillarboxPlayer)
+
+    /**
+     * Stop Media tracking.
+     *
+     * @param player The player tracked.
+     */
+    fun stop(player: PillarboxPlayer)
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
@@ -24,4 +24,25 @@ interface MediaItemTracker {
      * @param player The player tracked.
      */
     fun stop(player: ExoPlayer)
+
+    /**
+     * Update with data.
+     *
+     * Data may not have change.
+     *
+     * @param data The data to use with this Tracker.
+     */
+    fun update(data: Any) {}
+
+    /**
+     * Factory
+     */
+    interface Factory {
+        /**
+         * Create a new instance of a [MediaItemTracker]
+         *
+         * @return a new instance.
+         */
+        fun create(): MediaItemTracker
+    }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
@@ -4,7 +4,7 @@
  */
 package ch.srgssr.pillarbox.player.tracker
 
-import ch.srgssr.pillarbox.player.PillarboxPlayer
+import androidx.media3.exoplayer.ExoPlayer
 
 /**
  * Media item tracker
@@ -16,12 +16,12 @@ interface MediaItemTracker {
      *
      * @param player The player to track.
      */
-    fun start(player: PillarboxPlayer)
+    fun start(player: ExoPlayer)
 
     /**
      * Stop Media tracking.
      *
      * @param player The player tracked.
      */
-    fun stop(player: PillarboxPlayer)
+    fun stop(player: ExoPlayer)
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerData.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.tracker
+
+/**
+ * Tracker data
+ *
+ * @constructor Create empty Tracker data
+ */
+class MediaItemTrackerData {
+    private val map = HashMap<Class<*>, Any?>()
+
+    /**
+     * Trackers
+     */
+    val trackers: Collection<Class<*>>
+        get() {
+            return map.keys
+        }
+
+    /**
+     * Get data for
+     *
+     * @param T
+     * @param tracker
+     * @return
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T> getDataFor(tracker: MediaItemTracker): T? {
+        return map[tracker::class.java] as T?
+    }
+
+    /**
+     * Get data
+     *
+     * @param tracker
+     * @return
+     */
+    fun getData(tracker: MediaItemTracker): Any? {
+        return map[tracker::class.java]
+    }
+
+    /**
+     * Put data
+     *
+     * @param clazz
+     * @param data
+     */
+    fun putData(clazz: Class<*>, data: Any? = null) {
+        map[clazz] = data
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerList.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerList.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.tracker
+
+/**
+ * Trackers hold a list of [MediaItemTracker].
+ *
+ *  val trackers = mediaItem.getTrackers()
+ *  trackers.append(trackerA)
+ *
+ * @constructor Create empty Trackers.
+ */
+class MediaItemTrackerList internal constructor() : Iterable<MediaItemTracker> {
+    private val listTracker = ArrayList<MediaItemTracker>()
+
+    /**
+     * Immutable list of [MediaItemTracker].
+     */
+    val list: List<MediaItemTracker> = listTracker
+
+    /**
+     * The number of [MediaItemTracker] appended.
+     */
+    val size: Int
+        get() = list.size
+
+    /**
+     * Append tracker to the list. You can append only one type of Tracker.
+     *
+     * @param tracker The track to add.
+     * @return true if it's successful add the tracker, false otherwise.
+     */
+    fun append(tracker: MediaItemTracker): Boolean {
+        if (listTracker.find { it::class.java == tracker::class.java } == null) {
+            listTracker.add(tracker)
+            return true
+        }
+        return false
+    }
+
+    /**
+     * Appends multiple MediaTracker at once.
+     *
+     * @param trackers The MediaTracker list to append.
+     * @return false if one of the trackers is already added.
+     */
+    fun appends(vararg trackers: MediaItemTracker): Boolean {
+        var added = true
+        for (tracker in trackers) {
+            val currentAdded = append(tracker)
+            if (!currentAdded) {
+                added = false
+            }
+        }
+        return added
+    }
+
+    /**
+     * Find [MediaItemTracker] from T
+     *
+     * @param T The [MediaItemTracker] type to find.
+     * @param trackerClass The class to find.
+     * @return null if not found.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun <T : MediaItemTracker> findTracker(trackerClass: Class<T>): T? {
+        return listTracker.find { it::class.java == trackerClass } as T?
+    }
+
+    override fun iterator(): Iterator<MediaItemTracker> {
+        return list.iterator()
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerProvider.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerProvider.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.tracker
+
+/**
+ * Tracker factory
+ *
+ * @constructor Create empty Tracker factory
+ */
+interface MediaItemTrackerProvider {
+    /**
+     * Get media item tracker factory
+     *
+     * @param clazz
+     * @return
+     */
+    fun getMediaItemTrackerFactory(clazz: Class<*>): MediaItemTracker.Factory
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerRepository.kt
@@ -9,7 +9,7 @@ package ch.srgssr.pillarbox.player.tracker
  *
  * @constructor Create empty Media item media item tracker repository
  */
-class MediaItemMediaItemTrackerRepository : MediaItemTrackerProvider {
+class MediaItemTrackerRepository : MediaItemTrackerProvider {
     private val map = HashMap<Class<*>, MediaItemTracker.Factory>()
 
     /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/StringUtil.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/StringUtil.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.utils
+
+import androidx.media3.common.Player
+import androidx.media3.common.Player.DiscontinuityReason
+import androidx.media3.common.Player.MediaItemTransitionReason
+import androidx.media3.common.Player.State
+import androidx.media3.common.Player.TimelineChangeReason
+
+/**
+ * String util toString some Player constant enum
+ */
+object StringUtil {
+    private const val UNKNOWN = "UNKNOWN"
+
+    /**
+     * Media item transition reason string
+     */
+    fun mediaItemTransitionReasonString(value: @MediaItemTransitionReason Int): String {
+        return when (value) {
+            Player.MEDIA_ITEM_TRANSITION_REASON_AUTO -> "MEDIA_ITEM_TRANSITION_REASON_AUTO"
+            Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED -> "MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED"
+            Player.MEDIA_ITEM_TRANSITION_REASON_SEEK -> "MEDIA_ITEM_TRANSITION_REASON_SEEK"
+            Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT -> "MEDIA_ITEM_TRANSITION_REASON_REPEAT"
+            else -> UNKNOWN
+        }
+    }
+
+    /**
+     * Player state string
+     */
+    fun playerStateString(value: @State Int): String {
+        return when (value) {
+            Player.STATE_ENDED -> "STATE_ENDED"
+            Player.STATE_READY -> "STATE_READY"
+            Player.STATE_BUFFERING -> "STATE_BUFFERING"
+            Player.STATE_IDLE -> "STATE_IDLE"
+            else -> UNKNOWN
+        }
+    }
+
+    /**
+     * Timeline change reason string
+     */
+    fun timelineChangeReasonString(value: @TimelineChangeReason Int): String {
+        return when (value) {
+            Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED -> "TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED"
+            Player.TIMELINE_CHANGE_REASON_SOURCE_UPDATE -> "TIMELINE_CHANGE_REASON_SOURCE_UPDATE"
+            else -> UNKNOWN
+        }
+    }
+
+    /**
+     * Discontinuity reason string
+     */
+    fun discontinuityReasonString(value: @DiscontinuityReason Int): String {
+        return when (value) {
+            Player.DISCONTINUITY_REASON_SEEK -> "DISCONTINUITY_REASON_SEEK"
+            Player.DISCONTINUITY_REASON_REMOVE -> "DISCONTINUITY_REASON_REMOVE"
+            Player.DISCONTINUITY_REASON_INTERNAL -> "DISCONTINUITY_REASON_INTERNAL"
+            Player.DISCONTINUITY_REASON_SKIP -> "DISCONTINUITY_REASON_SKIP"
+            Player.DISCONTINUITY_REASON_SEEK_ADJUSTMENT -> "DISCONTINUITY_REASON_SEEK_ADJUSTMENT"
+            Player.DISCONTINUITY_REASON_AUTO_TRANSITION -> "DISCONTINUITY_REASON_AUTO_TRANSITION"
+            else -> UNKNOWN
+        }
+    }
+}

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/AnalyticsListenerCommander.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/AnalyticsListenerCommander.kt
@@ -1,0 +1,424 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import androidx.media3.common.AudioAttributes
+import androidx.media3.common.DeviceInfo
+import androidx.media3.common.Format
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.Metadata
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.PlaybackParameters
+import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
+import androidx.media3.common.Tracks
+import androidx.media3.common.VideoSize
+import androidx.media3.common.text.Cue
+import androidx.media3.common.text.CueGroup
+import androidx.media3.exoplayer.DecoderCounters
+import androidx.media3.exoplayer.DecoderReuseEvaluation
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.source.LoadEventInfo
+import androidx.media3.exoplayer.source.MediaLoadData
+import java.io.IOException
+
+class AnalyticsListenerCommander(mock: ExoPlayer) : ExoPlayer by mock, AnalyticsListener {
+    private val listeners = mutableListOf<AnalyticsListener>()
+
+    val hasListeners: Boolean
+        get() = listeners.isNotEmpty()
+
+
+    override fun addListener(listener: Player.Listener) {
+
+    }
+
+    override fun removeListener(listener: Player.Listener) {
+
+    }
+
+    override fun addAnalyticsListener(listener: AnalyticsListener) {
+        listeners.add(listener)
+    }
+
+    override fun removeAnalyticsListener(listener: AnalyticsListener) {
+        listeners.remove(listener)
+    }
+
+    private fun notifyAll(run: (Player: AnalyticsListener) -> Unit) {
+        val list = listeners.toList()
+        for (listener in list) {
+            run(listener)
+        }
+    }
+
+    override fun onPlaybackStateChanged(eventTime: AnalyticsListener.EventTime, state: Int) {
+        notifyAll { it.onPlaybackStateChanged(eventTime, state) }
+    }
+
+    override fun onPlayWhenReadyChanged(eventTime: AnalyticsListener.EventTime, playWhenReady: Boolean, reason: Int) {
+        notifyAll { it.onPlayWhenReadyChanged(eventTime, playWhenReady, reason) }
+    }
+
+    override fun onPlaybackSuppressionReasonChanged(eventTime: AnalyticsListener.EventTime, playbackSuppressionReason: Int) {
+        notifyAll { it.onPlaybackSuppressionReasonChanged(eventTime, playbackSuppressionReason) }
+    }
+
+    override fun onIsPlayingChanged(eventTime: AnalyticsListener.EventTime, isPlaying: Boolean) {
+        notifyAll { it.onIsPlayingChanged(eventTime, isPlaying) }
+    }
+
+    override fun onTimelineChanged(eventTime: AnalyticsListener.EventTime, reason: Int) {
+        notifyAll { it.onTimelineChanged(eventTime, reason) }
+    }
+
+    override fun onMediaItemTransition(eventTime: AnalyticsListener.EventTime, mediaItem: MediaItem?, reason: Int) {
+        notifyAll { it.onMediaItemTransition(eventTime, mediaItem, reason) }
+    }
+
+    override fun onPositionDiscontinuity(eventTime: AnalyticsListener.EventTime, reason: Int) {
+        notifyAll { it.onPositionDiscontinuity(eventTime, reason) }
+    }
+
+    override fun onPositionDiscontinuity(
+        eventTime: AnalyticsListener.EventTime,
+        oldPosition: Player.PositionInfo,
+        newPosition: Player.PositionInfo,
+        reason: Int
+    ) {
+        notifyAll { it.onPositionDiscontinuity(eventTime, oldPosition, newPosition, reason) }
+    }
+
+    override fun onSeekStarted(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onSeekStarted(eventTime) }
+    }
+
+    override fun onSeekProcessed(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onSeekProcessed(eventTime) }
+    }
+
+    override fun onPlaybackParametersChanged(eventTime: AnalyticsListener.EventTime, playbackParameters: PlaybackParameters) {
+        notifyAll { it.onPlaybackParametersChanged(eventTime, playbackParameters) }
+    }
+
+    override fun onSeekBackIncrementChanged(eventTime: AnalyticsListener.EventTime, seekBackIncrementMs: Long) {
+        notifyAll { it.onSeekBackIncrementChanged(eventTime, seekBackIncrementMs) }
+    }
+
+    override fun onSeekForwardIncrementChanged(eventTime: AnalyticsListener.EventTime, seekForwardIncrementMs: Long) {
+        notifyAll { it.onSeekForwardIncrementChanged(eventTime, seekForwardIncrementMs) }
+    }
+
+    override fun onMaxSeekToPreviousPositionChanged(eventTime: AnalyticsListener.EventTime, maxSeekToPreviousPositionMs: Long) {
+        notifyAll { it.onMaxSeekToPreviousPositionChanged(eventTime, maxSeekToPreviousPositionMs) }
+    }
+
+    override fun onRepeatModeChanged(eventTime: AnalyticsListener.EventTime, repeatMode: Int) {
+        notifyAll { it.onRepeatModeChanged(eventTime, repeatMode) }
+    }
+
+    override fun onShuffleModeChanged(eventTime: AnalyticsListener.EventTime, shuffleModeEnabled: Boolean) {
+        notifyAll { it.onShuffleModeChanged(eventTime, shuffleModeEnabled) }
+    }
+
+    override fun onIsLoadingChanged(eventTime: AnalyticsListener.EventTime, isLoading: Boolean) {
+        notifyAll { it.onIsLoadingChanged(eventTime, isLoading) }
+    }
+
+    override fun onLoadingChanged(eventTime: AnalyticsListener.EventTime, isLoading: Boolean) {
+        notifyAll { it.onLoadingChanged(eventTime, isLoading) }
+    }
+
+    override fun onAvailableCommandsChanged(eventTime: AnalyticsListener.EventTime, availableCommands: Player.Commands) {
+        notifyAll { it.onAvailableCommandsChanged(eventTime, availableCommands) }
+    }
+
+    override fun onPlayerError(eventTime: AnalyticsListener.EventTime, error: PlaybackException) {
+        notifyAll {
+            it.onPlayerError(eventTime, error)
+        }
+    }
+
+    override fun onPlayerErrorChanged(eventTime: AnalyticsListener.EventTime, error: PlaybackException?) {
+        notifyAll { it.onPlayerErrorChanged(eventTime, error) }
+    }
+
+    override fun onTracksChanged(eventTime: AnalyticsListener.EventTime, tracks: Tracks) {
+        notifyAll { it.onTracksChanged(eventTime, tracks) }
+    }
+
+    override fun onTrackSelectionParametersChanged(
+        eventTime: AnalyticsListener.EventTime,
+        trackSelectionParameters: TrackSelectionParameters
+    ) {
+        notifyAll { it.onTrackSelectionParametersChanged(eventTime, trackSelectionParameters) }
+    }
+
+    override fun onMediaMetadataChanged(eventTime: AnalyticsListener.EventTime, mediaMetadata: MediaMetadata) {
+        notifyAll { it.onMediaMetadataChanged(eventTime, mediaMetadata) }
+    }
+
+    override fun onPlaylistMetadataChanged(eventTime: AnalyticsListener.EventTime, playlistMetadata: MediaMetadata) {
+        notifyAll { it.onPlaylistMetadataChanged(eventTime, playlistMetadata) }
+    }
+
+    override fun onLoadStarted(eventTime: AnalyticsListener.EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
+        notifyAll { it.onLoadStarted(eventTime, loadEventInfo, mediaLoadData) }
+    }
+
+    override fun onLoadCompleted(eventTime: AnalyticsListener.EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
+        notifyAll { it.onLoadCompleted(eventTime, loadEventInfo, mediaLoadData) }
+    }
+
+    override fun onLoadCanceled(eventTime: AnalyticsListener.EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
+        notifyAll { it.onLoadCanceled(eventTime, loadEventInfo, mediaLoadData) }
+    }
+
+    override fun onLoadError(
+        eventTime: AnalyticsListener.EventTime,
+        loadEventInfo: LoadEventInfo,
+        mediaLoadData: MediaLoadData,
+        error: IOException,
+        wasCanceled: Boolean
+    ) {
+        notifyAll { it.onLoadError(eventTime, loadEventInfo, mediaLoadData, error, wasCanceled) }
+    }
+
+    override fun onDownstreamFormatChanged(eventTime: AnalyticsListener.EventTime, mediaLoadData: MediaLoadData) {
+        notifyAll { it.onDownstreamFormatChanged(eventTime, mediaLoadData) }
+    }
+
+    override fun onUpstreamDiscarded(eventTime: AnalyticsListener.EventTime, mediaLoadData: MediaLoadData) {
+        notifyAll { it.onUpstreamDiscarded(eventTime, mediaLoadData) }
+    }
+
+    override fun onBandwidthEstimate(
+        eventTime: AnalyticsListener.EventTime,
+        totalLoadTimeMs: Int,
+        totalBytesLoaded: Long,
+        bitrateEstimate: Long
+    ) {
+        notifyAll { it.onBandwidthEstimate(eventTime, totalLoadTimeMs, totalBytesLoaded, bitrateEstimate) }
+    }
+
+    override fun onMetadata(eventTime: AnalyticsListener.EventTime, metadata: Metadata) {
+        notifyAll { it.onMetadata(eventTime, metadata) }
+    }
+
+    override fun onCues(eventTime: AnalyticsListener.EventTime, cues: MutableList<Cue>) {
+        notifyAll { it.onCues(eventTime, cues) }
+    }
+
+    override fun onCues(eventTime: AnalyticsListener.EventTime, cueGroup: CueGroup) {
+        notifyAll { it.onCues(eventTime, cueGroup) }
+    }
+
+    override fun onDecoderEnabled(eventTime: AnalyticsListener.EventTime, trackType: Int, decoderCounters: DecoderCounters) {
+        notifyAll { it.onDecoderEnabled(eventTime, trackType, decoderCounters) }
+    }
+
+    override fun onDecoderInitialized(
+        eventTime: AnalyticsListener.EventTime,
+        trackType: Int,
+        decoderName: String,
+        initializationDurationMs: Long
+    ) {
+        notifyAll { it.onDecoderInitialized(eventTime, trackType, decoderName, initializationDurationMs) }
+    }
+
+    override fun onDecoderInputFormatChanged(eventTime: AnalyticsListener.EventTime, trackType: Int, format: Format) {
+        notifyAll { it.onDecoderInputFormatChanged(eventTime, trackType, format) }
+    }
+
+    override fun onDecoderDisabled(eventTime: AnalyticsListener.EventTime, trackType: Int, decoderCounters: DecoderCounters) {
+        notifyAll { it.onDecoderDisabled(eventTime, trackType, decoderCounters) }
+    }
+
+    override fun onAudioEnabled(eventTime: AnalyticsListener.EventTime, decoderCounters: DecoderCounters) {
+        notifyAll { it.onAudioEnabled(eventTime, decoderCounters) }
+    }
+
+    override fun onAudioDecoderInitialized(
+        eventTime: AnalyticsListener.EventTime,
+        decoderName: String,
+        initializedTimestampMs: Long,
+        initializationDurationMs: Long
+    ) {
+        notifyAll { it.onAudioDecoderInitialized(eventTime, decoderName, initializedTimestampMs, initializationDurationMs) }
+    }
+
+    override fun onAudioDecoderInitialized(eventTime: AnalyticsListener.EventTime, decoderName: String, initializationDurationMs: Long) {
+        notifyAll { it.onAudioDecoderInitialized(eventTime, decoderName, initializationDurationMs) }
+    }
+
+    override fun onAudioInputFormatChanged(eventTime: AnalyticsListener.EventTime, format: Format) {
+        notifyAll { it.onAudioInputFormatChanged(eventTime, format) }
+    }
+
+    override fun onAudioInputFormatChanged(
+        eventTime: AnalyticsListener.EventTime,
+        format: Format,
+        decoderReuseEvaluation: DecoderReuseEvaluation?
+    ) {
+        notifyAll { it.onAudioInputFormatChanged(eventTime, format, decoderReuseEvaluation) }
+    }
+
+    override fun onAudioPositionAdvancing(eventTime: AnalyticsListener.EventTime, playoutStartSystemTimeMs: Long) {
+        notifyAll { it.onAudioPositionAdvancing(eventTime, playoutStartSystemTimeMs) }
+    }
+
+    override fun onAudioUnderrun(eventTime: AnalyticsListener.EventTime, bufferSize: Int, bufferSizeMs: Long, elapsedSinceLastFeedMs: Long) {
+        notifyAll { it.onAudioUnderrun(eventTime, bufferSize, bufferSizeMs, elapsedSinceLastFeedMs) }
+    }
+
+    override fun onAudioDecoderReleased(eventTime: AnalyticsListener.EventTime, decoderName: String) {
+        notifyAll { it.onAudioDecoderReleased(eventTime, decoderName) }
+    }
+
+    override fun onAudioDisabled(eventTime: AnalyticsListener.EventTime, decoderCounters: DecoderCounters) {
+        notifyAll { it.onAudioDisabled(eventTime, decoderCounters) }
+    }
+
+    override fun onAudioSessionIdChanged(eventTime: AnalyticsListener.EventTime, audioSessionId: Int) {
+        notifyAll { it.onAudioSessionIdChanged(eventTime, audioSessionId) }
+    }
+
+    override fun onAudioAttributesChanged(eventTime: AnalyticsListener.EventTime, audioAttributes: AudioAttributes) {
+        notifyAll { it.onAudioAttributesChanged(eventTime, audioAttributes) }
+    }
+
+    override fun onSkipSilenceEnabledChanged(eventTime: AnalyticsListener.EventTime, skipSilenceEnabled: Boolean) {
+        notifyAll { it.onSkipSilenceEnabledChanged(eventTime, skipSilenceEnabled) }
+    }
+
+    override fun onAudioSinkError(eventTime: AnalyticsListener.EventTime, audioSinkError: Exception) {
+        notifyAll { it.onAudioSinkError(eventTime, audioSinkError) }
+    }
+
+    override fun onAudioCodecError(eventTime: AnalyticsListener.EventTime, audioCodecError: Exception) {
+        notifyAll { it.onAudioCodecError(eventTime, audioCodecError) }
+    }
+
+    override fun onVolumeChanged(eventTime: AnalyticsListener.EventTime, volume: Float) {
+        notifyAll { it.onVolumeChanged(eventTime, volume) }
+    }
+
+    override fun onDeviceInfoChanged(eventTime: AnalyticsListener.EventTime, deviceInfo: DeviceInfo) {
+        notifyAll { it.onDeviceInfoChanged(eventTime, deviceInfo) }
+    }
+
+    override fun onDeviceVolumeChanged(eventTime: AnalyticsListener.EventTime, volume: Int, muted: Boolean) {
+        notifyAll { it.onDeviceVolumeChanged(eventTime, volume, muted) }
+    }
+
+    override fun onVideoEnabled(eventTime: AnalyticsListener.EventTime, decoderCounters: DecoderCounters) {
+        notifyAll { it.onVideoEnabled(eventTime, decoderCounters) }
+    }
+
+    override fun onVideoDecoderInitialized(
+        eventTime: AnalyticsListener.EventTime,
+        decoderName: String,
+        initializedTimestampMs: Long,
+        initializationDurationMs: Long
+    ) {
+        notifyAll { it.onVideoDecoderInitialized(eventTime, decoderName, initializedTimestampMs, initializationDurationMs) }
+    }
+
+    override fun onVideoDecoderInitialized(eventTime: AnalyticsListener.EventTime, decoderName: String, initializationDurationMs: Long) {
+        notifyAll { it.onVideoDecoderInitialized(eventTime, decoderName, initializationDurationMs) }
+    }
+
+    override fun onVideoInputFormatChanged(eventTime: AnalyticsListener.EventTime, format: Format) {
+        notifyAll { it.onVideoInputFormatChanged(eventTime, format) }
+    }
+
+    override fun onVideoInputFormatChanged(
+        eventTime: AnalyticsListener.EventTime,
+        format: Format,
+        decoderReuseEvaluation: DecoderReuseEvaluation?
+    ) {
+        notifyAll { it.onVideoInputFormatChanged(eventTime, format, decoderReuseEvaluation) }
+    }
+
+    override fun onDroppedVideoFrames(eventTime: AnalyticsListener.EventTime, droppedFrames: Int, elapsedMs: Long) {
+        notifyAll { it.onDroppedVideoFrames(eventTime, droppedFrames, elapsedMs) }
+    }
+
+    override fun onVideoDecoderReleased(eventTime: AnalyticsListener.EventTime, decoderName: String) {
+        notifyAll { it.onVideoDecoderReleased(eventTime, decoderName) }
+    }
+
+    override fun onVideoDisabled(eventTime: AnalyticsListener.EventTime, decoderCounters: DecoderCounters) {
+        notifyAll { it.onVideoDisabled(eventTime, decoderCounters) }
+    }
+
+    override fun onVideoFrameProcessingOffset(eventTime: AnalyticsListener.EventTime, totalProcessingOffsetUs: Long, frameCount: Int) {
+        notifyAll { it.onVideoFrameProcessingOffset(eventTime, totalProcessingOffsetUs, frameCount) }
+    }
+
+    override fun onVideoCodecError(eventTime: AnalyticsListener.EventTime, videoCodecError: Exception) {
+        notifyAll { it.onVideoCodecError(eventTime, videoCodecError) }
+    }
+
+    override fun onRenderedFirstFrame(eventTime: AnalyticsListener.EventTime, output: Any, renderTimeMs: Long) {
+        notifyAll { it.onRenderedFirstFrame(eventTime, output, renderTimeMs) }
+    }
+
+    override fun onVideoSizeChanged(eventTime: AnalyticsListener.EventTime, videoSize: VideoSize) {
+        notifyAll { it.onVideoSizeChanged(eventTime, videoSize) }
+    }
+
+    override fun onVideoSizeChanged(
+        eventTime: AnalyticsListener.EventTime,
+        width: Int,
+        height: Int,
+        unappliedRotationDegrees: Int,
+        pixelWidthHeightRatio: Float
+    ) {
+        notifyAll { it.onVideoSizeChanged(eventTime, width, height, unappliedRotationDegrees, pixelWidthHeightRatio) }
+    }
+
+    override fun onSurfaceSizeChanged(eventTime: AnalyticsListener.EventTime, width: Int, height: Int) {
+        notifyAll { it.onSurfaceSizeChanged(eventTime, width, height) }
+    }
+
+    override fun onDrmSessionAcquired(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onDrmSessionAcquired(eventTime) }
+    }
+
+    override fun onDrmSessionAcquired(eventTime: AnalyticsListener.EventTime, state: Int) {
+        notifyAll { it.onDrmSessionAcquired(eventTime, state) }
+    }
+
+    override fun onDrmKeysLoaded(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onDrmKeysLoaded(eventTime) }
+    }
+
+    override fun onDrmSessionManagerError(eventTime: AnalyticsListener.EventTime, error: Exception) {
+        notifyAll { it.onDrmSessionManagerError(eventTime, error) }
+    }
+
+    override fun onDrmKeysRestored(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onDrmKeysRestored(eventTime) }
+    }
+
+    override fun onDrmKeysRemoved(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onDrmKeysRemoved(eventTime) }
+    }
+
+    override fun onDrmSessionReleased(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onDrmSessionReleased(eventTime) }
+    }
+
+    override fun onPlayerReleased(eventTime: AnalyticsListener.EventTime) {
+        notifyAll { it.onPlayerReleased(eventTime) }
+    }
+
+    override fun onEvents(player: Player, events: AnalyticsListener.Events) {
+        notifyAll { it.onEvents(player, events) }
+    }
+}

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -9,7 +9,7 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
-import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
 import io.mockk.clearAllMocks
@@ -34,7 +34,7 @@ class TestCurrentMediaItemTracker {
         analyticsCommander = AnalyticsListenerCommander(mock = mockk(relaxed = false))
         every { analyticsCommander.currentMediaItem } returns null
         tracker = TestTracker()
-        currentItemTracker = CurrentMediaItemTracker(analyticsCommander, MediaItemMediaItemTrackerRepository().apply {
+        currentItemTracker = CurrentMediaItemTracker(analyticsCommander, MediaItemTrackerRepository().apply {
             registerFactory(TestTracker::class.java, object : MediaItemTracker.Factory {
                 override fun create(): MediaItemTracker {
                     return tracker

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -6,10 +6,8 @@ package ch.srgssr.pillarbox.player
 
 import android.net.Uri
 import androidx.media3.common.MediaItem
-import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
@@ -51,62 +49,139 @@ class TestCurrentMediaItemTracker {
     }
 
     @Test
-    fun testStartTimeLineChanged() = runTest {
+    fun testAreEqualsDifferentMediaItem() {
         val mediaItem = createMediaItem("M1")
-        val eventTime = createEventTime(mediaItem)
-        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
-        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
-        analyticsCommander.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
-        Assert.assertEquals(expected, tracker.stateList)
-    }
-
-    @Test
-    fun testEndAtEoF() = runTest {
-        val mediaItem = createMediaItem("M1")
-        val eventTime = createEventTime(mediaItem)
-        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
-        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
-        analyticsCommander.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
-        Assert.assertEquals(expected, tracker.stateList)
-    }
-
-    @Test
-    fun testEoFRestart() = runTest {
-        val mediaItem = createMediaItem("M1")
-        val eventTime = createEventTime(mediaItem)
-        val expected = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
-        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
-        analyticsCommander.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
-        analyticsCommander.onPlaybackStateChanged(eventTime, Player.STATE_READY)
-        analyticsCommander.onPlayerReleased(eventTime)
-
-        Assert.assertEquals(expected, tracker.stateList)
-    }
-
-    @Test
-    fun testMediaTransition() = runTest {
-        val expected = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
-        val mediaItem = createMediaItem("M1")
-        val eventTime = createEventTime(mediaItem)
-
-        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         val mediaItem2 = createMediaItem("M2")
-        val eventTime2 = createEventTime(mediaItem2)
-        analyticsCommander.onMediaItemTransition(eventTime2, mediaItem2, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
-        analyticsCommander.onMediaItemTransition(eventTime2, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        Assert.assertFalse(CurrentMediaItemTracker.areEquals(mediaItem, mediaItem2))
+    }
+
+    @Test
+    fun testAreEqualsSameMediaId() {
+        val mediaItem = createMediaItem("M1")
+        val mediaItem2 = createMediaItem("M1")
+        Assert.assertTrue(CurrentMediaItemTracker.areEquals(mediaItem, mediaItem2))
+    }
+
+    @Test
+    fun testStartEnd() = runTest {
+        val mediaItem = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemEnd(mediaItem)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testStartAsyncLoadEnd() = runTest {
+        val mediaItemEmpty = MediaItem.Builder().setMediaId("M1").build()
+        val mediaItemLoaded = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        analyticsCommander.simulateItemStart(mediaItemEmpty)
+        analyticsCommander.simulateItemLoaded(mediaItemLoaded)
+        analyticsCommander.simulateItemEnd(mediaItemLoaded)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testStartReleased() = runTest {
+        val mediaItem = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateRelease(mediaItem)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testRelease() = runTest {
+        val mediaItem = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE)
+        analyticsCommander.simulateRelease(mediaItem)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testRestartAfterEnd() = runTest {
+        val mediaItem = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemEnd(mediaItem)
+        analyticsCommander.simulatedReady(mediaItem)
+        analyticsCommander.simulateItemEnd(mediaItem)
+        analyticsCommander.simulateRelease(mediaItem)
 
         Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testMediaTransitionSeekToNext() = runTest {
+        val expectedStates = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
+        val mediaItem = createMediaItem("M1")
+        val mediaItem2 = createMediaItem("M2")
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemTransitionSeek(mediaItem, mediaItem2)
+        analyticsCommander.simulateItemEnd(mediaItem2)
+        Assert.assertEquals("Different Item", expectedStates, tracker.stateList)
+        tracker.clear()
+
+        val mediaItem3 = createMediaItem("M1")
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemTransitionSeek(mediaItem, mediaItem3)
+        analyticsCommander.simulateItemEnd(mediaItem3)
+        Assert.assertEquals("Different Item but equal", expectedStates, tracker.stateList)
+    }
+
+    @Test
+    fun testMediaItemTransitionWithAsyncItem() = runTest {
+        val expectedStates = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
+        val mediaItem = createMediaItem("M1")
+        val mediaItem2 = MediaItem.Builder().setMediaId("M2").build()
+        val mediaItem2Loaded = createMediaItem("M2")
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemTransitionSeek(mediaItem, mediaItem2)
+        Assert.assertEquals(listOf(EventState.IDLE, EventState.START, EventState.END), tracker.stateList)
+
+        analyticsCommander.simulateItemLoaded(mediaItem2Loaded)
+        analyticsCommander.simulateRelease(mediaItem2Loaded)
+        Assert.assertEquals(expectedStates, tracker.stateList)
+    }
+
+
+    @Test
+    fun testMediaTransitionSameItemAuto() = runTest {
+        val expectedStates = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
+        val mediaItem = createMediaItem("M1")
+        val mediaItem2 = createMediaItem("M2")
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemTransitionAuto(mediaItem, mediaItem2)
+        analyticsCommander.simulateItemEnd(mediaItem2)
+        Assert.assertEquals("Different Item", expectedStates, tracker.stateList)
+        tracker.clear()
+
+        val mediaItem3 = createMediaItem("M1")
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemTransitionAuto(mediaItem, mediaItem3)
+        analyticsCommander.simulateItemEnd(mediaItem3)
+        Assert.assertEquals("Different Item but equal", expectedStates, tracker.stateList)
+    }
+
+    @Test
+    fun testMediaTransitionRepeat() = runTest {
+        val expectedStates = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START)
+        val mediaItem = createMediaItem("M1")
+
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemTransitionRepeat(mediaItem)
+
+        Assert.assertEquals(expectedStates, tracker.stateList)
     }
 
     @Test
     fun testMultipleStart() = runTest {
         val mediaItem = createMediaItem("M1")
-        val eventTime = createEventTime(mediaItem)
 
-        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
-        analyticsCommander.onMediaItemTransition(eventTime, mediaItem, Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED)
-        analyticsCommander.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
-
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemEnd(mediaItem)
         val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
         Assert.assertEquals(expected, tracker.stateList)
     }
@@ -114,30 +189,25 @@ class TestCurrentMediaItemTracker {
     @Test
     fun testMultipleStop() = runTest {
         val mediaItem = createMediaItem("M1")
-        val eventTime = createEventTime(mediaItem)
-
-        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
-        analyticsCommander.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
-        analyticsCommander.onPlayerReleased(eventTime)
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemEnd(mediaItem)
+        analyticsCommander.simulateRelease(mediaItem)
 
         val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
         Assert.assertEquals(expected, tracker.stateList)
     }
 
     companion object {
+        private val uri: Uri = mockk(relaxed = true)
 
         fun createMediaItem(mediaId: String): MediaItem {
-            val uri: Uri = mockk(relaxed = true)
+            every { uri.toString() } returns "https://host/media.mp4"
+            every { uri.equals(Any()) } returns true
             return MediaItem.Builder()
                 .setUri(uri)
                 .setMediaId(mediaId)
                 .setTag(MediaItemTrackerData().apply { putData(TestTracker::class.java, mediaId) })
                 .build()
-        }
-
-        fun createEventTime(mediaItem: MediaItem): EventTime {
-            val timeline = DummyTimeline(mediaItem)
-            return EventTime(0, timeline, 0, null, 0, timeline, 0, null, 0, 0)
         }
     }
 
@@ -148,6 +218,11 @@ class TestCurrentMediaItemTracker {
     private class TestTracker : MediaItemTracker {
 
         val stateList = ArrayList<EventState>().apply { add(EventState.IDLE) }
+
+        fun clear() {
+            stateList.clear()
+            stateList.add(EventState.IDLE)
+        }
 
         override fun start(player: ExoPlayer) {
             stateList.add(EventState.START)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -8,7 +8,9 @@ import android.net.Uri
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
+import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerList
 import io.mockk.clearAllMocks
@@ -30,14 +32,14 @@ import org.junit.Test
 @OptIn(ExperimentalCoroutinesApi::class)
 class TestCurrentMediaItemTracker {
 
-    private lateinit var fakePlayer: AnalyticsListenerCommander
-    private lateinit var pillarboxPlayer: PillarboxPlayer
+    private lateinit var analyticsCommander: AnalyticsListenerCommander
+    private lateinit var currentItemTracker: CurrentMediaItemTracker
 
     @Before
     fun setUp() {
-        fakePlayer = AnalyticsListenerCommander(mock = mockk(relaxed = false))
-        every { fakePlayer.currentMediaItem } returns null
-        pillarboxPlayer = PillarboxPlayer(fakePlayer)
+        analyticsCommander = AnalyticsListenerCommander(mock = mockk(relaxed = false))
+        every { analyticsCommander.currentMediaItem } returns null
+        currentItemTracker = CurrentMediaItemTracker(analyticsCommander)
     }
 
     @After
@@ -50,10 +52,10 @@ class TestCurrentMediaItemTracker {
         val tracker = TestTracker()
         val mediaItem = createMediaItem("M1", tracker)
         val eventTime = createEventTime(mediaItem)
-        fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         Assert.assertEquals(EventState.START, tracker.eventState.take(1).first().state)
 
-        fakePlayer.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        analyticsCommander.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
         Assert.assertEquals(EventState.END, tracker.eventState.take(1).first().state)
         Assert.assertEquals(0, tracker.startCount)
     }
@@ -63,10 +65,10 @@ class TestCurrentMediaItemTracker {
         val tracker = TestTracker()
         val mediaItem = createMediaItem("M1", tracker)
         val eventTime = createEventTime(mediaItem)
-        fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         Assert.assertEquals(EventState.START, tracker.eventState.take(1).first().state)
 
-        fakePlayer.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
+        analyticsCommander.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
         Assert.assertEquals(EventState.END, tracker.eventState.take(1).first().state)
         Assert.assertEquals(0, tracker.startCount)
     }
@@ -78,13 +80,13 @@ class TestCurrentMediaItemTracker {
         val eventTime = createEventTime(mediaItem)
         val expected = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
         launch {
-            fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+            analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
             delay(100)
-            fakePlayer.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
+            analyticsCommander.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
             delay(100)
-            fakePlayer.onPlaybackStateChanged(eventTime, Player.STATE_READY)
+            analyticsCommander.onPlaybackStateChanged(eventTime, Player.STATE_READY)
             delay(100)
-            fakePlayer.onPlayerReleased(eventTime)
+            analyticsCommander.onPlayerReleased(eventTime)
         }
 
         Assert.assertEquals(expected, tracker.eventState.take(expected.size).toList().map { it.state })
@@ -96,17 +98,17 @@ class TestCurrentMediaItemTracker {
         val tracker = TestTracker()
         val mediaItem = createMediaItem("M1", tracker)
         val eventTime = createEventTime(mediaItem)
-        fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         Assert.assertEquals(EventState.START, tracker.eventState.take(1).first().state)
 
         val tracker2 = TestTracker()
         val mediaItem2 = createMediaItem("M2", tracker2)
         val eventTime2 = createEventTime(mediaItem2)
-        fakePlayer.onMediaItemTransition(eventTime2, mediaItem2, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        analyticsCommander.onMediaItemTransition(eventTime2, mediaItem2, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
         Assert.assertEquals(EventState.END, tracker.eventState.take(1).first().state)
         Assert.assertEquals(EventState.START, tracker2.eventState.take(1).first().state)
 
-        fakePlayer.onMediaItemTransition(eventTime2, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        analyticsCommander.onMediaItemTransition(eventTime2, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
         Assert.assertEquals(EventState.END, tracker2.eventState.take(1).first().state)
         Assert.assertEquals(0, tracker.startCount)
     }
@@ -117,11 +119,11 @@ class TestCurrentMediaItemTracker {
         val mediaItem = createMediaItem("M1", tracker)
         val eventTime = createEventTime(mediaItem)
         launch {
-            fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+            analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
             delay(1_000)
-            fakePlayer.onMediaItemTransition(eventTime, mediaItem, Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED)
+            analyticsCommander.onMediaItemTransition(eventTime, mediaItem, Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED)
             delay(1_000)
-            fakePlayer.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+            analyticsCommander.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
         }
         val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
         Assert.assertEquals(expected, tracker.eventState.take(3).toList().map { it.state })
@@ -134,11 +136,11 @@ class TestCurrentMediaItemTracker {
         val mediaItem = createMediaItem("M1", tracker)
         val eventTime = createEventTime(mediaItem)
         launch {
-            fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+            analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
             delay(1_000)
-            fakePlayer.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+            analyticsCommander.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
             delay(1_000)
-            fakePlayer.onPlayerReleased(eventTime)
+            analyticsCommander.onPlayerReleased(eventTime)
 
         }
         val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
@@ -173,12 +175,12 @@ class TestCurrentMediaItemTracker {
         val eventState = MutableStateFlow(StartEvent(EventState.IDLE))
         var startCount = 0
 
-        override fun start(player: PillarboxPlayer) {
+        override fun start(player: ExoPlayer) {
             startCount++
             eventState.value = StartEvent(EventState.START)
         }
 
-        override fun stop(player: PillarboxPlayer) {
+        override fun stop(player: ExoPlayer) {
             startCount--
             eventState.value = StartEvent(EventState.END)
         }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import android.net.Uri
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
+import androidx.media3.common.Timeline
+import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
+import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerList
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestCurrentMediaItemTracker {
+
+    private lateinit var fakePlayer: AnalyticsListenerCommander
+    private lateinit var pillarboxPlayer: PillarboxPlayer
+
+    @Before
+    fun setUp() {
+        fakePlayer = AnalyticsListenerCommander(mock = mockk(relaxed = false))
+        every { fakePlayer.currentMediaItem } returns null
+        pillarboxPlayer = PillarboxPlayer(fakePlayer)
+    }
+
+    @After
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun testStartTimeLineChanged() = runTest {
+        val tracker = TestTracker()
+        val mediaItem = createMediaItem("M1", tracker)
+        val eventTime = createEventTime(mediaItem)
+        fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+        Assert.assertEquals(EventState.START, tracker.eventState.take(1).first().state)
+
+        fakePlayer.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        Assert.assertEquals(EventState.END, tracker.eventState.take(1).first().state)
+        Assert.assertEquals(0, tracker.startCount)
+    }
+
+    @Test
+    fun testEndAtEoF() = runTest {
+        val tracker = TestTracker()
+        val mediaItem = createMediaItem("M1", tracker)
+        val eventTime = createEventTime(mediaItem)
+        fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+        Assert.assertEquals(EventState.START, tracker.eventState.take(1).first().state)
+
+        fakePlayer.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
+        Assert.assertEquals(EventState.END, tracker.eventState.take(1).first().state)
+        Assert.assertEquals(0, tracker.startCount)
+    }
+
+    @Test
+    fun testEoFRestart() = runTest {
+        val tracker = TestTracker()
+        val mediaItem = createMediaItem("M1", tracker)
+        val eventTime = createEventTime(mediaItem)
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
+        launch {
+            fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+            delay(100)
+            fakePlayer.onPlaybackStateChanged(eventTime, Player.STATE_ENDED)
+            delay(100)
+            fakePlayer.onPlaybackStateChanged(eventTime, Player.STATE_READY)
+            delay(100)
+            fakePlayer.onPlayerReleased(eventTime)
+        }
+
+        Assert.assertEquals(expected, tracker.eventState.take(expected.size).toList().map { it.state })
+        Assert.assertEquals(0, tracker.startCount)
+    }
+
+    @Test
+    fun testMediaTransition() = runTest {
+        val tracker = TestTracker()
+        val mediaItem = createMediaItem("M1", tracker)
+        val eventTime = createEventTime(mediaItem)
+        fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+        Assert.assertEquals(EventState.START, tracker.eventState.take(1).first().state)
+
+        val tracker2 = TestTracker()
+        val mediaItem2 = createMediaItem("M2", tracker2)
+        val eventTime2 = createEventTime(mediaItem2)
+        fakePlayer.onMediaItemTransition(eventTime2, mediaItem2, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        Assert.assertEquals(EventState.END, tracker.eventState.take(1).first().state)
+        Assert.assertEquals(EventState.START, tracker2.eventState.take(1).first().state)
+
+        fakePlayer.onMediaItemTransition(eventTime2, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        Assert.assertEquals(EventState.END, tracker2.eventState.take(1).first().state)
+        Assert.assertEquals(0, tracker.startCount)
+    }
+
+    @Test
+    fun testMultipleStart() = runTest {
+        val tracker = TestTracker()
+        val mediaItem = createMediaItem("M1", tracker)
+        val eventTime = createEventTime(mediaItem)
+        launch {
+            fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+            delay(1_000)
+            fakePlayer.onMediaItemTransition(eventTime, mediaItem, Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED)
+            delay(1_000)
+            fakePlayer.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+        }
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        Assert.assertEquals(expected, tracker.eventState.take(3).toList().map { it.state })
+        Assert.assertEquals(0, tracker.startCount)
+    }
+
+    @Test
+    fun testMultipleStop() = runTest {
+        val tracker = TestTracker()
+        val mediaItem = createMediaItem("M1", tracker)
+        val eventTime = createEventTime(mediaItem)
+        launch {
+            fakePlayer.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
+            delay(1_000)
+            fakePlayer.onMediaItemTransition(eventTime, null, Player.MEDIA_ITEM_TRANSITION_REASON_SEEK)
+            delay(1_000)
+            fakePlayer.onPlayerReleased(eventTime)
+
+        }
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        Assert.assertEquals(expected, tracker.eventState.take(3).toList().map { it.state })
+        Assert.assertEquals(0, tracker.startCount)
+    }
+
+    companion object {
+
+        fun createMediaItem(mediaId: String, tracker: MediaItemTracker): MediaItem {
+            val uri: Uri = mockk(relaxed = true)
+            return MediaItem.Builder()
+                .setUri(uri)
+                .setMediaId(mediaId)
+                .setTag(MediaItemTrackerList().apply { append(tracker) })
+                .build()
+        }
+
+        fun createEventTime(mediaItem: MediaItem): EventTime {
+            val timeline = DummyTimeline(mediaItem)
+            return EventTime(0, timeline, 0, null, 0, timeline, 0, null, 0, 0)
+        }
+    }
+
+    private enum class EventState {
+        IDLE, START, END
+    }
+
+    private data class StartEvent(val state: EventState, val time: Long = System.currentTimeMillis())
+
+    private class TestTracker : MediaItemTracker {
+        val eventState = MutableStateFlow(StartEvent(EventState.IDLE))
+        var startCount = 0
+
+        override fun start(player: PillarboxPlayer) {
+            startCount++
+            eventState.value = StartEvent(EventState.START)
+        }
+
+        override fun stop(player: PillarboxPlayer) {
+            startCount--
+            eventState.value = StartEvent(EventState.END)
+        }
+    }
+
+    private class DummyTimeline(private val mediaItem: MediaItem) : Timeline() {
+
+        override fun getWindowCount(): Int {
+            return 1
+        }
+
+        override fun getWindow(windowIndex: Int, window: Window, defaultPositionProjectionUs: Long): Window {
+            window.mediaItem = mediaItem
+            return window
+        }
+
+        override fun getPeriodCount(): Int {
+            return 0
+        }
+
+        override fun getPeriod(periodIndex: Int, period: Period, setIds: Boolean): Period {
+            return Period()
+        }
+
+        override fun getIndexOfPeriod(uid: Any): Int {
+            return 0
+        }
+
+        override fun getUidOfPeriod(periodIndex: Int): Any {
+            return Any()
+        }
+
+    }
+}

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.player
 
+import androidx.media3.exoplayer.ExoPlayer
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerList
 import org.junit.Assert
@@ -89,27 +90,27 @@ class TestMediaItemTrackerList {
     }
 
     private class ItemTrackerA : MediaItemTracker {
-        override fun start(player: PillarboxPlayer) {
+        override fun start(player: ExoPlayer) {
         }
 
-        override fun stop(player: PillarboxPlayer) {
+        override fun stop(player: ExoPlayer) {
         }
 
     }
 
     private class ItemTrackerB : MediaItemTracker {
-        override fun start(player: PillarboxPlayer) {
+        override fun start(player: ExoPlayer) {
         }
 
-        override fun stop(player: PillarboxPlayer) {
+        override fun stop(player: ExoPlayer) {
         }
     }
 
     private open class ItemTrackerC : MediaItemTracker {
-        override fun start(player: PillarboxPlayer) {
+        override fun start(player: ExoPlayer) {
         }
 
-        override fun stop(player: PillarboxPlayer) {
+        override fun stop(player: ExoPlayer) {
         }
     }
 

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerList
+import org.junit.Assert
+import org.junit.Test
+
+class TestMediaItemTrackerList {
+
+    @Test
+    fun testEmpty() {
+        val trackers = MediaItemTrackerList()
+        Assert.assertEquals(trackers.size, 0)
+        Assert.assertTrue(trackers.list.isEmpty())
+    }
+
+    @Test
+    fun testAppendOnce() {
+        val trackers = MediaItemTrackerList()
+        val tracker = ItemTrackerA()
+        val added = trackers.append(tracker)
+        Assert.assertTrue(added)
+        Assert.assertEquals(trackers.size, 1)
+        Assert.assertEquals(trackers.list, listOf(tracker))
+    }
+
+    @Test
+    fun testAppendTwiceSameKindOfTracker() {
+        val trackers = MediaItemTrackerList()
+        val trackerA = ItemTrackerA()
+        val trackerAA = ItemTrackerA()
+        trackers.append(trackerA)
+        val added = trackers.append(trackerAA)
+        Assert.assertFalse(added)
+        Assert.assertEquals(trackers.size, 1)
+        Assert.assertEquals(trackers.list, listOf(trackerA))
+    }
+
+    @Test
+    fun testAppendDifferentTracker() {
+        val trackers = MediaItemTrackerList()
+        val trackerList = listOf(ItemTrackerA(), ItemTrackerB(), ItemTrackerC())
+        for (tracker in trackerList) {
+            trackers.append(tracker)
+        }
+
+        Assert.assertEquals(trackers.size, trackerList.size)
+        Assert.assertEquals(trackers.list, trackerList)
+    }
+
+    @Test
+    fun testAppendDifferentTrackerWithOpenTracker() {
+        val trackers = MediaItemTrackerList()
+        val trackerList = listOf(ItemTrackerC(), ItemTrackerD())
+        for (tracker in trackerList) {
+            trackers.append(tracker)
+        }
+        Assert.assertEquals(trackers.size, trackerList.size)
+        Assert.assertEquals(trackers.list, trackerList)
+
+        val trackersRevert = MediaItemTrackerList()
+        val trackerListRevert = listOf(ItemTrackerD(), ItemTrackerC())
+        for (tracker in trackerListRevert) {
+            trackersRevert.append(tracker)
+        }
+        Assert.assertEquals(trackersRevert.size, trackerListRevert.size)
+        Assert.assertEquals(trackersRevert.list, trackerListRevert)
+    }
+
+    @Test
+    fun testFindTracker() {
+        val trackers = MediaItemTrackerList()
+        val tracker = ItemTrackerA()
+        val tracker2 = ItemTrackerB()
+        trackers.append(tracker)
+        trackers.append(tracker2)
+
+        val trackerA = trackers.findTracker(ItemTrackerA::class.java)
+        Assert.assertEquals(tracker, trackerA)
+        val trackerB = trackers.findTracker(ItemTrackerB::class.java)
+        Assert.assertEquals(tracker2, trackerB)
+
+        val trackerC = trackers.findTracker(ItemTrackerC::class.java)
+        Assert.assertNull(trackerC)
+    }
+
+    private class ItemTrackerA : MediaItemTracker {
+        override fun start(player: PillarboxPlayer) {
+        }
+
+        override fun stop(player: PillarboxPlayer) {
+        }
+
+    }
+
+    private class ItemTrackerB : MediaItemTracker {
+        override fun start(player: PillarboxPlayer) {
+        }
+
+        override fun stop(player: PillarboxPlayer) {
+        }
+    }
+
+    private open class ItemTrackerC : MediaItemTracker {
+        override fun start(player: PillarboxPlayer) {
+        }
+
+        override fun stop(player: PillarboxPlayer) {
+        }
+    }
+
+    private class ItemTrackerD : ItemTrackerC()
+}

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
@@ -5,7 +5,7 @@
 package ch.srgssr.pillarbox.player
 
 import androidx.media3.exoplayer.ExoPlayer
-import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
 import org.junit.Assert
 import org.junit.Before
@@ -13,11 +13,11 @@ import org.junit.Test
 
 class TestMediaItemTrackerRepository {
 
-    private lateinit var trackerRepository: MediaItemMediaItemTrackerRepository
+    private lateinit var trackerRepository: MediaItemTrackerRepository
 
     @Before
     fun init() {
-        trackerRepository = MediaItemMediaItemTrackerRepository()
+        trackerRepository = MediaItemTrackerRepository()
     }
 
     @Test(expected = AssertionError::class)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import androidx.media3.exoplayer.ExoPlayer
+import ch.srgssr.pillarbox.player.tracker.MediaItemMediaItemTrackerRepository
+import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+
+class TestMediaItemTrackerRepository {
+
+    private lateinit var trackerRepository: MediaItemMediaItemTrackerRepository
+
+    @Before
+    fun init() {
+        trackerRepository = MediaItemMediaItemTrackerRepository()
+    }
+
+    @Test(expected = AssertionError::class)
+    fun testNotFoundTracker() {
+        trackerRepository.getMediaItemTrackerFactory(String::class.java)
+    }
+
+    @Test
+    fun testRetrieveTracker() {
+        val testFactory = TestTracker.Factory()
+        trackerRepository.registerFactory(TestTracker::class.java, testFactory)
+        val factory = trackerRepository.getMediaItemTrackerFactory(TestTracker::class.java)
+        Assert.assertEquals(TestTracker.Factory::class.java, factory::class.java)
+        Assert.assertEquals(testFactory, factory)
+    }
+
+    private class TestTracker : MediaItemTracker {
+
+        class Factory : MediaItemTracker.Factory {
+            override fun create(): MediaItemTracker {
+                return TestTracker()
+            }
+        }
+
+        override fun start(player: ExoPlayer) {
+
+        }
+
+        override fun stop(player: ExoPlayer) {
+
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add Media tracking to Pillarbox. It is the result of a previous PoC #83 

## Changes made

- New API for media tracking `MediaItemTracker`, `MediaItemTrackerProvider` and `MediaItemTrackerData`
- `MediaItemTrackerProvider` can be set when instantiating a `PillarboxPlayer`.
- When creating a `MediaItem` from `MediaItemSource` you can add a `MediaItemTrackerData` to append your `MediaItemTracker` and add it to `MediaItem.Builder.setTrackerData`.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
