### PR TITLE
Fix media_volume for CommandersAct

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -117,7 +117,16 @@ internal class CommandersActStreaming(
         if (player.isCurrentMediaItemLive) {
             event.timeShift = getTimeshift(position)
         }
-        event.deviceVolume = if (player.volume == 0f) 0f else player.deviceVolume / 100f
+        val maxVolume = player.deviceInfo.maxVolume
+        val minVolume = player.deviceInfo.minVolume
+        val volumeRange = maxVolume - minVolume
+        if (volumeRange == 0 || player.volume == 0f) {
+            event.deviceVolume = player.volume
+        } else {
+            val deviceVolume = player.deviceVolume - minVolume
+            event.deviceVolume = deviceVolume / volumeRange.toFloat()
+        }
+
         event.mediaPosition = if (player.isCurrentMediaItemLive) totalPlayTime else position
         commandersAct.sendTcMediaEvent(event)
     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -79,6 +79,7 @@ class PillarboxPlayer internal constructor(
                     defaultMediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
                 )
             )
+            .setDeviceVolumeControlEnabled(true) // allow player to control device volume
             .build(),
         mediaItemTrackerProvider = mediaItemTrackerProvider
     )


### PR DESCRIPTION
# Pull request

## Description

Fix `media_volume` always sending 0. The reason is because player can't have access to the device control volume.

## Changes made

- Allow `PillarboxPlayer` to controls device volume.
- Change media volume computation with `CommandersActStreaming`.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
