### PR TITLE
Always send uptime for livestreams

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -163,7 +163,6 @@ internal class CommandersActStreaming(
     }
 
     private fun notifyUptime(position: Duration) {
-        if (getTimeshift(position) > LIVE_EDGE_THRESHOLD) return
         notifyEvent(MediaEventType.Uptime, position)
     }
 
@@ -204,6 +203,5 @@ internal class CommandersActStreaming(
         internal var UPTIME_PERIOD = 60.seconds
         internal var POS_PERIOD = 30.seconds
         private const val VALID_SEEK_THRESHOLD: Long = 1000L
-        private val LIVE_EDGE_THRESHOLD = 60.seconds
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -59,7 +59,7 @@ internal class CommandersActStreaming(
                     notifyPos(player.currentPosition.milliseconds)
                 }
             }.also {
-                if (!player.isCurrentMediaItemLive) return
+                if (!player.isCurrentMediaItemLive) return@also
                 it.scheduleAtFixedRate(HEART_BEAT_DELAY.inWholeMilliseconds, period = UPTIME_PERIOD.inWholeMilliseconds) {
                     MainScope().launch(Dispatchers.Main) {
                         notifyUptime(player.currentPosition.milliseconds)


### PR DESCRIPTION
## Description

After some investigation and asked ADI team, we have to send `uptime` event when playing live stream. This event is always send regardless it is live with dvr and/or stream is time shifted.

## Changes made

- Always send uptime event when stream is live or live with dvr.
- Fix heart beat doesn't stop when playing on demand content.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
