### PR TITLE
Fix analytics

### DIFF
--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCEventUtils.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCEventUtils.kt
@@ -65,8 +65,7 @@ object TCEventUtils {
      * @return [TCPageViewEvent]
      */
     fun PageView.toTCCustomEvent(distributor: String): TCPageViewEvent {
-        val pageViewEvent = TCPageViewEvent()
-        pageViewEvent.pageType = title
+        val pageViewEvent = TCPageViewEvent(title)
         for (i in levels.indices) {
             pageViewEvent.addAdditionalParameter(NAVIGATION_LEVEL_I + (i + 1), levels[i])
         }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.util.EventLogger
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Enable/Disable EventLogger when item is currently active.
@@ -20,8 +21,8 @@ class SRGEventLoggerTracker : MediaItemTracker {
         player.addAnalyticsListener(eventLogger)
     }
 
-    override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason) {
-        Log.w(TAG, "---- Stop")
+    override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
+        Log.w(TAG, "---- Stop because $reason at ${positionMs.milliseconds}")
         player.removeAnalyticsListener(eventLogger)
     }
 

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/TotalPlaytimeCounter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/TotalPlaytimeCounter.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.core.business.tracker
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Total playtime counter
+ */
+class TotalPlaytimeCounter {
+    private var totalPlayTime: Duration = Duration.ZERO
+    private var lastPlayTime = 0L
+
+    /**
+     * Play
+     * Calling twice play after sometime will compute totalPlaytime
+     */
+    fun play() {
+        pause()
+        lastPlayTime = System.currentTimeMillis()
+    }
+
+    /**
+     * Get total play time
+     *
+     * @return if paused totalPlayTime else totalPlayTime + delta from last play
+     */
+    fun getTotalPlayTime(): Duration {
+        return if (lastPlayTime <= 0L) {
+            totalPlayTime
+        } else {
+            totalPlayTime + (System.currentTimeMillis() - lastPlayTime).milliseconds
+        }
+    }
+
+    /**
+     * Pause total play time tracking and compute total playtime.
+     */
+    fun pause() {
+        if (lastPlayTime > 0L) {
+            totalPlayTime += (System.currentTimeMillis() - lastPlayTime).milliseconds
+            lastPlayTime = 0L
+        }
+    }
+}

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -151,11 +151,11 @@ internal class CommandersActStreaming(
         stopHeartBeat()
     }
 
-    fun notifyStop(isEoF: Boolean = false) {
+    fun notifyStop(position: Duration, isEoF: Boolean = false) {
         stopHeartBeat()
         if (state == State.Idle) return
         this.state = State.Idle
-        notifyEvent(if (isEoF) MediaEventType.Eof else MediaEventType.Stop, player.currentPosition.milliseconds)
+        notifyEvent(if (isEoF) MediaEventType.Eof else MediaEventType.Stop, position)
     }
 
     private fun notifySeek(seekStartPosition: Duration) {

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTracker.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.core.business.tracker.commandersact
 import androidx.media3.exoplayer.ExoPlayer
 import ch.srgssr.pillarbox.analytics.commandersact.CommandersAct
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Commanders act tracker
@@ -45,11 +46,10 @@ class CommandersActTracker(private val commandersAct: CommandersAct) : MediaItem
         }
     }
 
-    // stop is called
-    override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason) {
+    override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
         analyticsStreaming?.let {
             player.removeAnalyticsListener(it)
-            it.notifyStop(reason == MediaItemTracker.StopReason.EoF)
+            it.notifyStop(position = positionMs.milliseconds, reason == MediaItemTracker.StopReason.EoF)
         }
         analyticsStreaming = null
         currentData = null

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
@@ -104,6 +104,7 @@ class ComScoreTracker : MediaItemTracker {
         DebugLogger.debug(TAG, "notifyEnd")
         ComScoreActiveTracker.notifyUxInactive(this)
         Analytics.notifyUxInactive()
+        streamingAnalytics.notifyEnd()
     }
 
     private fun notifyBufferStart() {

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
@@ -53,7 +53,7 @@ class ComScoreTracker : MediaItemTracker {
         player.addAnalyticsListener(component)
     }
 
-    override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason) {
+    override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
         player.removeAnalyticsListener(component)
         notifyEnd()
         streamingAnalytics.removeListener(debugListener)
@@ -82,6 +82,7 @@ class ComScoreTracker : MediaItemTracker {
                 player.currentTimeline.getWindow(player.currentMediaItemIndex, window)
                 notifyPlay(player.currentPosition, window)
             }
+
             player.playbackState == Player.STATE_BUFFERING -> notifyBufferStart()
         }
     }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
