### PR TITLE
197 improve subtitles UI

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerSurface.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerSurface.kt
@@ -45,9 +45,16 @@ fun DemoPlayerSurface(
             player = player,
             scaleMode = scaleMode,
             defaultAspectRatio = defaultAspectRatio,
-            surfaceContent = surfaceContent
+            surfaceContent = {
+                if (scaleMode == ScaleMode.Fit) {
+                    ExoPlayerSubtitleView(modifier = Modifier.matchParentSize(), player = player)
+                }
+                surfaceContent?.invoke()
+            }
         )
-        ExoPlayerSubtitleView(modifier = Modifier.matchParentSize(), player = player)
+        if (scaleMode != ScaleMode.Fit) {
+            ExoPlayerSubtitleView(modifier = Modifier.matchParentSize(), player = player)
+        }
         content.invoke(this)
     }
 }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurface.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
 import androidx.media3.common.Player
 
 /**
@@ -32,7 +33,7 @@ fun PlayerSurface(
         defaultAspectRatio = defaultAspectRatio ?: 0.0f
     )
     AspectRatioBox(
-        modifier = modifier,
+        modifier = Modifier.clipToBounds().then(modifier),
         aspectRatio = videoAspectRatio,
         scaleMode = scaleMode,
         contentAlignment = contentAlignment


### PR DESCRIPTION
# Pull request

## Description

Improve subtitles display in Pillarbox demo.

## Changes made

- Subtitles are displayed on the player surface when player scale mode is set to fit.
- Subtitles fit the container if player scale mode is not set to fit. So the subtitles won't be clipped anymore.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
