### PR TITLE
Fix viewAspectRatio badly computed

### DIFF
--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/AspectRatioBox.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/AspectRatioBox.kt
@@ -50,7 +50,7 @@ internal fun getContentConstraints(constraints: Constraints, aspectRatio: Float?
     }
     val width = constraints.minWidth.coerceAtLeast(constraints.maxWidth)
     val height = constraints.minHeight.coerceAtLeast(constraints.maxHeight)
-    val viewAspectRatio = width / height.coerceAtLeast(1)
+    val viewAspectRatio = width / height.coerceAtLeast(1).toFloat()
     val aspectDeformation: Float = aspectRatio / viewAspectRatio - 1
     return when (scaleMode) {
         ScaleMode.Fit -> {
@@ -63,6 +63,7 @@ internal fun getContentConstraints(constraints: Constraints, aspectRatio: Float?
             }
             Constraints.fixed(contentWidth, contentHeight)
         }
+
         ScaleMode.Crop, ScaleMode.Zoom -> {
             var contentWidth = width
             var contentHeight = height
@@ -73,6 +74,7 @@ internal fun getContentConstraints(constraints: Constraints, aspectRatio: Float?
             }
             Constraints.fixed(contentWidth, contentHeight)
         }
+
         else -> {
             constraints
         }
@@ -104,11 +106,13 @@ internal fun contentViewMeasurePolicy(aspectRatio: Float?, scaleMode: ScaleMode,
                         x = -(placeable.width / 2f).roundToInt() + size.width / 2
                         y = -(placeable.height / 2f).roundToInt() + size.height / 2
                     }
+
                     ScaleMode.Fit -> {
                         val offset = contentAlignment.align(IntSize(placeable.width, placeable.height), size, LayoutDirection.Ltr)
                         x = offset.x
                         y = offset.y
                     }
+
                     else -> {}
                 }
                 placeable.place(x, y, 0f)


### PR DESCRIPTION
## Description

Fix issue when displaying a 4:3 video in the demo with playlist view. The video aspect ratio was incorrectly computed and so the video may be displayed outside its parent.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
