### PR TITLE
Allow integrator to set custom MediaSession.Callback

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/DefaultMediaSessionCallback.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/DefaultMediaSessionCallback.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.service
+
+import androidx.media3.common.MediaItem
+import androidx.media3.session.MediaSession
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+
+/**
+ * Default media session callback that allow to add [MediaItem] with an url or an mediaId to the MediaController.
+ *
+ * @see [MediaSession.Builder.setCallback]
+ */
+interface DefaultMediaSessionCallback : MediaSession.Callback {
+
+    override fun onAddMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: MutableList<MediaItem>
+    ): ListenableFuture<MutableList<MediaItem>> {
+        for (mediaItem in mediaItems) {
+            if (mediaItem.localConfiguration == null && mediaItem.mediaId.isBlank()) {
+                return Futures.immediateFailedFuture(UnsupportedOperationException())
+            }
+        }
+        return Futures.immediateFuture(mediaItems)
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaSessionService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaSessionService.kt
@@ -46,6 +46,7 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  *      connection.release() when controller no more needed.
  * ```
  */
+@Suppress("MemberVisibilityCanBePrivate")
 abstract class PillarboxMediaSessionService : MediaSessionService() {
     private var player: Player? = null
     private var mediaSession: MediaSession? = null
@@ -57,13 +58,19 @@ abstract class PillarboxMediaSessionService : MediaSessionService() {
 
     /**
      * Set player to use with this Service.
+     * @param player PillarboxPlayer to link to this service.
+     * @param mediaSessionCallback The MediaSession.Callback to use [MediaSession.Builder.setCallback].
      */
-    fun setPlayer(player: PillarboxPlayer) {
+    fun setPlayer(
+        player: PillarboxPlayer,
+        mediaSessionCallback: MediaSession.Callback = object : DefaultMediaSessionCallback {}
+    ) {
         if (this.player == null) {
             this.player = null
             player.setWakeMode(C.WAKE_MODE_NETWORK)
             player.setHandleAudioFocus(true)
             val builder = MediaSession.Builder(this, player)
+                .setCallback(mediaSessionCallback)
                 .setId(packageName)
             sessionActivity()?.let {
                 builder.setSessionActivity(it)


### PR DESCRIPTION
## Description

`PillarboxMediaSessionService` have to provide a custom MediaSession.Callback in order to be able to add `Mediaitem` to a MediaController, especially if those MediaItem have not url but a mediaId.

## Changes made

- Add MediaSession.Callback to  `PillarboxMediaSessionService.setPlayer` to allow integrators to customize it.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
