### PR TITLE
Reflet AD from AccessibilityManager settings user preference

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/DemoItem.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/DemoItem.kt
@@ -137,6 +137,11 @@ data class DemoItem(
             uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8"
         )
 
+        val AppleWWDC_2023 = DemoItem(
+            title = "Apple WWDC Keynote 2023",
+            uri = "https://events-delivery.apple.com/0105cftwpxxsfrpdwklppzjhjocakrsk/m3u8/vod_index-PQsoJoECcKHTYzphNkXohHsQWACugmET.m3u8"
+        )
+
         val GoogleDashH264 = DemoItem(
             title = "VoD - Dash (H264)",
             uri = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd"

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Playlist.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/data/Playlist.kt
@@ -204,6 +204,7 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem.AppleAdvanced_16_9_TS_HLS,
                 DemoItem.AppleAdvanced_16_9_fMP4_HLS,
                 DemoItem.AppleAdvanced_16_9_HEVC_h264_HLS,
+                DemoItem.AppleWWDC_2023
             )
         )
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
@@ -116,7 +116,7 @@ class DemoMediaLibraryService : PillarboxMediaLibraryService() {
              * For MediaItem with only id, like urn, it is fine. But one with uri not, as the localConfiguration is null here.
              * We have to get the orignal mediaItem with uri set.
              */
-            return Futures.immediateFuture(mediaItems.map { demoBrowser.getMediaItemFromId(it.mediaId)!! }.toMutableList())
+            return Futures.immediateFuture(mediaItems.map { demoBrowser.getMediaItemFromId(it.mediaId) ?: it }.toMutableList())
         }
 
         override fun onSearch(

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayer.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayer.kt
@@ -5,6 +5,7 @@
 package ch.srgssr.pillarbox.demo.ui.player
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.SideEffect
@@ -35,7 +36,7 @@ import com.google.accompanist.systemuicontroller.rememberSystemUiController
  * @param pictureInPictureClick he picture in picture button action. If null no button.
  * @param displayPlaylist If it displays playlist ui or not.
  */
-@OptIn(ExperimentalMaterialNavigationApi::class)
+@OptIn(ExperimentalMaterialNavigationApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun DemoPlayer(
     player: Player,
@@ -50,9 +51,6 @@ fun DemoPlayer(
         modifier = modifier,
         bottomSheetNavigator = bottomSheetNavigator
     ) {
-        if (!bottomSheetNavigator.navigatorSheetState.isVisible) {
-            navController.popBackStack()
-        }
         NavHost(navController, startDestination = "player") {
             composable(route = "player") {
                 PlayerContent(

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -10,6 +10,7 @@ import androidx.media3.common.PlaybackException
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline.Window
+import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.datasource.DataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.DefaultLoadControl
@@ -17,9 +18,11 @@ import androidx.media3.exoplayer.DefaultRenderersFactory
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.LoadControl
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import androidx.media3.exoplayer.trackselection.DefaultTrackSelector
 import androidx.media3.exoplayer.upstream.DefaultBandwidthMeter
 import androidx.media3.exoplayer.util.EventLogger
 import ch.srgssr.pillarbox.player.data.MediaItemSource
+import ch.srgssr.pillarbox.player.extension.setPreferredAudioRoleFlagsToAccessibilityManagerSettings
 import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerProvider
@@ -81,6 +84,14 @@ class PillarboxPlayer internal constructor(
                 PillarboxMediaSourceFactory(
                     mediaItemSource = mediaItemSource,
                     defaultMediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory)
+                )
+            )
+            .setTrackSelector(
+                DefaultTrackSelector(
+                    context,
+                    TrackSelectionParameters.Builder(context)
+                        .setPreferredAudioRoleFlagsToAccessibilityManagerSettings(context)
+                        .build()
                 )
             )
             .setDeviceVolumeControlEnabled(true) // allow player to control device volume


### PR DESCRIPTION
# Pull request

## Description

By default TrackSelectionParameters will take in count Accessibility audio description preferences. This feature is introduce since api level >= 30.

## Changes made

- Default audio tracks use Accessibility audio description preference.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
