### PR TITLE
Simplify custom tracker for MediaCompositionMediaItemSource

### DIFF
--- a/pillarbox-core-business/docs/README.md
+++ b/pillarbox-core-business/docs/README.md
@@ -5,7 +5,8 @@
 
 # Pillarbox Core Business module
 
-Provides SRG SSR media URN `MediaItemSource` to Pillarbox. It basically converts an integration layer integration layer `MediaComposition` to a playable `MediaItem`.
+Provides SRG SSR media URN `MediaItemSource` to Pillarbox. It basically converts an integration layer integration layer `MediaComposition` to a
+playable `MediaItem`.
 
 Supported contents are :
 
@@ -78,6 +79,45 @@ All exceptions thrown by `MediaCompositionMediaItemSource` are caught by the pla
         }
     }
 })
+```
+
+## Add custom trackers
+
+`MediaItemTracker` can be added to the player. The data related to tracker have to be added during `MediaItem` creation inside
+`MediaCompositionMediaItemSource`. `TrackerDataProvider` allow to add data for specific tracker.
+
+### Create custom MediaItemTracker
+
+```kotlin
+class CustomTracker : MediaItemTracker {
+
+    data class Data(val mediaComposition: MediaComposition)
+
+    // implements here functions
+}
+```
+
+### Create and add required custom tracker data
+
+```kotlin
+val mediaItemSource = MediaCompositionMediaItemSource(
+    mediaCompositionDataSource = mediaCompositionDataSource,
+    trackerDataProvider = object : TrackerDataProvider {
+        override fun update(trackerData: MediaItemTrackerData, resource: Resource, chapter: Chapter, mediaComposition: MediaComposition) {
+            trackerData.putData(CustomTracker::class.java, CustomTracker.Data(mediaComposition))
+        }
+    })
+```
+
+### Inject custom tracker to the player
+
+```kotlin
+val player = PillarboxPlayer(context = context,
+    mediaItemSource = mediaItemSource,
+    mediaItemTrackerProvider = DefaultMediaItemTrackerRepository().apply {
+        registerFactory(CustomTracker::class.java, CustomTracker.Factory())
+    }
+)
 ```
 
 ## Going further

--- a/pillarbox-core-business/docs/README.md
+++ b/pillarbox-core-business/docs/README.md
@@ -5,7 +5,7 @@
 
 # Pillarbox Core Business module
 
-Provides SRG SSR media URN `MediaItemSource` to Pillarbox. It basically converts an integration layer integration layer `MediaComposition` to a
+Provides SRG SSR media URN `MediaItemSource` to Pillarbox. It basically converts an integration layer `MediaComposition` to a
 playable `MediaItem`.
 
 Supported contents are :

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
@@ -30,9 +30,13 @@ import ch.srgssr.pillarbox.player.setTrackerData
  * - [MediaMetadata.subtitle] with [Chapter.lead]
  * - [MediaMetadata.description] with [Chapter.description]
  *
- * @property mediaCompositionDataSource
+ * @property mediaCompositionDataSource The MediaCompositionDataSource to use to load a MediaComposition.
+ * @property trackerDataProvider The TrackerDataProvider to customize TrackerData.
  */
-class MediaCompositionMediaItemSource(private val mediaCompositionDataSource: MediaCompositionDataSource) : MediaItemSource {
+class MediaCompositionMediaItemSource(
+    private val mediaCompositionDataSource: MediaCompositionDataSource,
+    private val trackerDataProvider: TrackerDataProvider? = null
+) : MediaItemSource {
     private val resourceSelector = ResourceSelector()
 
     private fun fillMetaData(metadata: MediaMetadata, chapter: Chapter): MediaMetadata {
@@ -71,6 +75,7 @@ class MediaCompositionMediaItemSource(private val mediaCompositionDataSource: Me
                     uri = appendTokenQueryToUri(uri)
                 }
                 val trackerData = mediaItem.getMediaItemTrackerData()
+                trackerDataProvider?.update(trackerData, resource, chapter, result.data)
                 trackerData.putData(SRGEventLoggerTracker::class.java, null)
                 return mediaItem.buildUpon()
                     .setMediaMetadata(fillMetaData(mediaItem.mediaMetadata, chapter))

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/TrackerDataProvider.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/TrackerDataProvider.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.core.business
+
+import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
+import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
+import ch.srgssr.pillarbox.core.business.integrationlayer.data.Resource
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
+
+/**
+ * Tracker data provider to add some data for custom tracker.
+ */
+interface TrackerDataProvider {
+    /**
+     * Update tracker data with given integration layer data.
+     *
+     * @param trackerData The [MediaItemTrackerData] to update.
+     * @param resource The selected [Resource].
+     * @param chapter The selected [Chapter].
+     * @param mediaComposition The loaded [MediaComposition].
+     */
+    fun update(
+        trackerData: MediaItemTrackerData,
+        resource: Resource,
+        chapter: Chapter,
+        mediaComposition: MediaComposition
+    )
+}

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/MediaUrn.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/MediaUrn.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data
 
+import androidx.media3.common.MediaItem
 import java.util.regex.Pattern
 
 /**
@@ -28,6 +29,17 @@ object MediaUrn {
      */
     fun isValid(urn: String): Boolean {
         return pattern.matcher(urn).matches()
+    }
+
+    /**
+     * Create a [MediaItem] from given urn.
+     *
+     * @param urn The urn to create the [MediaItem].
+     * @return [MediaItem] with given urn.
+     */
+    fun createMediaItem(urn: String): MediaItem {
+        require(isValid(urn)) { "Invalid Urn $urn" }
+        return MediaItem.Builder().setMediaId(urn).build()
     }
 }
 

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/DefaultMediaItemTrackerRepository.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/DefaultMediaItemTrackerRepository.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.core.business.tracker
+
+import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerProvider
+import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
+
+/**
+ * Default media item tracker repository for SRG.
+ *
+ * @property trackerRepository The MediaItemTrackerRepository to use to store Tracker.Factory.
+ */
+class DefaultMediaItemTrackerRepository internal constructor(private val trackerRepository: MediaItemTrackerRepository) : MediaItemTrackerProvider by
+trackerRepository {
+    init {
+        registerFactory(SRGEventLoggerTracker::class.java, SRGEventLoggerTracker.Factory())
+    }
+
+    constructor() : this(trackerRepository = MediaItemTrackerRepository())
+
+    /**
+     * Register factory
+     * @see MediaItemTrackerRepository.registerFactory
+     * @param T Class type extends [MediaItemTracker]
+     * @param trackerClass The class the trackerFactory create. Clazz must extends MediaItemTracker.
+     * @param trackerFactory The tracker factory associated with clazz.
+     */
+    fun <T : MediaItemTracker> registerFactory(trackerClass: Class<T>, trackerFactory: MediaItemTracker.Factory) {
+        trackerRepository.registerFactory(trackerClass, trackerFactory)
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Dependencies.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Dependencies.kt
@@ -9,9 +9,8 @@ import ch.srgssr.pillarbox.core.business.MediaCompositionMediaItemSource
 import ch.srgssr.pillarbox.core.business.akamai.AkamaiTokenDataSource
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.IlHost
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.MediaCompositionDataSourceImpl
-import ch.srgssr.pillarbox.core.business.tracker.SRGEventLoggerTracker
+import ch.srgssr.pillarbox.core.business.tracker.DefaultMediaItemTrackerRepository
 import ch.srgssr.pillarbox.player.PillarboxPlayer
-import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
 
 /**
  * Dependencies to make custom Dependency Injection
@@ -39,9 +38,7 @@ object Dependencies {
              * Optional, only needed if you plan to play akamai token protected content
              */
             dataSourceFactory = AkamaiTokenDataSource.Factory(),
-            mediaItemTrackerProvider = MediaItemTrackerRepository().apply {
-                registerFactory(SRGEventLoggerTracker::class.java, SRGEventLoggerTracker.Factory())
-            }
+            mediaItemTrackerProvider = DefaultMediaItemTrackerRepository()
         )
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryViewModel.kt
@@ -8,6 +8,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.media3.common.C
 import androidx.media3.common.Player
+import ch.srgssr.pillarbox.core.business.tracker.DefaultMediaItemTrackerRepository
 import ch.srgssr.pillarbox.demo.data.Dependencies
 import ch.srgssr.pillarbox.demo.data.Playlist
 import ch.srgssr.pillarbox.player.PillarboxPlayer
@@ -20,14 +21,30 @@ import kotlin.math.ceil
  */
 class StoryViewModel(application: Application) : AndroidViewModel(application) {
     private val mediaItemSource = Dependencies.provideMixedItemSource(application)
+    private val itemTrackerProvider = DefaultMediaItemTrackerRepository()
 
     /**
      * Players
      */
     private val players = arrayOf(
-        PillarboxPlayer(context = application, mediaItemSource = mediaItemSource, loadControl = StoryLoadControl.build()),
-        PillarboxPlayer(context = application, mediaItemSource = mediaItemSource, loadControl = StoryLoadControl.build()),
-        PillarboxPlayer(context = application, mediaItemSource = mediaItemSource, loadControl = StoryLoadControl.build())
+        PillarboxPlayer(
+            context = application,
+            mediaItemSource = mediaItemSource,
+            loadControl = StoryLoadControl.build(),
+            mediaItemTrackerProvider = itemTrackerProvider
+        ),
+        PillarboxPlayer(
+            context = application,
+            mediaItemSource = mediaItemSource,
+            loadControl = StoryLoadControl.build(),
+            mediaItemTrackerProvider = itemTrackerProvider
+        ),
+        PillarboxPlayer(
+            context = application,
+            mediaItemSource = mediaItemSource,
+            loadControl = StoryLoadControl.build(),
+            mediaItemTrackerProvider = itemTrackerProvider
+        )
     )
 
     /**


### PR DESCRIPTION
## Description

Add more customization to `MediaCompositionMediaItemSource` to easily add custom tracker data.

## Changes made

- Add a `TrackerDataProvider` to `MediaCompositionMediaItemSource`.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
