### PR TITLE
174 remove unused commandersact streaming label

### DIFF
--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
@@ -53,11 +53,6 @@ class TCMediaEvent(
      */
     var audioTrackLanguage: String? = null
 
-    /**
-     * Current playback speed
-     */
-    var playbackSpeed: Float = 1.0f
-
     override fun getJsonObject(): JSONObject {
         val jsonObject = super.getJsonObject()
         for (asset in assets) {
@@ -81,8 +76,6 @@ class TCMediaEvent(
             jsonObject.putIfValid(MEDIA_AUDIO_TRACK, it)
         }
 
-        jsonObject.putIfValid(MEDIA_PLAYBACK_RATE, playbackSpeed.toString())
-
         return jsonObject
     }
 
@@ -101,7 +94,6 @@ class TCMediaEvent(
         private const val MEDIA_SUBTITLES_ON = "media_subtitles_on"
         private const val MEDIA_AUDIO_TRACK = "media_audio_track"
         private const val MEDIA_SUBTITLE_SELECTION = "media_subtitle_selection"
-        private const val MEDIA_PLAYBACK_RATE = "media_playback_rate"
         private const val KEY_SOURCE_ID = "source_id"
 
         private fun toSeconds(duration: Duration): Long {

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
@@ -39,11 +39,6 @@ class TCMediaEvent(
     var deviceVolume: Float? = null
 
     /**
-     * Bandwidth
-     */
-    var bandwidth: Long? = null
-
-    /**
      * Is subtitles on
      */
     var isSubtitlesOn: Boolean = false
@@ -72,9 +67,6 @@ class TCMediaEvent(
         jsonObject.putIfValid(MEDIA_POSITION, toSeconds(mediaPosition).toString())
         timeShift?.let {
             jsonObject.putIfValid(MEDIA_TIMESHIFT, toSeconds(it).toString())
-        }
-        bandwidth?.let {
-            jsonObject.putIfValid(MEDIA_BANDWIDTH, it.toString())
         }
         deviceVolume?.let {
             jsonObject.putIfValid(MEDIA_VOLUME, it.toString())
@@ -106,7 +98,6 @@ class TCMediaEvent(
         private const val MEDIA_POSITION = "media_position"
         private const val MEDIA_PLAYER_DISPLAY = "media_player_display"
         private const val MEDIA_TIMESHIFT = "media_timeshift"
-        private const val MEDIA_BANDWIDTH = "media_bandwidth"
         private const val MEDIA_SUBTITLES_ON = "media_subtitles_on"
         private const val MEDIA_AUDIO_TRACK = "media_audio_track"
         private const val MEDIA_SUBTITLE_SELECTION = "media_subtitle_selection"

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -122,7 +122,6 @@ internal class CommandersActStreaming(
             }
             event.timeShift = timeShift
         }
-        event.bandwidth = player.getCurrentBandwidth()
         event.deviceVolume = if (player.volume == 0f) 0f else player.deviceVolume / 100f
         event.mediaPosition = if (player.isCurrentMediaItemLive) totalPlayTime else position
         event.playbackSpeed = player.getPlaybackSpeed()
@@ -208,15 +207,4 @@ internal class CommandersActStreaming(
         private val TIMESHIFT_EQUIVALENT_LIVE = 60.seconds
         private const val VALID_SEEK_THRESHOLD: Long = 1000L
     }
-}
-
-/**
- * Compute bit rate
- * @return null if not applicable
- */
-private fun ExoPlayer.getCurrentBandwidth(): Long? {
-    val videoBandwidth = if (videoFormat != null && videoFormat!!.bitrate != Format.NO_VALUE) videoFormat!!.bitrate else 0
-    val audioBandwidth = if (audioFormat != null && audioFormat!!.bitrate != Format.NO_VALUE) audioFormat!!.bitrate else 0
-    val bandwidth = (videoBandwidth + audioBandwidth).toLong()
-    return if (bandwidth > 0) bandwidth else null
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -115,11 +115,7 @@ internal class CommandersActStreaming(
         handleAudioTrack(event)
 
         if (player.isCurrentMediaItemLive) {
-            var timeShift = getTimeshift(position)
-            if (timeShift < TIMESHIFT_EQUIVALENT_LIVE) {
-                timeShift = ZERO
-            }
-            event.timeShift = timeShift
+            event.timeShift = getTimeshift(position)
         }
         event.deviceVolume = if (player.volume == 0f) 0f else player.deviceVolume / 100f
         event.mediaPosition = if (player.isCurrentMediaItemLive) totalPlayTime else position
@@ -158,12 +154,7 @@ internal class CommandersActStreaming(
     }
 
     private fun notifyUptime(position: Duration) {
-        if (!isCurrentlyLiveAt(position)) return
         notifyEvent(MediaEventType.Uptime, position)
-    }
-
-    private fun isCurrentlyLiveAt(position: Duration): Boolean {
-        return player.isCurrentMediaItemLive && getTimeshift(position) < TIMESHIFT_EQUIVALENT_LIVE
     }
 
     private fun getTimeshift(position: Duration): Duration {
@@ -202,7 +193,6 @@ internal class CommandersActStreaming(
         internal var HEART_BEAT_DELAY = 30.seconds
         internal var UPTIME_PERIOD = 60.seconds
         internal var POS_PERIOD = 30.seconds
-        private val TIMESHIFT_EQUIVALENT_LIVE = 60.seconds
         private const val VALID_SEEK_THRESHOLD: Long = 1000L
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -123,7 +123,7 @@ internal class CommandersActStreaming(
             event.timeShift = timeShift
         }
         event.bandwidth = player.getCurrentBandwidth()
-        event.deviceVolume = player.deviceVolume / 100f
+        event.deviceVolume = if (player.volume == 0f) 0f else player.deviceVolume / 100f
         event.mediaPosition = if (player.isCurrentMediaItemLive) totalPlayTime else position
         event.playbackSpeed = player.getPlaybackSpeed()
         commandersAct.sendTcMediaEvent(event)

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -13,7 +13,6 @@ import ch.srgssr.pillarbox.analytics.commandersact.CommandersAct
 import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType
 import ch.srgssr.pillarbox.analytics.commandersact.TCMediaEvent
 import ch.srgssr.pillarbox.core.business.tracker.TotalPlaytimeCounter
-import ch.srgssr.pillarbox.player.getPlaybackSpeed
 import ch.srgssr.pillarbox.player.utils.DebugLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -124,7 +123,6 @@ internal class CommandersActStreaming(
         }
         event.deviceVolume = if (player.volume == 0f) 0f else player.deviceVolume / 100f
         event.mediaPosition = if (player.isCurrentMediaItemLive) totalPlayTime else position
-        event.playbackSpeed = player.getPlaybackSpeed()
         commandersAct.sendTcMediaEvent(event)
     }
 

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -60,6 +60,7 @@ internal class CommandersActStreaming(
                     notifyPos(player.currentPosition.milliseconds)
                 }
             }.also {
+                if (!player.isCurrentMediaItemLive) return
                 it.scheduleAtFixedRate(HEART_BEAT_DELAY.inWholeMilliseconds, period = UPTIME_PERIOD.inWholeMilliseconds) {
                     MainScope().launch(Dispatchers.Main) {
                         notifyUptime(player.currentPosition.milliseconds)


### PR DESCRIPTION
## Description

Remove some unused media Commanders Act labels.

## Changes made

- Remove `media_bandwidth`.
- Remove `media_playback_rate`.
- Change `media_volume` to 0 if player volume is equal to 0.
- Uptime heart beat is not started when current media is not live.
- `media_timeshift` is no more round to 0, the value is always computed.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
