### PR TITLE
Start ComScore only when at least one activity has been created

### DIFF
--- a/pillarbox-analytics/docs/README.md
+++ b/pillarbox-analytics/docs/README.md
@@ -19,7 +19,8 @@ implementation("ch.srgssr.pillarbox:pillarbox-analytics:$LATEST_RELEASE_VERSION"
 
 ### Configuration and create
 
-Before using `SRGAnalytics` make sure to call `SRGAnalytics.init` first.
+Before using `SRGAnalytics` make sure to call `SRGAnalytics.init` first. It is strongly recommend to call init inside your `Application.onCreate` 
+method.
 
 ```kotlin
 val analyticsConfig = AnalyticsConfig(

--- a/pillarbox-analytics/docs/README.md
+++ b/pillarbox-analytics/docs/README.md
@@ -19,8 +19,8 @@ implementation("ch.srgssr.pillarbox:pillarbox-analytics:$LATEST_RELEASE_VERSION"
 
 ### Configuration and create
 
-Before using `SRGAnalytics` make sure to call `SRGAnalytics.init` first. It is strongly recommend to call init inside your `Application.onCreate` 
-method.
+Before using `SRGAnalytics` make sure to call `SRGAnalytics.init` first, otherwise it can lead to an undefined behavior.
+It is strongly recommended to call the initializer inside your `Application.onCreate` method.
 
 ```kotlin
 val analyticsConfig = AnalyticsConfig(

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
@@ -18,14 +18,14 @@ class SRGAnalyticsTest {
 
     @Test
     fun testInitTwice() {
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
         val analytics = SRGAnalytics.init(appContext = appContext, config = config)
         Assert.assertEquals(analytics, SRGAnalytics.init(appContext, config))
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testInitTwiceDifferentConfig() {
-        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext.applicationContext
         SRGAnalytics.init(appContext = appContext, config = config)
         val config2 = config.copy(analyticsConfig = AnalyticsConfig(distributor = AnalyticsConfig.BuDistributor.RSI, "pillarbox-test-fail"))
         SRGAnalytics.init(appContext, config2)

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestComScore.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestComScore.kt
@@ -16,7 +16,7 @@ class TestComScore {
 
     @Before
     fun setup() {
-        val appContext = getInstrumentation().targetContext
+        val appContext = getInstrumentation().targetContext.applicationContext
         comScore = ComScore.init(config = TestUtils.analyticsConfig, appContext = appContext)
     }
 

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
@@ -11,9 +11,9 @@ import ch.srgssr.pillarbox.analytics.commandersact.CommandersActImpl
 import ch.srgssr.pillarbox.analytics.comscore.ComScore
 
 /**
- * Analytics for SRGSSR
+ * Analytics for SRG SSR
  *
- * Have to be initialized first with [SRGAnalytics.init]
+ * Initialize it before using page view or event by calling [SRGAnalytics.init] in your Application.create
  */
 object SRGAnalytics : PageViewAnalytics, EventAnalytics, UserAnalytics {
     private var config: Config? = null

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.analytics.comscore
 
+import android.app.Application
 import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
@@ -15,6 +16,7 @@ import com.comscore.Analytics
 import com.comscore.PublisherConfiguration
 import com.comscore.UsagePropertiesAutoUpdateMode
 import com.comscore.util.log.LogLevel
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * ComScore
@@ -41,6 +43,8 @@ internal object ComScore : PageViewAnalytics {
      * Custom label Key for push notification source
      */
     private const val KEY_FROM_PUSH_NOTIFICATION = "srg_ap_push"
+
+    private val started = AtomicBoolean(false)
 
     /**
      * Init ComScore
@@ -80,19 +84,24 @@ internal object ComScore : PageViewAnalytics {
         if (BuildConfig.DEBUG) {
             Analytics.getConfiguration().enableImplementationValidationMode()
         }
-        start(appContext)
+        ComScoreStarter.startTrackingActivity(appContext as Application)
+        if (ComScoreStarter.uiExperienceStarted) {
+            start(appContext)
+        }
         return this
     }
 
-    private fun start(appContext: Context): ComScore {
-        checkInitialized()
-        Analytics.start(appContext)
-        return this
+    internal fun start(appContext: Context) {
+        if (!started.getAndSet(true)) {
+            checkInitialized()
+            Log.i("COMSCORE", "Start")
+            Analytics.start(appContext)
+        }
     }
 
     override fun sendPageView(pageView: PageView) {
         checkInitialized()
-
+        if (!started.get()) return
         Analytics.notifyViewEvent(pageView.toComScoreLabel())
     }
 

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * ComScore
  *
+ * Initialize ComScore before using page view by calling [ComScore.init] in your Application.create
+ *
  * SRGSSR doc : https://confluence.srg.beecollaboration.com/pages/viewpage.action?pageId=13188965
  *
  * @constructor Create empty Com score
@@ -47,7 +49,7 @@ internal object ComScore : PageViewAnalytics {
     private val started = AtomicBoolean(false)
 
     /**
-     * Init ComScore have to be called inside Application.onCreate
+     * Init ComScore have to be called inside your Application.onCreate
      *
      * @param config Common analytics configuration
      * @param appContext Application context
@@ -84,11 +86,12 @@ internal object ComScore : PageViewAnalytics {
         if (BuildConfig.DEBUG) {
             Analytics.getConfiguration().enableImplementationValidationMode()
         }
-        ComScoreStarter.startTrackingActivity(appContext as Application)
-        if (ComScoreStarter.isUiExperienceStarted) {
-            start(appContext)
-        }
+        startWhenAtLeastOneActivityIsCreated(appContext)
         return this
+    }
+
+    private fun startWhenAtLeastOneActivityIsCreated(appContext: Context) {
+        ComScoreStarter.startTrackingActivity(appContext.applicationContext as Application)
     }
 
     internal fun start(appContext: Context) {

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
@@ -85,7 +85,7 @@ internal object ComScore : PageViewAnalytics {
             Analytics.getConfiguration().enableImplementationValidationMode()
         }
         ComScoreStarter.startTrackingActivity(appContext as Application)
-        if (ComScoreStarter.uiExperienceStarted) {
+        if (ComScoreStarter.isUiExperienceStarted) {
             start(appContext)
         }
         return this

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
@@ -47,7 +47,7 @@ internal object ComScore : PageViewAnalytics {
     private val started = AtomicBoolean(false)
 
     /**
-     * Init ComScore
+     * Init ComScore have to be called inside Application.onCreate
      *
      * @param config Common analytics configuration
      * @param appContext Application context

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * No need to use this class if integrator call SRGAnalytics.init inside Application.onCreate.
  */
-object ComScoreStarter : Application.ActivityLifecycleCallbacks {
+internal object ComScoreStarter : Application.ActivityLifecycleCallbacks {
     private val uiExperienceStarted = AtomicBoolean(false)
 
     /**

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.analytics.comscore
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * ComScore Starter
+ *
+ * Track Activity lifecycle to ensure comScore start only when at least one Activity has been created.
+ * It avoids comScore ghost start issue.
+ *
+ * For example, Application is created in background by UrbanAirship or other method without UI presented to user.
+ *
+ * No need to use this class if integrator call SRGAnalytics.init inside Application.onCreate.
+ */
+object ComScoreStarter : Application.ActivityLifecycleCallbacks {
+    private val _uiExperienceStarted = AtomicBoolean(false)
+
+    /**
+     * Ui experience started
+     *
+     * At least one Activity was created!
+     */
+    val uiExperienceStarted get() = _uiExperienceStarted.get()
+
+    /**
+     * Start tracking activity
+     *
+     * Should be called inside your Application.onCreate
+     *
+     * @param application The application to track Activity lifecycle.
+     */
+    fun startTrackingActivity(application: Application) {
+        application.registerActivityLifecycleCallbacks(this)
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        _uiExperienceStarted.set(true)
+        activity.application.unregisterActivityLifecycleCallbacks(this)
+        ComScore.start(activity.applicationContext)
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+        // Nothing
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        // Nothing
+    }
+}

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
@@ -20,14 +20,14 @@ import java.util.concurrent.atomic.AtomicBoolean
  * No need to use this class if integrator call SRGAnalytics.init inside Application.onCreate.
  */
 object ComScoreStarter : Application.ActivityLifecycleCallbacks {
-    private val _uiExperienceStarted = AtomicBoolean(false)
+    private val uiExperienceStarted = AtomicBoolean(false)
 
     /**
      * Ui experience started
      *
      * At least one Activity was created!
      */
-    val uiExperienceStarted get() = _uiExperienceStarted.get()
+    val isUiExperienceStarted get() = uiExperienceStarted.get()
 
     /**
      * Start tracking activity
@@ -41,7 +41,7 @@ object ComScoreStarter : Application.ActivityLifecycleCallbacks {
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        _uiExperienceStarted.set(true)
+        uiExperienceStarted.set(true)
         activity.application.unregisterActivityLifecycleCallbacks(this)
         ComScore.start(activity.applicationContext)
     }

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreStarter.kt
@@ -7,41 +7,20 @@ package ch.srgssr.pillarbox.analytics.comscore
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * ComScore Starter
  *
  * Track Activity lifecycle to ensure comScore start only when at least one Activity has been created.
  * It avoids comScore ghost start issue.
- *
- * For example, Application is created in background by UrbanAirship or other method without UI presented to user.
- *
- * No need to use this class if integrator call SRGAnalytics.init inside Application.onCreate.
  */
 internal object ComScoreStarter : Application.ActivityLifecycleCallbacks {
-    private val uiExperienceStarted = AtomicBoolean(false)
 
-    /**
-     * Ui experience started
-     *
-     * At least one Activity was created!
-     */
-    val isUiExperienceStarted get() = uiExperienceStarted.get()
-
-    /**
-     * Start tracking activity
-     *
-     * Should be called inside your Application.onCreate
-     *
-     * @param application The application to track Activity lifecycle.
-     */
-    fun startTrackingActivity(application: Application) {
+    internal fun startTrackingActivity(application: Application) {
         application.registerActivityLifecycleCallbacks(this)
     }
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        uiExperienceStarted.set(true)
         activity.application.unregisterActivityLifecycleCallbacks(this)
         ComScore.start(activity.applicationContext)
     }

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
+        android:name=".DemoApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
@@ -2,29 +2,32 @@
  * Copyright (c) 2023. SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.demo.di
+package ch.srgssr.pillarbox.demo
 
-import android.content.Context
+import android.app.Application
 import ch.srgssr.pillarbox.analytics.AnalyticsConfig
 import ch.srgssr.pillarbox.analytics.SRGAnalytics
 import ch.srgssr.pillarbox.analytics.commandersact.CommandersActConfig
 
 /**
- * Analytics module
+ * Demo application
+ *  - Init SRG Analytics
  */
-object AnalyticsModule {
-    private const val VIRTUAL_SITE = "pillarbox-demo-android"
+class DemoApplication : Application() {
 
-    /**
-     * Provider analytics
-     */
-    fun providerAnalytics(appContext: Context): SRGAnalytics {
+    override fun onCreate() {
+        super.onCreate()
+        initAnalytics()
+    }
+
+    private fun initAnalytics() {
         val analyticsConfig = AnalyticsConfig(
             distributor = AnalyticsConfig.BuDistributor.SRG,
             nonLocalizedApplicationName = "PillarboxDemo"
         )
-        val commandersActConfig = CommandersActConfig(virtualSite = VIRTUAL_SITE, sourceKey = CommandersActConfig.SOURCE_KEY_SRG_DEBUG)
+        val commandersActConfig = CommandersActConfig(virtualSite = "pillarbox-demo-android", sourceKey = CommandersActConfig.SOURCE_KEY_SRG_DEBUG)
         val config = SRGAnalytics.Config(analyticsConfig = analyticsConfig, commandersAct = commandersActConfig)
-        return SRGAnalytics.init(appContext = appContext, config = config)
+
+        SRGAnalytics.init(appContext = this, config = config)
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
@@ -15,7 +15,7 @@ import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.AndroidViewModel
 import ch.srgssr.pillarbox.analytics.PageView
-import ch.srgssr.pillarbox.demo.di.AnalyticsModule
+import ch.srgssr.pillarbox.analytics.SRGAnalytics
 import ch.srgssr.pillarbox.demo.ui.MainNavigation
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 
@@ -45,12 +45,10 @@ class MainActivity : ComponentActivity() {
  * Main view model to store SRGAnalytics
  */
 class MainViewModel(application: Application) : AndroidViewModel(application) {
-    private val analytics = AnalyticsModule.providerAnalytics(application)
-
     /**
      * Track page view
      */
     fun trackPageView() {
-        analytics.sendPageView(PageView("main", levels = arrayOf("app", "pillarbox")))
+        SRGAnalytics.sendPageView(PageView("main", levels = arrayOf("app", "pillarbox")))
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
@@ -4,16 +4,13 @@
  */
 package ch.srgssr.pillarbox.demo
 
-import android.app.Application
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
-import androidx.lifecycle.AndroidViewModel
 import ch.srgssr.pillarbox.analytics.PageView
 import ch.srgssr.pillarbox.analytics.SRGAnalytics
 import ch.srgssr.pillarbox.demo.ui.MainNavigation
@@ -25,11 +22,8 @@ import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
  * @constructor Create empty Main activity
  */
 class MainActivity : ComponentActivity() {
-    private val mainViewModel: MainViewModel by viewModels()
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        mainViewModel.trackPageView()
         setContent {
             PillarboxTheme {
                 // A surface container using the 'background' color from the theme
@@ -39,16 +33,9 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
-}
 
-/**
- * Main view model to store SRGAnalytics
- */
-class MainViewModel(application: Application) : AndroidViewModel(application) {
-    /**
-     * Track page view
-     */
-    fun trackPageView() {
+    override fun onResume() {
+        super.onResume()
         SRGAnalytics.sendPageView(PageView("main", levels = arrayOf("app", "pillarbox")))
     }
 }


### PR DESCRIPTION
## Description

Avoid comScore "ghost" start. The solution is to call Analytics.start only when at least one Activity has been created.
To achieve this, a new `ComScoreTracker` has been implemented, it implements an `Application.ActivityLifecycleCallbacks` to track `Activity` lifecycle. It is automatically called with `SRGAnalytics.init`.

## Changes made

- Update the demo, add a `DemoApplication` that shows how to init `SRGAnalytics`.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
