### PR TITLE
217 load mediacomposition without segments

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionDataSourceImpl.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionDataSourceImpl.kt
@@ -28,7 +28,7 @@ class MediaCompositionDataSourceImpl(private val mediaCompositionService: MediaC
 
     override suspend fun getMediaCompositionByUrn(urn: String): RemoteResult<MediaComposition> {
         return try {
-            val result = mediaCompositionService.getMediaCompositionByUrn(urn)
+            val result = mediaCompositionService.getMediaCompositionByUrn(urn, true)
             RemoteResult.Success(result)
         } catch (e: HttpException) {
             RemoteResult.Error(e, e.code())

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionService.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionService.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.core.business.integrationlayer.service
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
 import retrofit2.http.GET
 import retrofit2.http.Path
+import retrofit2.http.Query
 
 /**
  * Retrofit media composition service from Integration layer
@@ -16,8 +17,9 @@ interface MediaCompositionService {
     /**
      * Get MediaComposition by urn
      *
-     * @param urn of the content
+     * @param urn Urn of the content.
+     * @param onlyChapters Only chapters, no segments are delivered.
      */
     @GET("integrationlayer/2.1/mediaComposition/byUrn/{urn}")
-    suspend fun getMediaCompositionByUrn(@Path("urn") urn: String): MediaComposition
+    suspend fun getMediaCompositionByUrn(@Path("urn") urn: String, @Query("onlyChapters") onlyChapters: Boolean? = null): MediaComposition
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionService.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionService.kt
@@ -21,5 +21,5 @@ interface MediaCompositionService {
      * @param onlyChapters Only chapters, no segments are delivered.
      */
     @GET("integrationlayer/2.1/mediaComposition/byUrn/{urn}")
-    suspend fun getMediaCompositionByUrn(@Path("urn") urn: String, @Query("onlyChapters") onlyChapters: Boolean? = null): MediaComposition
+    suspend fun getMediaCompositionByUrn(@Path("urn") urn: String, @Query("onlyChapters") onlyChapters: Boolean = true): MediaComposition
 }


### PR DESCRIPTION
# Pull request

## Description

When playing a segment urn, the played media is the segment related media and not the full length media.

## Changes made

- Add query parameter `onlyChapter` to `MediaCompositionService`.
- `MediaCompositionDataSourceImpl` load MediaComposition without segments.


## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
