### PR TITLE
Fix crash when removing last item from a playlist

### DIFF
--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -6,8 +6,10 @@ package ch.srgssr.pillarbox.player
 
 import android.net.Uri
 import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.analytics.AnalyticsListener
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
@@ -297,6 +299,16 @@ class TestCurrentMediaItemTracker {
         analyticsCommander.simulateItemLoaded(mediaItemLoaded)
         analyticsCommander.simulateItemEnd(mediaItemLoaded)
         currentItemTracker.enabled = false
+        Assert.assertEquals(expected, tracker.stateList)
+    }
+
+    @Test
+    fun testStartRemoveItem() = runTest {
+        val mediaItem = createMediaItem("M1")
+        val expected = listOf(EventState.IDLE, EventState.START, EventState.END)
+        analyticsCommander.simulateItemStart(mediaItem)
+        val eventTime = AnalyticsListener.EventTime(0, Timeline.EMPTY, 0, null, 0, Timeline.EMPTY, 0, null, 0, 0)
+        analyticsCommander.onTimelineChanged(eventTime, Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED)
         Assert.assertEquals(expected, tracker.stateList)
     }
 


### PR DESCRIPTION
## Description

The demo was crashing when removing the last item from a playlist. We fix that by making CurrentMediaItemTracker reading more safely the timeline received from the listeners. When removing the last item, ON_TIME_LINE_CHANGED is called with a empty timeline.

## Changes made

> `CurrentMediaItemTracker` safely read MediaItem from Timeline.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
