### PR TITLE
Fix crash on Android 6

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,6 +11,7 @@ object Version {
     const val appCompat = "1.4.2"
     const val material = "1.6.1"
     const val media3 = "1.0.0"
+    const val guava = "31.1-android"
     const val media = "1.6.0"
     const val glide = "4.14.2"
     const val gson = "2.9.1"
@@ -99,6 +100,7 @@ object Dependencies {
     object Google {
         const val gson = "com.google.code.gson:gson:${Version.gson}"
         const val material = "com.google.android.material:material:${Version.material}"
+        const val guavaAndroid = "com.google.guava:guava:${Version.guava}"
     }
 
     object Test {

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
     api(Dependencies.Coroutines.core)
     // MediaSession MediaController use guava ListenableFuture
     api(Dependencies.Coroutines.guava)
+    // Exoplayer/Media3 need guava-android version and not jre! https://github.com/google/ExoPlayer/issues/9704
+    implementation(Dependencies.Google.guavaAndroid)
 
     api(Dependencies.AndroidX.media)
     api(Dependencies.Media3.exoplayer)


### PR DESCRIPTION
## Description

Fix a crash that occurs only on Android 6 devices. To fix it we just have to use the correct version of guava.

## Changes made

- Add guava android to the dependencies.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