@@ -13,7 +13,6 @@ import ch.srgssr.pillarbox.analytics.BuildConfig
 import ch.srgssr.pillarbox.player.getPlaybackSpeed
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
 import ch.srgssr.pillarbox.player.utils.DebugLogger
-import com.comscore.Analytics
 import com.comscore.streaming.ContentMetadata
 import com.comscore.streaming.StreamingAnalytics
 import com.comscore.streaming.StreamingListener
@@ -90,7 +89,7 @@ class ComScoreTracker : MediaItemTracker {
     private fun notifyPause() {
         DebugLogger.debug(TAG, "notifyPause")
         streamingAnalytics.notifyPause()
-        Analytics.notifyUxInactive()
+        ComScoreActiveTracker.notifyUxInactive(this)
     }
 
     private fun notifyPlay(position: Long, window: Window) {
@@ -103,7 +102,6 @@ class ComScoreTracker : MediaItemTracker {
     private fun notifyEnd() {
         DebugLogger.debug(TAG, "notifyEnd")
         ComScoreActiveTracker.notifyUxInactive(this)
-        Analytics.notifyUxInactive()
         streamingAnalytics.notifyEnd()
     }
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
-import ch.srgssr.pillarbox.analytics.PageView
-import ch.srgssr.pillarbox.analytics.SRGAnalytics
 import ch.srgssr.pillarbox.demo.ui.MainNavigation
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 
@@ -32,10 +30,5 @@ class MainActivity : ComponentActivity() {
                 }
             }
         }
-    }
-
-    override fun onResume() {
-        super.onResume()
-        SRGAnalytics.sendPageView(PageView("main", levels = arrayOf("app", "pillarbox")))
     }
 }

