### PR TITLE
Uptime is send only when time shift <= 30 seconds

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -154,6 +154,7 @@ internal class CommandersActStreaming(
     }
 
     private fun notifyUptime(position: Duration) {
+        if (getTimeshift(position) > LIVE_EDGE_THRESHOLD) return
         notifyEvent(MediaEventType.Uptime, position)
     }
 
@@ -194,5 +195,6 @@ internal class CommandersActStreaming(
         internal var UPTIME_PERIOD = 60.seconds
         internal var POS_PERIOD = 30.seconds
         private const val VALID_SEEK_THRESHOLD: Long = 1000L
+        private val LIVE_EDGE_THRESHOLD = 60.seconds
     }
 }


### PR DESCRIPTION
## Changes made

- Change when `uptime` are send during live. They are send when time shift is less and equals to 30 seconds.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
