### PR TITLE
Tracking enable flag

### DIFF
--- a/pillarbox-player/docs/MediaItemTracking.md
+++ b/pillarbox-player/docs/MediaItemTracking.md
@@ -85,6 +85,6 @@ You can disable or enable tracking during execution with `player.trackingEnable`
 ```kotlin
 val player = PillarboxPlayer(context = context, mediaItemSource = DefaultMediaItemSource(), mediaItemTrackerProvider = DemoTrackerProvider())
 // Disable media stream tracking
-player.trackingEnable = false
+player.trackingEnabled = false
 ```
 

--- a/pillarbox-player/docs/MediaItemTracking.md
+++ b/pillarbox-player/docs/MediaItemTracking.md
@@ -78,4 +78,13 @@ val itemToPlay = MediaItem.fromUri("https://sample.com/sample.mp4")
 player.setMediaItem(itemToPlay)
 ```
 
+### Toggle analytics
+
+You can disable or enable tracking during execution with `player.trackingEnable`.
+
+```kotlin
+val player = PillarboxPlayer(context = context, mediaItemSource = DefaultMediaItemSource(), mediaItemTrackerProvider = DemoTrackerProvider())
+// Disable media stream tracking
+player.trackingEnable = false
+```
 

--- a/pillarbox-player/docs/MediaItemTracking.md
+++ b/pillarbox-player/docs/MediaItemTracking.md
@@ -78,7 +78,7 @@ val itemToPlay = MediaItem.fromUri("https://sample.com/sample.mp4")
 player.setMediaItem(itemToPlay)
 ```
 
-### Toggle analytics
+### Toggle tracking
 
 You can disable or enable tracking during execution with `player.trackingEnable`.
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -34,10 +34,18 @@ class PillarboxPlayer internal constructor(
     mediaItemTrackerProvider: MediaItemTrackerProvider? = null
 ) :
     ExoPlayer by exoPlayer {
+    private val itemTracker: CurrentMediaItemTracker?
+
+    /**
+     * Enable or disable MediaItem tracking
+     */
+    var trackingEnable: Boolean
+        set(value) = itemTracker?.let { it.enabled = value } ?: Unit
+        get() = itemTracker?.enabled ?: false
 
     init {
         addListener(ComponentListener())
-        mediaItemTrackerProvider?.let {
+        itemTracker = mediaItemTrackerProvider?.let {
             CurrentMediaItemTracker(this, it)
         }
     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -39,7 +39,7 @@ class PillarboxPlayer internal constructor(
     /**
      * Enable or disable MediaItem tracking
      */
-    var trackingEnable: Boolean
+    var trackingEnabled: Boolean
         set(value) = itemTracker?.let { it.enabled = value } ?: Unit
         get() = itemTracker?.enabled ?: false
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -47,6 +47,7 @@ internal class CurrentMediaItemTracker internal constructor(
     private var currentMediaItem: MediaItem? = player.currentMediaItem
         set(value) {
             when {
+                !enabled -> field = value
                 !areEqual(field, value) -> {
                     field?.let { if (it.canHaveTrackingSession()) stopSession() }
                     field = value
@@ -69,6 +70,20 @@ internal class CurrentMediaItemTracker internal constructor(
                     field?.let { updateSession(it) }
                 }
             } // When
+        }
+
+    var enabled: Boolean = true
+        set(value) {
+            if (field != value) {
+                field = value
+                if (field) {
+                    if (currentMediaItem.canHaveTrackingSession()) {
+                        currentMediaItem?.let { startSession(it) }
+                    }
+                } else {
+                    trackers?.let { stopSession() }
+                }
+            }
         }
 
     private val window = Window()

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -187,6 +187,18 @@ class TestCurrentMediaItemTracker {
         Assert.assertEquals(expectedStates, tracker.stateList)
     }
 
+    @Test
+    fun testItemWithoutTrackerToggleAnalytics() = runTest {
+        val tag = "testItemWithoutTracker"
+        val mediaItem = createMediaItemWithoutTracker("M1", tag)
+        val expected = listOf(EventState.IDLE)
+        currentItemTracker.enabled = true
+        analyticsCommander.simulateItemStart(mediaItem)
+        currentItemTracker.enabled = false
+        currentItemTracker.enabled = true
+        analyticsCommander.simulateItemEnd(mediaItem)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
 
     @Test
     fun testMediaTransitionSameItemAuto() = runTest {
@@ -236,6 +248,55 @@ class TestCurrentMediaItemTracker {
         analyticsCommander.simulateRelease(mediaItem)
 
         val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testStartEndDisableAtStartAnalytics() = runTest {
+        val mediaItem = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE)
+        currentItemTracker.enabled = false
+        analyticsCommander.simulateItemStart(mediaItem)
+        analyticsCommander.simulateItemEnd(mediaItem)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testStartEndToggleAnalytics() = runTest {
+        val mediaItem = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
+        currentItemTracker.enabled = true
+        analyticsCommander.simulateItemStart(mediaItem)
+        currentItemTracker.enabled = false
+        currentItemTracker.enabled = true
+        analyticsCommander.simulateItemEnd(mediaItem)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testStartAsyncLoadEndToggleAnalytics() = runTest {
+        val mediaItemEmpty = MediaItem.Builder().setMediaId("M1").build()
+        val mediaItemLoaded = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END, EventState.START, EventState.END)
+        currentItemTracker.enabled = true
+        analyticsCommander.simulateItemStart(mediaItemEmpty)
+        analyticsCommander.simulateItemLoaded(mediaItemLoaded)
+        currentItemTracker.enabled = false
+        currentItemTracker.enabled = true
+        analyticsCommander.simulateItemEnd(mediaItemLoaded)
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testStartAsyncLoadEndDisableAtEnd() = runTest {
+        val mediaItemEmpty = MediaItem.Builder().setMediaId("M1").build()
+        val mediaItemLoaded = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        currentItemTracker.enabled = true
+        analyticsCommander.simulateItemStart(mediaItemEmpty)
+        analyticsCommander.simulateItemLoaded(mediaItemLoaded)
+        analyticsCommander.simulateItemEnd(mediaItemLoaded)
+        currentItemTracker.enabled = false
         Assert.assertEquals(expected, tracker.stateList)
     }
 


### PR DESCRIPTION
## Description

Allow integrator to disable / enable media stream tracking for each instance of `PillarboxPlayer`.

## Changes made

- Add `PillarboxPlayer.trackingEnabled` to enable or disable media stream tracking.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