--- a/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/AnalyticsListenerCommander.kt
+++ b/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/AnalyticsListenerCommander.kt
@@ -91,7 +91,16 @@ open class AnalyticsListenerCommander(exoplayer: ExoPlayer) :
 
     fun simulateRelease(item: MediaItem) {
         val eventTime = createEventTime(item)
+        onPlaybackStateChanged(eventTime, Player.STATE_IDLE)
         onPlayerReleased(eventTime)
+    }
+
+    fun simulateItemRemoved(item1: MediaItem, item2: MediaItem? = null) {
+        val oldPosition = createPositionInfo(item1, 0)
+        val newPosition = createPositionInfo(item2, 1)
+        val eventTime = createEventTime(item1, 1)
+        onPositionDiscontinuity(eventTime, oldPosition, newPosition, Player.DISCONTINUITY_REASON_REMOVE)
+        onMediaItemTransition(eventTime, item2, Player.MEDIA_ITEM_TRANSITION_REASON_PLAYLIST_CHANGED)
     }
 
     fun simulateItemTransitionSeek(item1: MediaItem, item2: MediaItem) {
@@ -112,6 +121,9 @@ open class AnalyticsListenerCommander(exoplayer: ExoPlayer) :
 
     fun simulateItemTransitionRepeat(item1: MediaItem) {
         val eventTime = createEventTime(item1, 1)
+        val oldPosition = createPositionInfo(item1, 0)
+        val newPosition = createPositionInfo(item1, 0)
+        onPositionDiscontinuity(eventTime, oldPosition, newPosition, Player.DISCONTINUITY_REASON_AUTO_TRANSITION)
         onMediaItemTransition(eventTime, item1, Player.MEDIA_ITEM_TRANSITION_REASON_REPEAT)
     }
 
@@ -470,7 +482,7 @@ open class AnalyticsListenerCommander(exoplayer: ExoPlayer) :
 
     companion object {
 
-        fun createPositionInfo(mediaItem: MediaItem, index: Int = 0): PositionInfo {
+        fun createPositionInfo(mediaItem: MediaItem?, index: Int = 0): PositionInfo {
             return PositionInfo(null, index, mediaItem, null, 0, 0, 0, 0, 0)
         }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -84,6 +84,19 @@ class PillarboxPlayer internal constructor(
     )
 
     /**
+     * Releases the player.
+     * This method must be called when the player is no longer required. The player must not be used after calling this method.
+     *
+     * Release call automatically [stop] if the player is not in [Player.STATE_IDLE].
+     */
+    override fun release() {
+        if (playbackState != Player.STATE_IDLE) {
+            stop()
+        }
+        exoPlayer.release()
+    }
+
+    /**
      * Handle audio focus with currently set AudioAttributes
      * @param handleAudioFocus true if the player should handle audio focus, false otherwise.
      */

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -98,11 +98,11 @@ internal class CurrentMediaItemTracker internal constructor(
             currentMediaItem = mediaItem
             currentMediaItem?.let { startNewSession(it) }
         } else {
-            stopSessionInternal()
+            updateSessionInternal()
         }
     }
 
-    private fun stopSessionInternal() {
+    private fun updateSessionInternal() {
         trackers?.let {
             for (tracker in it.list) {
                 currentMediaItem?.getMediaItemTrackerDataOrNull()?.getData(tracker)?.let { data ->

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -192,10 +192,11 @@ internal class CurrentMediaItemTracker internal constructor(
         mediaItem?.let { startNewSession(mediaItem) }
     }
 
+    /*
+     * Strange behaviors during buffering onPlayerReleased is called but the listener is not removed?
+     */
     override fun onPlayerReleased(eventTime: EventTime) {
         DebugLogger.debug(TAG, "onPlayerReleased")
-        player.removeAnalyticsListener(this)
-        stopSession(MediaItemTracker.StopReason.Stop)
     }
 
     companion object {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
@@ -31,8 +31,9 @@ interface MediaItemTracker {
      *
      * @param player The player tracked.
      * @param reason To tell how the track is stopped.
+     * @param positionMs The player position when the tracker is stopped.
      */
-    fun stop(player: ExoPlayer, reason: StopReason)
+    fun stop(player: ExoPlayer, reason: StopReason, positionMs: Long)
 
     /**
      * Update with data.

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
@@ -93,7 +93,7 @@ class TestMediaItemTrackerList {
         override fun start(player: ExoPlayer, initialData: Any?) {
         }
 
-        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason) {
+        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
         }
 
     }
@@ -102,7 +102,7 @@ class TestMediaItemTrackerList {
         override fun start(player: ExoPlayer, initialData: Any?) {
         }
 
-        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason) {
+        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
         }
     }
 
@@ -110,7 +110,7 @@ class TestMediaItemTrackerList {
         override fun start(player: ExoPlayer, initialData: Any?) {
         }
 
-        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason) {
+        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
         }
     }
 

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
@@ -46,7 +46,7 @@ class TestMediaItemTrackerRepository {
 
         }
 
-        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason) {
+        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs:Long) {
 
         }
     }


### PR DESCRIPTION
# Pull request

## Description

Improve play time computation when playing live content. Improve current media item detection and avoid sending unnecessary seek during item transition.

## Fixes
- #147 
- #148 

## Changes made

- Forward position when stopping `MediaItemTracker`.
- Change current media item detection.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
