### PR TITLE
136 improve composable interoperability view

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
@@ -83,7 +83,7 @@ fun MultiPlayer() {
 @Composable
 private fun PlayerView(player: Player, modifier: Modifier) {
     DemoPlayerSurface(modifier = modifier, player = player) {
-        PlayingControls(modifier = Modifier.matchParentSize(), player = player)
+        PlayingControls(modifier = Modifier.matchParentSize(), player = player, autoHideEnabled = false)
     }
 }
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
@@ -67,11 +67,13 @@ fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
         } else {
             null
         }
-        PlayerSurface(
-            modifier = Modifier.fillMaxHeight(),
-            player = player,
-            scaleMode = ScaleMode.Zoom
-        )
+        player?.let {
+            PlayerSurface(
+                modifier = Modifier.fillMaxHeight(),
+                scaleMode = ScaleMode.Zoom,
+                player = player,
+            )
+        }
         Text(text = "Page $page")
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
@@ -4,10 +4,13 @@
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.story
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerDefaults
+import androidx.compose.foundation.pager.PagerSnapDistance
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -51,10 +54,15 @@ fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
     HorizontalPager(
         modifier = Modifier.fillMaxHeight(),
         key = { page -> playlist[page].uri },
+        flingBehavior = PagerDefaults.flingBehavior(
+            state = pagerState,
+            pagerSnapDistance = PagerSnapDistance.atMost(0),
+            snapAnimationSpec = spring(stiffness = Spring.StiffnessHigh)
+        ),
         beyondBoundsPageCount = 0,
         pageCount = playlist.size,
         state = pagerState,
-        contentPadding = PaddingValues(horizontal = 1.dp) // Add tiny padding to remove surface glitches
+        pageSpacing = 1.dp
     ) { page ->
         // When flinging -> may "load" more that 3 pages
         val currentPage = pagerState.currentPage

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ExoPlayerControlView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ExoPlayerControlView.kt
@@ -5,11 +5,10 @@
 package ch.srgssr.pillarbox.ui
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.viewinterop.NoOpUpdate
 import androidx.media3.common.Player
 import androidx.media3.ui.PlayerControlView
 
@@ -19,29 +18,17 @@ import androidx.media3.ui.PlayerControlView
  * @param player The player to bind to the controls.
  * @param modifier The modifier to be applied to the layout.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ExoPlayerControlView(player: Player, modifier: Modifier = Modifier) {
-    val playerControlView = rememberPlayerControlView(player)
     AndroidView(
         modifier = modifier,
-        factory = { playerControlView },
+        factory = { PlayerControlView(it) },
         update = {
             it.player = player
             it.showTimeoutMs = -1
-        }
+        }, onRelease = {
+            it.player = null
+        }, onReset = NoOpUpdate
     )
-}
-
-@Composable
-private fun rememberPlayerControlView(player: Player): PlayerControlView {
-    val context = LocalContext.current
-    val playerControlView = remember(player) {
-        PlayerControlView(context)
-    }
-    DisposableEffect(playerControlView) {
-        onDispose {
-            playerControlView.player = null
-        }
-    }
-    return playerControlView
 }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ExoPlayerView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ExoPlayerView.kt
@@ -8,10 +8,12 @@ import androidx.annotation.ColorInt
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.viewinterop.NoOpUpdate
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.media3.common.ErrorMessageProvider
@@ -37,9 +39,10 @@ import androidx.media3.ui.PlayerView.ShowBuffering
  * @param controllerVisibilityListener [PlayerView.setControllerVisibilityListener]
  * @param shutterBackgroundColor [PlayerView.setShutterBackgroundColor]
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ExoPlayerView(
-    player: Player?,
+    player: Player,
     modifier: Modifier = Modifier,
     useController: Boolean = true,
     controllerAutoShow: Boolean = true,
@@ -72,7 +75,10 @@ fun ExoPlayerView(
             view.setShowPreviousButton(showPreviousButton)
             view.setShutterBackgroundColor(shutterBackgroundColor)
             view.player = player
-        }
+        }, onRelease = { view ->
+            view.player = null
+        },
+        onReset = NoOpUpdate
     )
 }
 
@@ -95,7 +101,6 @@ private fun rememberPlayerView(): PlayerView {
         lifecycle.addObserver(lifecycleObserver)
         onDispose {
             lifecycle.removeObserver(lifecycleObserver)
-            playerView.player = null
         }
     }
     return playerView

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ExoplayerSubtitleView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ExoplayerSubtitleView.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.viewinterop.AndroidView
@@ -50,6 +51,7 @@ fun ExoPlayerSubtitleView(
  * @param captionStyle Caption style of the subtitle texts. It will override any user preferred style.
  * @param subtitleTextSize Text size of the subtitle texts. It will override any user preferred size.
  */
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun ExoPlayerSubtitleView(
     modifier: Modifier = Modifier,
@@ -80,6 +82,10 @@ fun ExoPlayerSubtitleView(
                     view.setUserDefaultTextSize()
                 }
             }
+        }, onRelease = { view ->
+            view.setCues(null)
+        }, onReset = { view ->
+            view.setCues(null)
         }
     )
 }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurface.kt
@@ -28,7 +28,7 @@ import ch.srgssr.pillarbox.player.computeAspectRatio
  */
 @Composable
 fun PlayerSurface(
-    player: Player?,
+    player: Player,
     modifier: Modifier = Modifier,
     scaleMode: ScaleMode = ScaleMode.Fit,
     contentAlignment: Alignment = Alignment.Center,


### PR DESCRIPTION
## Description

Remove none needed remember View from Compose and using onRelease and onReset from Compose AndroidView.

## Changes made

- Remove remember from `ExoplayerSubtitleView`
- Remove remember from `PlayerSurfaceView`
- Keep remember for `ExoplayerView` as we need to do some work linked to lifecyle.
- Demo : Improve story showcase.
- Demo : Always display controls for multiplayer showcase.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
