### PR TITLE
Remove default sourceKey

### DIFF
--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActConfig.kt
@@ -4,17 +4,16 @@
  */
 package ch.srgssr.pillarbox.analytics.commandersact
 
-import ch.srgssr.pillarbox.analytics.BuildConfig
-
 /**
  * Config
  *
  * @property virtualSite The app site name given by the analytics team.
  * @property sourceKey The sourceKey given by the analytics team.
  */
+@Suppress("unused")
 data class CommandersActConfig(
     val virtualSite: String,
-    val sourceKey: String = if (BuildConfig.DEBUG) SOURCE_KEY_SRG_DEBUG else SOURCE_KEY_SRG_PROD
+    val sourceKey: String
 ) {
 
     companion object {


### PR DESCRIPTION
# Pull request

## Description

Remove default source key for CommandersAct config. To avoid calling production settings by mistake.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
