### PR TITLE
162 add UI to inject url or urn

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/DemoItem.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/DemoItem.kt
@@ -139,14 +139,24 @@ data class DemoItem(
 
         val GoogleDashH264 = DemoItem(
             title = "VoD - Dash (H264)",
-            description = "Dash sample from Exoplayer",
             uri = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd"
+        )
+
+        val GoogleDashH264_CENC_Widewine = DemoItem(
+            title = "VoD - Dash Widewine cenc (H264)",
+            uri = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd",
+            licenseUrl = "https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test"
         )
 
         val GoogleDashH265 = DemoItem(
             title = "VoD - Dash (H265)",
-            description = "Dash sample from Exoplayer",
             uri = "https://storage.googleapis.com/wvmedia/clear/hevc/tears/tears.mpd"
+        )
+
+        val GoogleDashH265_CENC_Widewine = DemoItem(
+            title = "VoD - Dash widewine cenc (H265)",
+            uri = "https://storage.googleapis.com/wvmedia/cenc/hevc/tears/tears.mpd",
+            licenseUrl = "https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test"
         )
 
         val OnDemandHorizontalVideo = DemoItem(

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/DemoItem.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/DemoItem.kt
@@ -7,7 +7,9 @@
 package ch.srgssr.pillarbox.demo.data
 
 import android.net.Uri
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaItem.DrmConfiguration
 import androidx.media3.common.MediaMetadata
 import java.io.Serializable
 
@@ -18,9 +20,16 @@ import java.io.Serializable
  * @property uri
  * @property description
  * @property imageUrl
+ * @property licenseUrl
  */
 @Suppress("UndocumentedPublicProperty")
-data class DemoItem(val title: String, val uri: String, val description: String? = null, val imageUrl: String? = null) : Serializable {
+data class DemoItem(
+    val title: String,
+    val uri: String,
+    val description: String? = null,
+    val imageUrl: String? = null,
+    val licenseUrl: String? = null,
+) : Serializable {
     /**
      * Convert to a [MediaItem]
      * When [uri] is a Urn, set [MediaItem.Builder.setUri] to null,
@@ -37,6 +46,13 @@ data class DemoItem(val title: String, val uri: String, val description: String?
                     .setDescription(description)
                     .setArtworkUri(imageUrl?.let { Uri.parse(it) })
                     .build()
+            )
+            .setDrmConfiguration(
+                licenseUrl?.let {
+                    DrmConfiguration.Builder(C.WIDEVINE_UUID)
+                        .setLicenseUri(licenseUrl)
+                        .build()
+                }
             )
             .build()
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Playlist.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Playlist.kt
@@ -211,7 +211,9 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
             title = "Google samples",
             items = listOf(
                 DemoItem.GoogleDashH264,
+                DemoItem.GoogleDashH264_CENC_Widewine,
                 DemoItem.GoogleDashH265,
+                DemoItem.GoogleDashH265_CENC_Widewine
             )
         )
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Card
 import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
@@ -56,6 +57,16 @@ fun ExamplesHome() {
 private fun ListStreamView(playlistList: List<Playlist>, onItemClicked: (DemoItem) -> Unit) {
     val scrollState = rememberScrollState()
     Column(modifier = Modifier.verticalScroll(scrollState)) {
+        Card(
+            modifier = Modifier
+                .padding(4.dp)
+                .fillMaxWidth()
+        ) {
+            InsertContentView(
+                modifier = Modifier.fillMaxWidth().padding(6.dp),
+                onItemClicked
+            )
+        }
         for (playlist in playlistList) {
             PlaylistHeaderView(playlist = playlist)
             Column {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.ui.examples
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.Button
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import ch.srgssr.pillarbox.demo.data.DemoItem
+
+private val keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Uri)
+
+private data class InsertContentData(val uri: String = "", val licenseUrl: String = "") {
+    val isValidUrl: Boolean
+        get() {
+            return uri.startsWith("http")
+        }
+
+    fun toDemoItem(): DemoItem {
+        return DemoItem(
+            title = uri,
+            uri = uri,
+            licenseUrl = licenseUrl
+        )
+    }
+}
+
+/**
+ * Insert content view
+ *
+ * @param modifier The modifier to use.
+ * @param onContentClicked The event when user click button play.
+ * @receiver
+ */
+@Composable
+fun InsertContentView(modifier: Modifier = Modifier, onContentClicked: (DemoItem) -> Unit) {
+    var insertContentData by remember {
+        mutableStateOf(InsertContentData())
+    }
+    Column(modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        TextField(
+            modifier = Modifier.fillMaxWidth(),
+            value = insertContentData.uri,
+            keyboardOptions = keyboardOptions,
+            singleLine = true,
+            onValueChange = {
+                insertContentData = insertContentData.copy(uri = it)
+            },
+            label = {
+                Text(text = "Url or urn")
+            },
+            trailingIcon = {
+                IconButton(onClick = { insertContentData = InsertContentData() }) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Clear"
+                    )
+                }
+            },
+        )
+        if (insertContentData.uri.isNotBlank() && insertContentData.isValidUrl) {
+            TextField(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 4.dp),
+                value = insertContentData.licenseUrl,
+                keyboardOptions = keyboardOptions,
+                singleLine = true,
+                onValueChange = {
+                    insertContentData = insertContentData.copy(licenseUrl = it)
+                },
+                label = {
+                    Text(text = "License url")
+                },
+                trailingIcon = {
+                    IconButton(onClick = { insertContentData = insertContentData.copy(licenseUrl = "") }) {
+                        Icon(
+                            imageVector = Icons.Default.Close,
+                            contentDescription = "Clear"
+                        )
+                    }
+                },
+            )
+        }
+        Button(onClick = { onContentClicked(insertContentData.toDemoItem()) }) {
+            Text(text = "Play")
+        }
+    }
+}
+
+@Composable
+@Preview
+private fun InsertContentPreview() {
+    InsertContentView() {
+    }
+}


### PR DESCRIPTION
## Description

Add a ui component to allow Pillarbox user to add their content. They can add either urn content or url content with license url in case of url content with drm.


## Changes made

-  Add a UI to add user content at the top of the Examples tab.


## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
