### PR TITLE
Add seek increment api

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/di/PlayerModule.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/di/PlayerModule.kt
@@ -34,7 +34,7 @@ object PlayerModule {
      * Provide default player that allow to play urls and urns content from the SRG
      */
     fun provideDefaultPlayer(context: Context): PillarboxPlayer {
-        val seekIncrement = SeekIncrement(seekBackIncrement = 10.seconds, seekForwardIncrement = 30.seconds)
+        val seekIncrement = SeekIncrement(backward = 10.seconds, forward = 30.seconds)
         return PillarboxPlayer(
             context = context,
             mediaItemSource = provideMixedItemSource(context),

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/di/PlayerModule.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/di/PlayerModule.kt
@@ -12,6 +12,8 @@ import ch.srgssr.pillarbox.core.business.integrationlayer.service.MediaCompositi
 import ch.srgssr.pillarbox.core.business.tracker.DefaultMediaItemTrackerRepository
 import ch.srgssr.pillarbox.demo.data.MixedMediaItemSource
 import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.SeekIncrement
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Dependencies to make custom Dependency Injection
@@ -32,6 +34,7 @@ object PlayerModule {
      * Provide default player that allow to play urls and urns content from the SRG
      */
     fun provideDefaultPlayer(context: Context): PillarboxPlayer {
+        val seekIncrement = SeekIncrement(seekBackIncrement = 10.seconds, seekForwardIncrement = 30.seconds)
         return PillarboxPlayer(
             context = context,
             mediaItemSource = provideMixedItemSource(context),
@@ -39,7 +42,8 @@ object PlayerModule {
              * Optional, only needed if you plan to play akamai token protected content
              */
             dataSourceFactory = AkamaiTokenDataSource.Factory(),
-            mediaItemTrackerProvider = DefaultMediaItemTrackerRepository()
+            mediaItemTrackerProvider = DefaultMediaItemTrackerRepository(),
+            seekIncrement = seekIncrement
         )
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -59,12 +59,13 @@ class PillarboxPlayer internal constructor(
         mediaItemSource: MediaItemSource,
         dataSourceFactory: DataSource.Factory = DefaultHttpDataSource.Factory(),
         loadControl: LoadControl = DefaultLoadControl(),
-        mediaItemTrackerProvider: MediaItemTrackerProvider = MediaItemTrackerRepository()
+        mediaItemTrackerProvider: MediaItemTrackerProvider = MediaItemTrackerRepository(),
+        seekIncrement: SeekIncrement = SeekIncrement()
     ) : this(
         ExoPlayer.Builder(context)
             .setUsePlatformDiagnostics(false)
-            // .setSeekBackIncrementMs(10000)
-            // .setSeekForwardIncrementMs(10000)
+            .setSeekBackIncrementMs(seekIncrement.seekBackIncrement.inWholeMilliseconds)
+            .setSeekForwardIncrementMs(seekIncrement.seekForwardIncrement.inWholeMilliseconds)
             .setRenderersFactory(
                 DefaultRenderersFactory(context)
                     .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -64,8 +64,8 @@ class PillarboxPlayer internal constructor(
     ) : this(
         ExoPlayer.Builder(context)
             .setUsePlatformDiagnostics(false)
-            .setSeekBackIncrementMs(seekIncrement.seekBackIncrement.inWholeMilliseconds)
-            .setSeekForwardIncrementMs(seekIncrement.seekForwardIncrement.inWholeMilliseconds)
+            .setSeekBackIncrementMs(seekIncrement.backward.inWholeMilliseconds)
+            .setSeekForwardIncrementMs(seekIncrement.forward.inWholeMilliseconds)
             .setRenderersFactory(
                 DefaultRenderersFactory(context)
                     .setExtensionRendererMode(DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Seek increment
+ *
+ * @property seekBackIncrement Seek back increment.
+ * @property seekForwardIncrement Seek forward increment
+ */
+data class SeekIncrement(
+    val seekBackIncrement: Duration = DefaultSeekBackIncrement,
+    val seekForwardIncrement: Duration = DefaultSeekForwardIncrement
+) {
+
+    init {
+        require(seekBackIncrement > Duration.ZERO) { "Seek back increment have to be greater than zero" }
+        require(seekForwardIncrement > Duration.ZERO) { "Seek forward increment have to be greater than zero" }
+    }
+
+    companion object {
+        private val DefaultSeekBackIncrement = 5L.seconds
+        private val DefaultSeekForwardIncrement = 10L.seconds
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
@@ -4,8 +4,9 @@
  */
 package ch.srgssr.pillarbox.player
 
+import androidx.media3.common.C
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Seek increment
@@ -24,7 +25,7 @@ data class SeekIncrement(
     }
 
     companion object {
-        private val DefaultSeekBackIncrement = 5L.seconds
-        private val DefaultSeekForwardIncrement = 10L.seconds
+        private val DefaultSeekBackIncrement = C.DEFAULT_SEEK_BACK_INCREMENT_MS.milliseconds
+        private val DefaultSeekForwardIncrement = C.DEFAULT_SEEK_FORWARD_INCREMENT_MS.milliseconds
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
@@ -11,17 +11,17 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * Seek increment
  *
- * @property seekBackIncrement Seek back increment.
- * @property seekForwardIncrement Seek forward increment
+ * @property backward The seek back increment.
+ * @property forward The seek forward increment.
  */
 data class SeekIncrement(
-    val seekBackIncrement: Duration = DefaultSeekBackIncrement,
-    val seekForwardIncrement: Duration = DefaultSeekForwardIncrement
+    val backward: Duration = DefaultSeekBackIncrement,
+    val forward: Duration = DefaultSeekForwardIncrement
 ) {
 
     init {
-        require(seekBackIncrement > Duration.ZERO) { "Seek back increment have to be greater than zero" }
-        require(seekForwardIncrement > Duration.ZERO) { "Seek forward increment have to be greater than zero" }
+        require(backward > Duration.ZERO) { "Seek back increment have to be greater than zero" }
+        require(forward > Duration.ZERO) { "Seek forward increment have to be greater than zero" }
     }
 
     companion object {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import org.junit.Assert
+import org.junit.Test
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.seconds
+
+class TestSeekIncrement {
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testBothZero() {
+        SeekIncrement(seekBackIncrement = Duration.ZERO, seekForwardIncrement = Duration.ZERO)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testBothNegative() {
+        SeekIncrement(seekBackIncrement = NegativeIncrement, seekForwardIncrement = NegativeIncrement)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSeekBackNegative() {
+        SeekIncrement(seekBackIncrement = NegativeIncrement, seekForwardIncrement = PositiveIncrement)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSeekBackZero() {
+        SeekIncrement(seekBackIncrement = ZERO, seekForwardIncrement = PositiveIncrement)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSeekForwardNegative() {
+        SeekIncrement(seekBackIncrement = PositiveIncrement, seekForwardIncrement = NegativeIncrement)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testSeekForwardZero() {
+        SeekIncrement(seekBackIncrement = PositiveIncrement, seekForwardIncrement = ZERO)
+    }
+
+    @Test
+    fun testPositive() {
+        val seekBack = 10.seconds
+        val seekForward = 15.seconds
+        val increment = SeekIncrement(seekBackIncrement = seekBack, seekForwardIncrement = seekForward)
+        Assert.assertEquals(seekBack, increment.seekBackIncrement)
+        Assert.assertEquals(seekForward, increment.seekForwardIncrement)
+    }
+
+
+    companion object {
+        private val NegativeIncrement = (-10).seconds
+        private val PositiveIncrement = 5.seconds
+    }
+}

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
@@ -14,41 +14,41 @@ class TestSeekIncrement {
 
     @Test(expected = IllegalArgumentException::class)
     fun testBothZero() {
-        SeekIncrement(seekBackIncrement = Duration.ZERO, seekForwardIncrement = Duration.ZERO)
+        SeekIncrement(backward = Duration.ZERO, forward = Duration.ZERO)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testBothNegative() {
-        SeekIncrement(seekBackIncrement = NegativeIncrement, seekForwardIncrement = NegativeIncrement)
+        SeekIncrement(backward = NegativeIncrement, forward = NegativeIncrement)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testSeekBackNegative() {
-        SeekIncrement(seekBackIncrement = NegativeIncrement, seekForwardIncrement = PositiveIncrement)
+        SeekIncrement(backward = NegativeIncrement, forward = PositiveIncrement)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testSeekBackZero() {
-        SeekIncrement(seekBackIncrement = ZERO, seekForwardIncrement = PositiveIncrement)
+        SeekIncrement(backward = ZERO, forward = PositiveIncrement)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testSeekForwardNegative() {
-        SeekIncrement(seekBackIncrement = PositiveIncrement, seekForwardIncrement = NegativeIncrement)
+        SeekIncrement(backward = PositiveIncrement, forward = NegativeIncrement)
     }
 
     @Test(expected = IllegalArgumentException::class)
     fun testSeekForwardZero() {
-        SeekIncrement(seekBackIncrement = PositiveIncrement, seekForwardIncrement = ZERO)
+        SeekIncrement(backward = PositiveIncrement, forward = ZERO)
     }
 
     @Test
     fun testPositive() {
         val seekBack = 10.seconds
         val seekForward = 15.seconds
-        val increment = SeekIncrement(seekBackIncrement = seekBack, seekForwardIncrement = seekForward)
-        Assert.assertEquals(seekBack, increment.seekBackIncrement)
-        Assert.assertEquals(seekForward, increment.seekForwardIncrement)
+        val increment = SeekIncrement(backward = seekBack, forward = seekForward)
+        Assert.assertEquals(seekBack, increment.backward)
+        Assert.assertEquals(seekForward, increment.forward)
     }
 
 


### PR DESCRIPTION
## Description

Allow integrators to modify seek back and seek forward increment when creating `PillarboxPlayer`.

## Changes made

- Introduce `SeekIncrement` to specify both seek increments as `Duration`.
- Update PillarboxPlayer with new parameters.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
