### PR TITLE
195 forced subtitles support

### DIFF
--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -7,7 +7,7 @@ import java.util.*
 object AppConfig {
     const val minSdk = 21
     const val targetSdk = 33
-    const val compileSdk = 33
+    const val compileSdk = 34
 
     @Suppress("SimpleDateFormat")
     fun getBuildDate(): String {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -22,11 +22,11 @@ object Version {
     const val espresso = "3.5.1"
     const val lifecycle = "2.6.1"
     const val fragment = "1.5.7"
-    const val navigation = "2.5.3"
+    const val navigation = "2.7.0"
     const val activity = "1.7.2"
     const val composeCompiler = "1.5.1"
-    const val composeUi = "1.4.3"
-    const val composeMaterial = "1.4.3"
+    const val composeUi = "1.5.0"
+    const val composeMaterial = "1.5.0"
     const val detetk = "1.22.0"
 
     /*

--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -121,8 +121,8 @@ dependencies {
     implementation(Dependencies.Compose.activity)
     implementation(Dependencies.Compose.navigation)
     implementation(Dependencies.Compose.viewmodel)
-    implementation("com.google.accompanist:accompanist-systemuicontroller:0.30.1")
-    implementation("com.google.accompanist:accompanist-navigation-material:0.30.1")
+    implementation("com.google.accompanist:accompanist-systemuicontroller:0.33.0-alpha")
+    implementation("com.google.accompanist:accompanist-navigation-material:0.33.0-alpha")
 
     // Integration layer
     val dataProviderVersion = "0.4.0"

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSettingsContent.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSettingsContent.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.demo.ui.player.settings
 
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -68,7 +69,15 @@ fun PlaybackSettingsContent(
     val settingsViewModel: PlayerSettingsViewModel = viewModel(factory = PlayerSettingsViewModel.Factory(player))
     val currentPlaybackSpeed = settingsViewModel.playbackSpeed.collectAsState().value
     NavHost(navController = navController, startDestination = SettingDestination.Home.route) {
-        composable(route = SettingDestination.Home.route) {
+        composable(
+            route = SettingDestination.Home.route,
+            exitTransition = {
+                slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.Down)
+            },
+            enterTransition = {
+                slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Up)
+            }
+        ) {
             val hasAudios = settingsViewModel.hasAudio.collectAsState(initial = false)
             val hasSubtitles = settingsViewModel.hasSubtitles.collectAsState(initial = false)
             SettingsHome(
@@ -82,13 +91,29 @@ fun PlaybackSettingsContent(
                 },
             )
         }
-        composable(route = SettingDestination.PlaybackSpeed.route) {
+        composable(
+            route = SettingDestination.PlaybackSpeed.route,
+            exitTransition = {
+                slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.Down)
+            },
+            enterTransition = {
+                slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Up)
+            }
+        ) {
             PlaybackSpeedSettings(currentSpeed = currentPlaybackSpeed, onSpeedSelected = {
                 player.setPlaybackSpeed(it)
                 onDismissState()
             })
         }
-        composable(route = SettingDestination.Subtitles.route) {
+        composable(
+            route = SettingDestination.Subtitles.route,
+            exitTransition = {
+                slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.Down)
+            },
+            enterTransition = {
+                slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Up)
+            }
+        ) {
             val textTrackState = settingsViewModel.textTracks.collectAsState()
             val textTrackSelection = settingsViewModel.trackSelectionParameters.collectAsState()
             val disabled = textTrackSelection.value.isTextTrackDisabled
@@ -110,7 +135,15 @@ fun PlaybackSettingsContent(
                 onDismissState()
             }
         }
-        composable(route = SettingDestination.Audios.route) {
+        composable(
+            route = SettingDestination.Audios.route,
+            exitTransition = {
+                slideOutOfContainer(towards = AnimatedContentTransitionScope.SlideDirection.Down)
+            },
+            enterTransition = {
+                slideIntoContainer(towards = AnimatedContentTransitionScope.SlideDirection.Up)
+            }
+        ) {
             val audioTracks = settingsViewModel.audioTracks.collectAsState()
             val trackSelectionParametersState = settingsViewModel.trackSelectionParameters.collectAsState()
             val disabled = trackSelectionParametersState.value.isAudioTrackDisabled

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
@@ -27,8 +27,8 @@ import androidx.media3.common.Format
 import androidx.media3.common.TrackGroup
 import androidx.media3.common.Tracks
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.player.extension.getLocale
 import ch.srgssr.pillarbox.player.extension.hasAccessibilityRoles
-import ch.srgssr.pillarbox.player.extension.roleString
 
 /**
  * Track selection settings
@@ -74,7 +74,7 @@ fun TrackSelectionSettings(
                     when (group.type) {
                         C.TRACK_TYPE_AUDIO -> {
                             val str = StringBuilder()
-                            str.append("${format.label} / ${format.language}")
+                            str.append(format.getTrackLabel())
                             if (format.bitrate > Format.NO_VALUE) {
                                 str.append(" @${format.bitrate} bit/sec")
                             }
@@ -89,12 +89,12 @@ fun TrackSelectionSettings(
                         else -> {
                             if (format.hasAccessibilityRoles()) {
                                 Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Text(text = "${format.label} / ${format.language}")
+                                    Text(text = format.getTrackLabel())
                                     Spacer(modifier = Modifier.width(12.dp))
                                     Icon(imageVector = Icons.Default.HearingDisabled, contentDescription = "Hearing disabled")
                                 }
                             } else {
-                                Text(text = "${format.label} / ${format.language} ${format.roleString()}")
+                                Text(text = format.getTrackLabel())
                             }
                         }
                     }
@@ -105,6 +105,10 @@ fun TrackSelectionSettings(
             }
         }
     }
+}
+
+private fun Format.getTrackLabel(): String {
+    return getLocale()?.let { it.displayName } ?: label ?: C.LANGUAGE_UNDETERMINED
 }
 
 @Preview

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
@@ -16,6 +16,7 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.HearingDisabled
+import androidx.compose.material.icons.filled.RemoveRedEye
 import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -27,7 +28,7 @@ import androidx.media3.common.Format
 import androidx.media3.common.TrackGroup
 import androidx.media3.common.Tracks
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
-import ch.srgssr.pillarbox.player.extension.hasRole
+import ch.srgssr.pillarbox.player.extension.hasAccessibilityRoles
 import ch.srgssr.pillarbox.player.extension.roleString
 
 /**
@@ -78,11 +79,16 @@ fun TrackSelectionSettings(
                             if (format.bitrate > Format.NO_VALUE) {
                                 str.append(" @${format.bitrate} bit/sec")
                             }
-                            Text(text = str.toString())
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(text = str.toString())
+                                if (format.hasAccessibilityRoles()) {
+                                    Icon(imageVector = Icons.Filled.RemoveRedEye, contentDescription = "AD")
+                                }
+                            }
                         }
 
                         else -> {
-                            if (format.hasRole(C.ROLE_FLAG_DESCRIBES_MUSIC_AND_SOUND.or(C.ROLE_FLAG_TRANSCRIBES_DIALOG))) {
+                            if (format.hasAccessibilityRoles()) {
                                 Row(verticalAlignment = Alignment.CenterVertically) {
                                     Text(text = "${format.label} / ${format.language}")
                                     Spacer(modifier = Modifier.width(12.dp))

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
@@ -27,7 +27,7 @@ import androidx.media3.common.Format
 import androidx.media3.common.TrackGroup
 import androidx.media3.common.Tracks
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
-import ch.srgssr.pillarbox.player.extension.getLocale
+import ch.srgssr.pillarbox.player.extension.displayName
 import ch.srgssr.pillarbox.player.extension.hasAccessibilityRoles
 
 /**
@@ -74,7 +74,7 @@ fun TrackSelectionSettings(
                     when (group.type) {
                         C.TRACK_TYPE_AUDIO -> {
                             val str = StringBuilder()
-                            str.append(format.getTrackLabel())
+                            str.append(format.displayName)
                             if (format.bitrate > Format.NO_VALUE) {
                                 str.append(" @${format.bitrate} bit/sec")
                             }
@@ -89,12 +89,12 @@ fun TrackSelectionSettings(
                         else -> {
                             if (format.hasAccessibilityRoles()) {
                                 Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Text(text = format.getTrackLabel())
+                                    Text(text = format.displayName)
                                     Spacer(modifier = Modifier.width(12.dp))
                                     Icon(imageVector = Icons.Default.HearingDisabled, contentDescription = "Hearing disabled")
                                 }
                             } else {
-                                Text(text = format.getTrackLabel())
+                                Text(text = format.displayName)
                             }
                         }
                     }
@@ -105,10 +105,6 @@ fun TrackSelectionSettings(
             }
         }
     }
-}
-
-private fun Format.getTrackLabel(): String {
-    return getLocale()?.let { it.displayName } ?: label ?: C.LANGUAGE_UNDETERMINED
 }
 
 @Preview

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.HearingDisabled
-import androidx.compose.material.icons.filled.RemoveRedEye
 import androidx.compose.material.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -82,7 +81,7 @@ fun TrackSelectionSettings(
                             Row(verticalAlignment = Alignment.CenterVertically) {
                                 Text(text = str.toString())
                                 if (format.hasAccessibilityRoles()) {
-                                    Icon(imageVector = Icons.Filled.RemoveRedEye, contentDescription = "AD")
+                                    Icon(imageVector = Icons.Filled.HearingDisabled, contentDescription = "AD")
                                 }
                             }
                         }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
@@ -34,7 +34,10 @@ import ch.srgssr.pillarbox.ui.ScaleMode
 @Composable
 fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
     val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
-    val pagerState = rememberPagerState()
+
+    val pagerState = rememberPagerState() {
+        storyViewModel.playlist.items.size
+    }
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_START) {
@@ -53,16 +56,15 @@ fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
     val playlist = storyViewModel.playlist.items
     HorizontalPager(
         modifier = Modifier.fillMaxHeight(),
+        beyondBoundsPageCount = 0,
         key = { page -> playlist[page].uri },
         flingBehavior = PagerDefaults.flingBehavior(
             state = pagerState,
             pagerSnapDistance = PagerSnapDistance.atMost(0),
             snapAnimationSpec = spring(stiffness = Spring.StiffnessHigh)
         ),
-        beyondBoundsPageCount = 0,
-        pageCount = playlist.size,
-        state = pagerState,
-        pageSpacing = 1.dp
+        pageSpacing = 1.dp,
+        state = pagerState
     ) { page ->
         // When flinging -> may "load" more that 3 pages
         val currentPage = pagerState.currentPage

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/SimpleStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/SimpleStory.kt
@@ -35,11 +35,10 @@ fun SimpleStory() {
         Playlist.VideoUrls
     }
 
-    val pagerState = rememberPagerState()
+    val pagerState = rememberPagerState() { playlist.items.size }
     HorizontalPager(
         modifier = Modifier.fillMaxHeight(),
         key = { page -> playlist.items[page].uri },
-        pageCount = playlist.items.size,
         state = pagerState
     ) { page ->
         SimpleStoryPlayer(demoItem = playlist.items[page], isPlaying = pagerState.currentPage == page)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -282,12 +282,13 @@ fun Player.getAspectRatioAsFlow(defaultAspectRatio: Float): Flow<Float> = videoS
 /**
  * Get track selection parameters as flow [Player.getTrackSelectionParameters]
  */
-fun Player.getTrackSelectionParametersAsFlow() = callbackFlow {
+fun Player.getTrackSelectionParametersAsFlow(): Flow<TrackSelectionParameters> = callbackFlow {
     val listener = object : Player.Listener {
         override fun onTrackSelectionParametersChanged(parameters: TrackSelectionParameters) {
             trySend(parameters)
         }
     }
+
     trySend(trackSelectionParameters)
     addPlayerListener(player = this@getTrackSelectionParametersAsFlow, listener)
 }
@@ -295,7 +296,7 @@ fun Player.getTrackSelectionParametersAsFlow() = callbackFlow {
 /**
  * Get current tracks as flow [Player.getCurrentTracks]
  */
-fun Player.getCurrentTracksAsFlow() = callbackFlow {
+fun Player.getCurrentTracksAsFlow(): Flow<Tracks> = callbackFlow {
     val listener = object : Player.Listener {
         override fun onTracksChanged(tracks: Tracks) {
             trySend(tracks)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
@@ -31,8 +31,6 @@ fun Format.hasSelection(selection: @SelectionFlags Int): Boolean {
 
 /**
  * Is forced
- *
- * @return true if [Format.selectionFlags] contains [C.SELECTION_FLAG_FORCED].
  */
 fun Format.isForced(): Boolean {
     return hasSelection(C.SELECTION_FLAG_FORCED)
@@ -121,9 +119,7 @@ fun Format.roleString(): String {
 }
 
 /**
- * Check if it has SDH role flags
- *
- * @return
+ * Has accessibility roles
  */
 fun Format.hasAccessibilityRoles(): Boolean {
     return hasRole(C.ROLE_FLAG_DESCRIBES_VIDEO or C.ROLE_FLAG_DESCRIBES_MUSIC_AND_SOUND)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.C.RoleFlags
 import androidx.media3.common.C.SelectionFlags
 import androidx.media3.common.Format
 import androidx.media3.common.VideoSize
+import java.util.Locale
 
 /**
  * Check if [Format.roleFlags] contains [role]
@@ -126,4 +127,13 @@ fun Format.roleString(): String {
  */
 fun Format.hasAccessibilityRoles(): Boolean {
     return hasRole(C.ROLE_FLAG_DESCRIBES_VIDEO or C.ROLE_FLAG_DESCRIBES_MUSIC_AND_SOUND)
+}
+
+/**
+ * Returns a locale for the specified IETF BCP 47 [Format.language] tag string.
+ *
+ * @return null if not applicable.
+ */
+fun Format.getLocale(): Locale? {
+    return language?.let { Locale.forLanguageTag(language) }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
@@ -118,3 +118,12 @@ fun Format.roleString(): String {
     }
     return roleFlags.joinToString(",")
 }
+
+/**
+ * Check if it has SDH role flags
+ *
+ * @return
+ */
+fun Format.hasAccessibilityRoles(): Boolean {
+    return hasRole(C.ROLE_FLAG_DESCRIBES_VIDEO or C.ROLE_FLAG_DESCRIBES_MUSIC_AND_SOUND)
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
@@ -29,6 +29,15 @@ fun Format.hasSelection(selection: @SelectionFlags Int): Boolean {
 }
 
 /**
+ * Is forced
+ *
+ * @return true if [Format.selectionFlags] contains [C.SELECTION_FLAG_FORCED].
+ */
+fun Format.isForced(): Boolean {
+    return hasSelection(C.SELECTION_FLAG_FORCED)
+}
+
+/**
  * Video size of the format. [VideoSize.UNKNOWN] if no video size provided.
  */
 val Format.videoSize: VideoSize

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
@@ -137,3 +137,9 @@ fun Format.hasAccessibilityRoles(): Boolean {
 fun Format.getLocale(): Locale? {
     return language?.let { Locale.forLanguageTag(language) }
 }
+
+/**
+ * Display name
+ */
+val Format.displayName: String
+    get() = getLocale()?.let { it.displayName } ?: label ?: C.LANGUAGE_UNDETERMINED

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
@@ -49,9 +49,7 @@ fun TrackSelectionParameters.hasTrackOverride(trackType: @TrackType Int): Boolea
 }
 
 /**
- * Disable text track, forced subtitles may be shown.
- *
- * To completely remove text track [TrackSelectionParameters.disabledTrackTypes]
+ * Disable text track
  *
  * @return
  */

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
@@ -15,7 +15,6 @@ import androidx.media3.common.TrackSelectionParameters
 
 /**
  * Is text track disabled
- * FIXME Doesn't work in case of playlists. A overrides can be setup but no applicable for the next item.
  */
 val TrackSelectionParameters.isTextTrackDisabled: Boolean
     get() = disabledTrackTypes.contains(C.TRACK_TYPE_TEXT) ||
@@ -73,11 +72,9 @@ fun TrackSelectionParameters.disableAudioTrack(): TrackSelectionParameters {
 }
 
 /**
- * Default text track
+ * Default text track parameters.
  *
- * Reset [TrackSelectionParameters] for text as Default.
- *
- * @param context
+ * @param context The context.
  * @return
  */
 fun TrackSelectionParameters.defaultTextTrack(context: Context): TrackSelectionParameters {
@@ -92,11 +89,11 @@ fun TrackSelectionParameters.defaultTextTrack(context: Context): TrackSelectionP
 }
 
 /**
- * Default audio track
+ * Default audio track parameters.
  *
  * Reset [TrackSelectionParameters] for audio as Default.
  *
- * @param context
+ * @param context The context.
  * @return
  */
 fun TrackSelectionParameters.defaultAudioTrack(context: Context): TrackSelectionParameters {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Tracks.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Tracks.kt
@@ -6,13 +6,14 @@ package ch.srgssr.pillarbox.player.extension
 
 import androidx.media3.common.C
 import androidx.media3.common.C.TrackType
+import androidx.media3.common.TrackGroup
 import androidx.media3.common.Tracks
 
 /**
  * Text tracks
  */
 val Tracks.text: List<Tracks.Group>
-    get() = filterByTrackType(C.TRACK_TYPE_TEXT)
+    get() = filterByTrackType(C.TRACK_TYPE_TEXT).mapNotNull { it.filterForced() }
 
 /**
  * Audio tracks.
@@ -28,4 +29,30 @@ val Tracks.video: List<Tracks.Group>
 
 private fun Tracks.filterByTrackType(trackType: @TrackType Int): List<Tracks.Group> {
     return groups.filter { it.type == trackType }
+}
+
+@Suppress("SpreadOperator", "ReturnCount")
+private fun Tracks.Group.filterForced(): Tracks.Group? {
+    if (type != C.TRACK_TYPE_TEXT) return this
+    if (length == 1 && getTrackFormat(0).isForced()) return null
+    val listIndexNotForced = ArrayList<Int>(length)
+    for (i in 0 until length) {
+        val track = getTrackFormat(i)
+        if (!track.isForced()) {
+            listIndexNotForced.add(i)
+        }
+    }
+    if (listIndexNotForced.size == length) return this
+    val count = listIndexNotForced.size
+    val formats = Array(count) {
+        getTrackFormat(listIndexNotForced[it])
+    }
+    val trackSupport = Array(count) {
+        getTrackSupport(listIndexNotForced[it])
+    }
+    val trackEnabled = Array(count) {
+        isTrackSelected(listIndexNotForced[it])
+    }
+    val trackGroup = TrackGroup(mediaTrackGroup.id, *formats)
+    return Tracks.Group(trackGroup, isAdaptiveSupported, trackSupport.toIntArray(), trackEnabled.toBooleanArray())
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestTracksExtension.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestTracksExtension.kt
@@ -30,6 +30,8 @@ class TestTracksExtension {
                 createFormatTrackFormat("t1-sdh", mimeType = TEXT_MIME_TYPE, roleFlags = C.ROLE_FLAG_DESCRIBES_MUSIC_AND_SOUND),
             ),
         ),
+    )
+    private val listForcedSubtitles = listOf(
         createTrackGroup(
             listOf(
                 createFormatTrackFormat("t1-forced", mimeType = TEXT_MIME_TYPE, selectionFlags = C.SELECTION_FLAG_FORCED),
@@ -58,7 +60,7 @@ class TestTracksExtension {
             ),
         ),
     )
-    private val tracks = Tracks(listAudios + listTextTracks + listVideos)
+    private val tracks = Tracks(listAudios + listTextTracks + listVideos + listForcedSubtitles)
 
     @Test
     fun testTextTracks() {


### PR DESCRIPTION
# Pull request

## Description

Improve handling of forced subtitles. Forced subtitle are special subtitles that are displayed in the same language of the current audio track and are always displayed if no other subtitles are selected.

## Changes made

Changing audio and text tracks state has been changed. Now they setup TrackSelectionParameters with parameters that fit the need of forced subtitles.

Related to :  https://github.com/SRGSSR/pillarbox-android/pull/199

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
