### PR TITLE
105 srganalytics as singleton

### DIFF
--- a/pillarbox-analytics/docs/README.md
+++ b/pillarbox-analytics/docs/README.md
@@ -19,6 +19,8 @@ implementation("ch.srgssr.pillarbox:pillarbox-analytics:$LATEST_RELEASE_VERSION"
 
 ### Configuration and create
 
+Before using `SRGAnalytics`, make sur to call first `SRGAnalytics.init`.
+
 ```kotlin
 val analyticsConfig = AnalyticsConfig(
     distributor = AnalyticsConfig.BuDistributor.SRG,
@@ -30,7 +32,7 @@ val config = SRGAnalytics.Config(
     commandersAct = CommandersAct.Config.SRG_DEBUG
 )
 
-val analytics = SRGAnalytics(appContext = appContext, config = config)
+val analytics = SRGAnalytics.init(appContext = appContext, config = config)
 ```
 
 ### Send page view

--- a/pillarbox-analytics/docs/README.md
+++ b/pillarbox-analytics/docs/README.md
@@ -19,7 +19,7 @@ implementation("ch.srgssr.pillarbox:pillarbox-analytics:$LATEST_RELEASE_VERSION"
 
 ### Configuration and create
 
-Before using `SRGAnalytics`, make sur to call first `SRGAnalytics.init`.
+Before using `SRGAnalytics` make sure to call `SRGAnalytics.init` first.
 
 ```kotlin
 val analyticsConfig = AnalyticsConfig(

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
@@ -26,8 +26,8 @@ class SRGAnalyticsTest {
     @Test(expected = IllegalArgumentException::class)
     fun testInitTwiceDifferentConfig() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        val analytics = SRGAnalytics.init(appContext = appContext, config = config)
+        SRGAnalytics.init(appContext = appContext, config = config)
         val config2 = config.copy(analyticsConfig = AnalyticsConfig(distributor = AnalyticsConfig.BuDistributor.RSI, "pillarbox-test-fail"))
-        Assert.assertEquals(analytics, SRGAnalytics.init(appContext, config2))
+        SRGAnalytics.init(appContext, config2)
     }
 }

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.analytics
+
+import androidx.test.platform.app.InstrumentationRegistry
+import ch.srgssr.pillarbox.analytics.commandersact.CommandersAct
+import org.junit.Assert
+import org.junit.Test
+
+class SRGAnalyticsTest {
+
+    private val config = SRGAnalytics.Config(
+        analyticsConfig = AnalyticsConfig(distributor = AnalyticsConfig.BuDistributor.SRG, "pillarbox-test-android"),
+        commandersAct = CommandersAct.Config.SRG_DEBUG
+    )
+
+    @Test
+    fun testInitTwice() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val analytics = SRGAnalytics.init(appContext = appContext, config = config)
+        Assert.assertEquals(analytics, SRGAnalytics.init(appContext, config))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testInitTwiceDifferentConfig() {
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val analytics = SRGAnalytics.init(appContext = appContext, config = config)
+        val config2 = config.copy(analyticsConfig = AnalyticsConfig(distributor = AnalyticsConfig.BuDistributor.RSI, "pillarbox-test-fail"))
+        Assert.assertEquals(analytics, SRGAnalytics.init(appContext, config2))
+    }
+}

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
@@ -14,32 +14,56 @@ import ch.srgssr.pillarbox.analytics.comscore.ComScore
  * @param appContext Application context.
  * @param config Global analytics config.
  */
-class SRGAnalytics(appContext: Context, config: Config) : AnalyticsDelegate {
+object SRGAnalytics : AnalyticsDelegate {
+    private var config: Config? = null
+    private var _commandersAct: CommandersAct? = null
+    private var _comScore: ComScore? = null
 
     /**
      * TagCommander analytics
      */
-    val commandersAct by lazy {
-        CommandersAct(
-            appContext = appContext,
-            config = config.analyticsConfig,
-            commandersActConfig = config.commandersAct
-        )
-    }
+    val commandersAct: CommandersAct
+        get() = _commandersAct!!
 
     /**
      * ComScore analytics
      */
-    val comScore by lazy { ComScore.init(config.analyticsConfig, config.comScore, appContext) }
+    val comScore: ComScore
+        get() = _comScore!!
+
+    /**
+     * Init SRGAnalytics
+     *
+     * @param appContext Application context
+     * @param config SRGAnalytics configuration
+     */
+    fun init(appContext: Context, config: Config): SRGAnalytics {
+        if (this.config != null) {
+            require(this.config == config) { "Already init with another config" }
+            return this
+        }
+        return synchronized(this) {
+            this.config = config
+            _commandersAct = CommandersAct(config = config.analyticsConfig, commandersActConfig = config.commandersAct, appContext)
+            _comScore = ComScore.init(config = config.analyticsConfig, comScoreConfig = config.comScore, appContext)
+            this
+        }
+    }
 
     override fun sendPageViewEvent(pageEvent: PageEvent) {
+        checkInitialized()
         commandersAct.sendPageViewEvent(pageEvent)
         comScore.sendPageViewEvent(pageEvent)
     }
 
     override fun sendEvent(event: Event) {
+        checkInitialized()
         commandersAct.sendEvent(event)
         // Business decision to not send those event to comScore.
+    }
+
+    private fun checkInitialized() {
+        requireNotNull(config) { "SRGAnalytics init has to be called before!" }
     }
 
     /**

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/di/AnalyticsModule.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/di/AnalyticsModule.kt
@@ -25,6 +25,6 @@ object AnalyticsModule {
             nonLocalizedApplicationName = "PillarboxDemo"
         )
         val config = SRGAnalytics.Config(analyticsConfig = analyticsConfig, commandersAct = CommandersAct.Config.SRG_DEBUG)
-        return SRGAnalytics(appContext = appContext, config = config)
+        return SRGAnalytics.init(appContext = appContext, config = config)
     }
 }


### PR DESCRIPTION
## Description

Transform SRGAnalytics into a singleton as the common usage is to have only one instance of analytics during the application lifecycle.

## Changes made

- `SRGAnalytics` as a object class
- Add `SRGAnalytics.init` to initialize ComScore and CommandersAct 

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
