### PR TITLE
128 change commandersact event

### DIFF
--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersAct.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersAct.kt
@@ -7,18 +7,17 @@ package ch.srgssr.pillarbox.analytics.commandersact
 import ch.srgssr.pillarbox.analytics.EventAnalytics
 import ch.srgssr.pillarbox.analytics.PageViewAnalytics
 import ch.srgssr.pillarbox.analytics.UserAnalytics
-import com.tagcommander.lib.serverside.events.TCEvent
 
 /**
  * Commanders act interface
  */
 interface CommandersAct : PageViewAnalytics, EventAnalytics, UserAnalytics {
     /**
-     * Send tc event to TagCommander.
+     * Send tc media event to TagCommander.
      *
      * @param event to send
      */
-    fun sendTcEvent(event: TCEvent)
+    fun sendTcMediaEvent(event: TCMediaEvent)
 
     /**
      * Enable running in background

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActImpl.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActImpl.kt
@@ -86,7 +86,11 @@ internal class CommandersActImpl(
         sendTcEvent(event.toTCCustomEvent())
     }
 
-    override fun sendTcEvent(event: TCEvent) {
+    override fun sendTcMediaEvent(event: TCMediaEvent) {
+        sendTcEvent(event)
+    }
+
+    private fun sendTcEvent(event: TCEvent) {
         overrideApplicationNameIfNeeded()
         tcServerSide.execute(event)
     }

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/MediaEventType.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/MediaEventType.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.analytics.commandersact
+
+/**
+ * CommandersAct [TCMediaEvent] Media event type
+ */
+enum class MediaEventType {
+    Play,
+    Pause,
+    Eof,
+    Stop,
+    Seek,
+    Pos,
+    Uptime;
+
+    override fun toString(): String {
+        return super.toString().lowercase()
+    }
+}

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCEventUtils.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCEventUtils.kt
@@ -16,9 +16,7 @@ import com.tagcommander.lib.serverside.events.TCPageViewEvent
  */
 object TCEventUtils {
     // Event keys
-    private const val TC_EVENT_NAME = "hidden_event"
     private const val EVENT_VALUE = "event_value"
-    private const val EVENT_NAME = "event_name"
     private const val EVENT_TYPE = "event_type"
     private const val EVENT_SOURCE = "event_source"
     private const val EVENT_EXTRA_1 = "event_value_1"
@@ -42,8 +40,7 @@ object TCEventUtils {
      * @return [TCCustomEvent]
      */
     fun Event.toTCCustomEvent(): TCCustomEvent {
-        val event = TCCustomEvent(TC_EVENT_NAME)
-        event.addAdditionalParameter(EVENT_NAME, name)
+        val event = TCCustomEvent(name)
         event.addAdditionalParameterIfNotBlank(EVENT_TYPE, type)
         event.addAdditionalParameterIfNotBlank(EVENT_VALUE, value)
         event.addAdditionalParameterIfNotBlank(EVENT_SOURCE, source)

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.analytics.commandersact
+
+import ch.srgssr.pillarbox.analytics.BuildConfig
+import com.tagcommander.lib.serverside.events.TCCustomEvent
+import com.tagcommander.lib.serverside.schemas.TCEventPropertiesNames
+import org.json.JSONObject
+import kotlin.math.roundToLong
+import kotlin.time.Duration
+import kotlin.time.DurationUnit
+
+/**
+ * CommandersAct media event
+ *
+ * @property eventType Media event type defined by Analytics team.
+ * @property assets Assets to populate with key,values.
+ * @property sourceId an optional sourceId.
+ */
+class TCMediaEvent(
+    val eventType: MediaEventType,
+    val assets: Map<String, String>,
+    val sourceId: String? = null
+) : TCCustomEvent(eventType.toString()) {
+    /**
+     * Current Media position
+     */
+    var mediaPosition: Duration = Duration.ZERO
+
+    /**
+     * Time shift if applicable
+     */
+    var timeShift: Duration? = null
+
+    /**
+     * Device volume in percentage
+     */
+    var deviceVolume: Float? = null
+
+    /**
+     * Bandwidth
+     */
+    var bandwidth: Long? = null
+
+    /**
+     * Is subtitles on
+     */
+    var isSubtitlesOn: Boolean = false
+
+    /**
+     * Selected subtitle language if any
+     */
+    var subtitleSelectionLanguage: String? = null
+
+    /**
+     * Selected audio language if any
+     */
+    var audioTrackLanguage: String? = null
+
+    override fun getJsonObject(): JSONObject {
+        val jsonObject = super.getJsonObject()
+        val properties = jsonObject.getJSONObject(TCEventPropertiesNames.TCE_PROPERTIES)
+        for (asset in assets) {
+            properties.putIfValid(asset.key, asset.value)
+        }
+        properties.putIfValid(KEY_SOURCE_ID, sourceId)
+        properties.putIfValid(MEDIA_POSITION, toSeconds(mediaPosition).toString())
+        timeShift?.let {
+            properties.putIfValid(MEDIA_TIMESHIFT, toSeconds(it).toString())
+        }
+        bandwidth?.let {
+            properties.putIfValid(MEDIA_BANDWIDTH, it.toString())
+        }
+        deviceVolume?.let {
+            properties.putIfValid(MEDIA_VOLUME, it.toString())
+        }
+        properties.putIfValid(MEDIA_PLAYER_VERSION, BuildConfig.VERSION_NAME)
+        properties.putIfValid(MEDIA_PLAYER_DISPLAY, PLAYER_DISPLAY_NAME)
+        properties.putIfValid(MEDIA_SUBTITLES_ON, isSubtitlesOn.toString())
+        subtitleSelectionLanguage?.let {
+            properties.putIfValid(MEDIA_SUBTITLE_SELECTION, it)
+        }
+        audioTrackLanguage?.let {
+            properties.putIfValid(MEDIA_AUDIO_TRACK, it)
+        }
+
+        return jsonObject
+    }
+
+    private fun JSONObject.putIfValid(key: String, value: String?) {
+        if (value.isNullOrBlank()) return
+        put(key, value)
+    }
+
+    companion object {
+        private const val PLAYER_DISPLAY_NAME = "Pillarbox"
+        private const val MEDIA_PLAYER_VERSION = "media_player_version"
+        private const val MEDIA_VOLUME = "media_volume"
+        private const val MEDIA_POSITION = "media_position"
+        private const val MEDIA_PLAYER_DISPLAY = "media_player_display"
+        private const val MEDIA_TIMESHIFT = "media_timeshift"
+        private const val MEDIA_BANDWIDTH = "media_bandwidth"
+        private const val MEDIA_SUBTITLES_ON = "media_subtitles_on"
+        private const val MEDIA_AUDIO_TRACK = "media_audio_track"
+        private const val MEDIA_SUBTITLE_SELECTION = "media_subtitle_selection"
+        private const val KEY_SOURCE_ID = "source_id"
+
+        private fun toSeconds(duration: Duration): Long {
+            return duration.toDouble(DurationUnit.SECONDS).roundToLong()
+        }
+    }
+}

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/CommandersActEventTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/CommandersActEventTest.kt
@@ -58,8 +58,7 @@ class CommandersActEventTest {
             "extra4", extra5 = "extra5"
         )
         val tcEvent = event.toTCCustomEvent()
-        Assert.assertEquals("hidden_event", tcEvent.name)
-        Assert.assertEquals("name", tcEvent.additionalParameters.getData("event_name"))
+        Assert.assertEquals("name", tcEvent.name)
         Assert.assertEquals("value", tcEvent.additionalParameters.getData("event_value"))
         Assert.assertEquals("type", tcEvent.additionalParameters.getData("event_type"))
         Assert.assertEquals("source", tcEvent.additionalParameters.getData("event_source"))
@@ -77,8 +76,7 @@ class CommandersActEventTest {
             "name", type = "type", value = "value", source = "source", extra1 = "", extra2 = " ", extra3 = "extra3"
         )
         val tcEvent = event.toTCCustomEvent()
-        Assert.assertEquals("hidden_event", tcEvent.name)
-        Assert.assertEquals("name", tcEvent.additionalParameters.getData("event_name"))
+        Assert.assertEquals("name", tcEvent.name)
         Assert.assertEquals("value", tcEvent.additionalParameters.getData("event_value"))
         Assert.assertEquals("type", tcEvent.additionalParameters.getData("event_type"))
         Assert.assertEquals("source", tcEvent.additionalParameters.getData("event_source"))

--- a/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/CommandersActTrackerTest.kt
+++ b/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/CommandersActTrackerTest.kt
@@ -10,11 +10,12 @@ import androidx.test.filters.FlakyTest
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import ch.srgssr.pillarbox.analytics.PageView
 import ch.srgssr.pillarbox.analytics.commandersact.CommandersAct
+import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType
+import ch.srgssr.pillarbox.analytics.commandersact.TCMediaEvent
 import ch.srgssr.pillarbox.core.business.tracker.DefaultMediaItemTrackerRepository
 import ch.srgssr.pillarbox.core.business.tracker.commandersact.CommandersActStreaming
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.test.utils.TestPlayer
-import com.tagcommander.lib.serverside.events.TCEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -60,8 +61,8 @@ class CommandersActTrackerTest {
     @Test
     fun testStartEoF() = runTest {
         val expected = listOf(
-            CommandersActStreaming.EVENT_PLAY,
-            CommandersActStreaming.EVENT_EOF
+            MediaEventType.Play.toString(),
+            MediaEventType.Eof.toString()
         )
         launch(Dispatchers.Main) {
             val player = createPlayerWithUrn(LocalMediaCompositionDataSource.VodShort)
@@ -76,8 +77,8 @@ class CommandersActTrackerTest {
     @Test
     fun testPlayStop() = runTest {
         val expected = listOf(
-            CommandersActStreaming.EVENT_PLAY,
-            CommandersActStreaming.EVENT_STOP
+            MediaEventType.Play.toString(),
+            MediaEventType.Stop.toString()
         )
         launch(Dispatchers.Main) {
             val player = createPlayerWithUrn(LocalMediaCompositionDataSource.Vod)
@@ -90,10 +91,10 @@ class CommandersActTrackerTest {
     fun testPlaySeekPlay() = runTest {
         val seekPositionMs = 2_000L
         val expectedEvents = listOf(
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_PLAY, 0L),
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_SEEK, 0L),
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_PLAY, seekPositionMs.milliseconds.inWholeSeconds),
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_STOP)
+            CommandersActDelegate.Event(MediaEventType.Play.toString(), 0L),
+            CommandersActDelegate.Event(MediaEventType.Seek.toString(), 0L),
+            CommandersActDelegate.Event(MediaEventType.Play.toString(), seekPositionMs.milliseconds.inWholeSeconds),
+            CommandersActDelegate.Event(MediaEventType.Stop.toString())
         )
         launch(Dispatchers.Main) {
             val player = createPlayerWithUrn(LocalMediaCompositionDataSource.Vod)
@@ -111,8 +112,8 @@ class CommandersActTrackerTest {
     fun testPausePlaySeekPlay() = runTest {
         val seekPositionMs = 2_000L
         val expected = listOf(
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_PLAY, seekPositionMs.milliseconds.inWholeSeconds),
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_STOP)
+            CommandersActDelegate.Event(MediaEventType.Play.toString(), seekPositionMs.milliseconds.inWholeSeconds),
+            CommandersActDelegate.Event(MediaEventType.Stop.toString())
         )
         launch(Dispatchers.Main) {
             val player = createPlayerWithUrn(LocalMediaCompositionDataSource.Vod, false)
@@ -127,11 +128,11 @@ class CommandersActTrackerTest {
     fun testPlayPauseSeekPause() = runTest {
         val seekPositionMs = 4_000L
         val expected = listOf(
-            CommandersActStreaming.EVENT_PLAY,
-            CommandersActStreaming.EVENT_PAUSE,
-            CommandersActStreaming.EVENT_SEEK,
-            CommandersActStreaming.EVENT_PAUSE,
-            CommandersActStreaming.EVENT_STOP
+            MediaEventType.Play.toString(),
+            MediaEventType.Pause.toString(),
+            MediaEventType.Seek.toString(),
+            MediaEventType.Pause.toString(),
+            MediaEventType.Stop.toString()
         )
         launch(Dispatchers.Main) {
             val player = createPlayerWithUrn(LocalMediaCompositionDataSource.Vod)
@@ -149,13 +150,13 @@ class CommandersActTrackerTest {
     @Test
     fun testPosTime() = runTest {
         val expected = listOf(
-            CommandersActStreaming.EVENT_POS,
-            CommandersActStreaming.EVENT_POS,
+            MediaEventType.Pos.toString(),
+            MediaEventType.Pos.toString(),
         )
         var position = 0L.milliseconds
         val expectedEvent = listOf(
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_POS, (position + HEART_BEAT_DELAY).inWholeSeconds),
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_POS, (position + POS_PERIOD + HEART_BEAT_DELAY).inWholeSeconds),
+            CommandersActDelegate.Event(MediaEventType.Pos.toString(), (position + HEART_BEAT_DELAY).inWholeSeconds),
+            CommandersActDelegate.Event(MediaEventType.Pos.toString(), (position + POS_PERIOD + HEART_BEAT_DELAY).inWholeSeconds),
         )
         commandersActDelegate.ignorePeriodicEvents = false
         launch(Dispatchers.Main) {
@@ -163,8 +164,8 @@ class CommandersActTrackerTest {
             delay(POS_PERIOD + HEART_BEAT_DELAY + DELTA_PERIOD)
             Assert.assertEquals(false, player.player.isCurrentMediaItemLive)
             player.release()
-            Assert.assertEquals(expected, commandersActDelegate.eventNames.filter { it == CommandersActStreaming.EVENT_POS })
-            Assert.assertEquals(expectedEvent, commandersActDelegate.events.filter { it.name == CommandersActStreaming.EVENT_POS })
+            Assert.assertEquals(expected, commandersActDelegate.eventNames.filter { it == MediaEventType.Pos.toString() })
+            Assert.assertEquals(expectedEvent, commandersActDelegate.events.filter { it.name == MediaEventType.Pos.toString() })
         }
     }
 
@@ -172,13 +173,13 @@ class CommandersActTrackerTest {
     @Test
     fun testUpTime() = runTest {
         val expected = listOf(
-            CommandersActStreaming.EVENT_UPTIME,
-            CommandersActStreaming.EVENT_UPTIME,
+            MediaEventType.Uptime.toString(),
+            MediaEventType.Uptime.toString(),
         )
         val startPos = HEART_BEAT_DELAY.toDouble(DurationUnit.SECONDS).roundToLong()
         val positionsEvents = listOf(
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_UPTIME, position = startPos),
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_UPTIME, position = startPos + UPTIME_PERIOD.inWholeSeconds),
+            CommandersActDelegate.Event(MediaEventType.Uptime.toString(), position = startPos),
+            CommandersActDelegate.Event(MediaEventType.Uptime.toString(), position = startPos + UPTIME_PERIOD.inWholeSeconds),
         )
 
         commandersActDelegate.ignorePeriodicEvents = false
@@ -186,9 +187,9 @@ class CommandersActTrackerTest {
             val player = createPlayerWithUrn(LocalMediaCompositionDataSource.Live)
             delay(UPTIME_PERIOD + HEART_BEAT_DELAY + DELTA_PERIOD)
             player.release()
-            Assert.assertEquals(expected, commandersActDelegate.eventNames.filter { it == CommandersActStreaming.EVENT_UPTIME })
+            Assert.assertEquals(expected, commandersActDelegate.eventNames.filter { it == MediaEventType.Uptime.toString() })
             Assert.assertEquals(positionsEvents, commandersActDelegate.events.filter {
-                it.name == CommandersActStreaming.EVENT_UPTIME
+                it.name == MediaEventType.Uptime.toString()
             })
         }
     }
@@ -197,13 +198,13 @@ class CommandersActTrackerTest {
     @Test
     fun testUpTimeLiveWithDvr() = runTest {
         val expected = listOf(
-            CommandersActStreaming.EVENT_UPTIME,
-            CommandersActStreaming.EVENT_UPTIME,
+            MediaEventType.Uptime.toString(),
+            MediaEventType.Uptime.toString(),
         )
         val startPos = HEART_BEAT_DELAY.toDouble(DurationUnit.SECONDS).roundToLong()
         val positionsEvents = listOf(
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_UPTIME, position = startPos),
-            CommandersActDelegate.Event(CommandersActStreaming.EVENT_UPTIME, position = startPos + UPTIME_PERIOD.inWholeSeconds),
+            CommandersActDelegate.Event(MediaEventType.Uptime.toString(), position = startPos),
+            CommandersActDelegate.Event(MediaEventType.Uptime.toString(), position = startPos + UPTIME_PERIOD.inWholeSeconds),
         )
 
         commandersActDelegate.ignorePeriodicEvents = false
@@ -211,9 +212,9 @@ class CommandersActTrackerTest {
             val player = createPlayerWithUrn(LocalMediaCompositionDataSource.Dvr)
             delay(UPTIME_PERIOD + HEART_BEAT_DELAY + DELTA_PERIOD)
             player.release()
-            Assert.assertEquals(expected, commandersActDelegate.eventNames.filter { it == CommandersActStreaming.EVENT_UPTIME })
+            Assert.assertEquals(expected, commandersActDelegate.eventNames.filter { it == MediaEventType.Uptime.toString() })
             Assert.assertEquals(positionsEvents, commandersActDelegate.events.filter {
-                it.name == CommandersActStreaming.EVENT_UPTIME
+                it.name == MediaEventType.Uptime.toString()
             })
         }
     }
@@ -230,7 +231,7 @@ class CommandersActTrackerTest {
             delay(UPTIME_PERIOD + HEART_BEAT_DELAY + DELTA_PERIOD)
             player.release()
             val actualTimeshift = commandersActDelegate.events.first {
-                it.name == CommandersActStreaming.EVENT_POS || it.name == CommandersActStreaming.EVENT_UPTIME
+                it.name == MediaEventType.Pos.toString() || it.name == MediaEventType.Uptime.toString()
             }.timeshift
             Assert.assertFalse(commandersActDelegate.events.isEmpty())
             Assert.assertTrue("Timeshift expected $timeshift but was $actualTimeshift", abs(timeshift - actualTimeshift) <= 15)
@@ -281,16 +282,15 @@ class CommandersActTrackerTest {
         val events = ArrayList<Event>()
 
 
-        override fun sendTcEvent(event: TCEvent) {
+        override fun sendTcMediaEvent(event: TCMediaEvent) {
             if (event.isPeriodicEvent() && ignorePeriodicEvents) return
             eventNames.add(event.name)
-            var position: Long = 0L
-            var timeshift: Long = 0L
+            var position = 0L
+            var timeshift = 0L
             if (!event.isEndEvent()) {
-                position = event.additionalParameters.getData(CommandersActStreaming.MEDIA_POSITION).toLong()
-                timeshift = event.additionalParameters.getData(CommandersActStreaming.MEDIA_TIMESHIFT)?.toLong() ?: 0L
+                position = event.mediaPosition.inWholeSeconds
+                timeshift = event.timeShift?.inWholeSeconds ?: 0L
             }
-
             events.add(Event(name = event.name, position = position, timeshift = timeshift))
         }
 
@@ -309,12 +309,12 @@ class CommandersActTrackerTest {
         private val POS_PERIOD = 3.seconds
         private val DELTA_PERIOD = 500.milliseconds
 
-        private fun TCEvent.isPeriodicEvent(): Boolean {
-            return name == CommandersActStreaming.EVENT_POS || name == CommandersActStreaming.EVENT_UPTIME
+        private fun TCMediaEvent.isPeriodicEvent(): Boolean {
+            return eventType == MediaEventType.Pos || eventType == MediaEventType.Uptime
         }
 
-        private fun TCEvent.isEndEvent(): Boolean {
-            return name == CommandersActStreaming.EVENT_STOP || name == CommandersActStreaming.EVENT_EOF
+        private fun TCMediaEvent.isEndEvent(): Boolean {
+            return eventType == MediaEventType.Stop || eventType == MediaEventType.Eof
         }
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -10,23 +10,21 @@ import androidx.media3.common.Format
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
-import ch.srgssr.pillarbox.analytics.BuildConfig
 import ch.srgssr.pillarbox.analytics.commandersact.CommandersAct
+import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType
+import ch.srgssr.pillarbox.analytics.commandersact.TCMediaEvent
 import ch.srgssr.pillarbox.player.utils.DebugLogger
-import com.tagcommander.lib.serverside.events.TCCustomEvent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
-import java.util.*
+import java.util.Timer
 import kotlin.concurrent.fixedRateTimer
 import kotlin.concurrent.scheduleAtFixedRate
 import kotlin.math.abs
-import kotlin.math.roundToLong
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
 
 @Suppress("MagicNumber", "TooManyFunctions")
 internal class CommandersActStreaming(
@@ -118,13 +116,9 @@ internal class CommandersActStreaming(
         }
     }
 
-    private fun notifyEvent(name: String, position: Duration) {
-        DebugLogger.debug(TAG, "send : $name position = $position")
-        val event = TCCustomEvent(name)
-        event.addAll(currentData.assets)
-        currentData.sourceId?.let {
-            event.addAdditionalParameter(KEY_SOURCE_ID, it)
-        }
+    private fun notifyEvent(type: MediaEventType, position: Duration) {
+        DebugLogger.debug(TAG, "send : $type position = $position")
+        val event = TCMediaEvent(eventType = type, assets = currentData.assets, sourceId = currentData.sourceId)
         handleTextTrackData(event)
         handleAudioTrack(event)
 
@@ -133,33 +127,25 @@ internal class CommandersActStreaming(
             if (timeShift < TIMESHIFT_EQUIVALENT_LIVE) {
                 timeShift = ZERO
             }
-            event.addAdditionalParameter(MEDIA_TIMESHIFT, toSeconds(timeShift).toString())
+            event.timeShift = timeShift
         }
-
-        player.getCurrentBandwidth()?.let { bandwidth ->
-            event.addAdditionalParameter(MEDIA_BANDWIDTH, bandwidth.toString())
-        }
-        event.addAdditionalParameter(MEDIA_VOLUME, (player.deviceVolume / 100).toString())
-        event.addAdditionalParameter(
-            MEDIA_POSITION,
-            if (player.isCurrentMediaItemLive) toSeconds(totalPlayTime).toString() else toSeconds(position).toString()
-        )
-        event.addAdditionalParameter(MEDIA_PLAYER_VERSION, BuildConfig.VERSION_NAME)
-        event.addAdditionalParameter(MEDIA_PLAYER_DISPLAY, "Pillarbox")
-        commandersAct.sendTcEvent(event)
+        event.bandwidth = player.getCurrentBandwidth()
+        event.deviceVolume = player.deviceVolume / 100f
+        event.mediaPosition = if (player.isCurrentMediaItemLive) totalPlayTime else position
+        commandersAct.sendTcMediaEvent(event)
     }
 
     private fun notifyPlaying() {
         if (state == State.Playing) return
         this.state = State.Playing
-        notifyEvent(EVENT_PLAY, player.currentPosition.milliseconds)
+        notifyEvent(MediaEventType.Play, player.currentPosition.milliseconds)
         startHeartBeat()
     }
 
     private fun notifyPause() {
         if (state == State.Idle) return
         this.state = State.Paused
-        notifyEvent(EVENT_PAUSE, player.currentPosition.milliseconds)
+        notifyEvent(MediaEventType.Pause, player.currentPosition.milliseconds)
         stopHeartBeat()
     }
 
@@ -167,22 +153,22 @@ internal class CommandersActStreaming(
         stopHeartBeat()
         if (state == State.Idle) return
         this.state = State.Idle
-        notifyEvent(if (isEoF) EVENT_EOF else EVENT_STOP, player.currentPosition.milliseconds)
+        notifyEvent(if (isEoF) MediaEventType.Eof else MediaEventType.Stop, player.currentPosition.milliseconds)
     }
 
     private fun notifySeek(seekStartPosition: Duration) {
         if (state == State.Seeking || state == State.Idle) return
         state = State.Seeking
-        notifyEvent(EVENT_SEEK, seekStartPosition)
+        notifyEvent(MediaEventType.Seek, seekStartPosition)
     }
 
     private fun notifyPos(position: Duration) {
-        notifyEvent(EVENT_POS, position)
+        notifyEvent(MediaEventType.Pos, position)
     }
 
     private fun notifyUptime(position: Duration) {
         if (!isCurrentlyLiveAt(position)) return
-        notifyEvent(EVENT_UPTIME, position)
+        notifyEvent(MediaEventType.Uptime, position)
     }
 
     private fun isCurrentlyLiveAt(position: Duration): Boolean {
@@ -198,46 +184,28 @@ internal class CommandersActStreaming(
      *  MEDIA_SUBTITLES_ON to true if text track selected but not forced, false otherwise
      *  MEDIA_SUBTITLE_SELECTION the language name of the currently selected track
      */
-    private fun handleTextTrackData(event: TCCustomEvent) {
+    private fun handleTextTrackData(event: TCMediaEvent) {
         // TODO handle text track analytics
         val currentTextTrack: Format? = null
         val isSubtitlesOn: Boolean = currentTextTrack?.let {
             // TODO retrieve the language
-            event.addAdditionalParameter(MEDIA_SUBTITLE_SELECTION, VALUE_UNKNOWN_LANGUAGE)
+            event.subtitleSelectionLanguage = VALUE_UNKNOWN_LANGUAGE
             (it?.selectionFlags ?: 0 and C.SELECTION_FLAG_FORCED) != C.SELECTION_FLAG_FORCED
         } ?: false
-        event.addAdditionalParameter(MEDIA_SUBTITLES_ON, isSubtitlesOn.toString())
+        event.isSubtitlesOn = isSubtitlesOn
     }
 
-    private fun handleAudioTrack(event: TCCustomEvent) {
+    private fun handleAudioTrack(event: TCMediaEvent) {
         // TODO handle Audio track analytics
         val currentAudioTrack: Format? = null
         currentAudioTrack?.let { track ->
             // TODO retrieve the language
-            event.addAdditionalParameter(MEDIA_AUDIO_TRACK, VALUE_UNKNOWN_LANGUAGE)
+            event.audioTrackLanguage = VALUE_UNKNOWN_LANGUAGE
         }
     }
 
     companion object {
         private const val TAG = "CommandersActTracker"
-        const val EVENT_PLAY = "play"
-        const val EVENT_PAUSE = "pause"
-        const val EVENT_EOF = "eof"
-        const val EVENT_STOP = "stop"
-        const val EVENT_SEEK = "seek"
-        const val EVENT_POS = "pos"
-        const val EVENT_UPTIME = "uptime"
-
-        const val MEDIA_PLAYER_VERSION = "media_player_version"
-        const val MEDIA_VOLUME = "media_volume"
-        const val MEDIA_POSITION = "media_position"
-        const val MEDIA_PLAYER_DISPLAY = "media_player_display"
-        const val MEDIA_TIMESHIFT = "media_timeshift"
-        const val MEDIA_BANDWIDTH = "media_bandwidth"
-        const val MEDIA_SUBTITLES_ON = "media_subtitles_on"
-        const val MEDIA_AUDIO_TRACK = "media_audio_track"
-        const val MEDIA_SUBTITLE_SELECTION = "media_subtitle_selection"
-        const val KEY_SOURCE_ID = "source_id"
         const val VALUE_UNKNOWN_LANGUAGE = "UND"
 
         internal var HEART_BEAT_DELAY = 30.seconds
@@ -245,16 +213,6 @@ internal class CommandersActStreaming(
         internal var POS_PERIOD = 30.seconds
         private val TIMESHIFT_EQUIVALENT_LIVE = 60.seconds
         private const val VALID_SEEK_THRESHOLD: Long = 1000L
-
-        private fun TCCustomEvent.addAll(map: Map<String, String>) {
-            for (entry in map) {
-                addAdditionalParameter(entry.key, entry.value)
-            }
-        }
-
-        private fun toSeconds(duration: Duration): Long {
-            return duration.toDouble(DurationUnit.SECONDS).roundToLong()
-        }
     }
 }
 


### PR DESCRIPTION
# Pull request

## Description

Remove "hidden_event" event name for Event. Disallow sending generic TCEvent to CommandersAct. TCMediaEvent is created to allow MediaItemTrackers to send media event.

## Changes made

- Remove hidden_event for TCCustomEvent and send name instead.
- Change CommandersAct to send only PageView, Event and TCMediaEvent.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
