### PR TITLE
Update androidx.Media3 to 1.0.0

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -9,7 +9,7 @@ object Version {
     const val coroutines = "1.6.4"
     const val appCompat = "1.4.2"
     const val material = "1.6.1"
-    const val media3 = "1.0.0-rc02"
+    const val media3 = "1.0.0"
     const val media = "1.6.0"
     const val glide = "4.14.2"
     const val gson = "2.9.1"


### PR DESCRIPTION
## Description

Androidx.Media3 has finally release a production version. 

## Changes made

- Pull androidx.Media3 to version 1.0.0

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
