### PR TITLE
198 tracks selection analytics

### DIFF
--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
@@ -70,10 +70,10 @@ class TCMediaEvent(
         jsonObject.putIfValid(MEDIA_PLAYER_DISPLAY, PLAYER_DISPLAY_NAME)
         jsonObject.putIfValid(MEDIA_SUBTITLES_ON, isSubtitlesOn.toString())
         subtitleSelectionLanguage?.let {
-            jsonObject.putIfValid(MEDIA_SUBTITLE_SELECTION, it)
+            jsonObject.putIfValid(MEDIA_SUBTITLE_SELECTION, it.uppercase())
         }
         audioTrackLanguage?.let {
-            jsonObject.putIfValid(MEDIA_AUDIO_TRACK, it)
+            jsonObject.putIfValid(MEDIA_AUDIO_TRACK, it.uppercase())
         }
 
         return jsonObject

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -13,6 +13,7 @@ import ch.srgssr.pillarbox.analytics.commandersact.CommandersAct
 import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType
 import ch.srgssr.pillarbox.analytics.commandersact.TCMediaEvent
 import ch.srgssr.pillarbox.core.business.tracker.TotalPlaytimeCounter
+import ch.srgssr.pillarbox.player.extension.audio
 import ch.srgssr.pillarbox.player.utils.DebugLogger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.MainScope
@@ -186,12 +187,14 @@ internal class CommandersActStreaming(
         event.isSubtitlesOn = isSubtitlesOn
     }
 
+    @Suppress("SwallowedException")
     private fun handleAudioTrack(event: TCMediaEvent) {
-        // TODO handle Audio track analytics
-        val currentAudioTrack: Format? = null
-        currentAudioTrack?.let { track ->
-            // TODO retrieve the language
-            event.audioTrackLanguage = VALUE_UNKNOWN_LANGUAGE
+        try {
+            val selectedAudioGroup = player.currentTracks.audio.first { it.isSelected }
+            val selectedFormat: Format = selectedAudioGroup.getTrackFormat(0)
+            event.audioTrackLanguage = selectedFormat.language ?: C.LANGUAGE_UNDETERMINED
+        } catch (e: NoSuchElementException) {
+            event.audioTrackLanguage = null
         }
     }
 

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -184,8 +184,13 @@ internal class CommandersActStreaming(
                 it.type == C.TRACK_TYPE_TEXT && it.isSelected
             }
             val selectedFormat: Format = selectedTextGroup.getTrackFormat(0)
-            event.subtitleSelectionLanguage = selectedFormat.language ?: C.LANGUAGE_UNDETERMINED
-            event.isSubtitlesOn = !selectedFormat.isForced()
+            if (selectedFormat.isForced()) {
+                event.isSubtitlesOn = false
+                event.subtitleSelectionLanguage = null
+            } else {
+                event.subtitleSelectionLanguage = selectedFormat.language ?: C.LANGUAGE_UNDETERMINED
+                event.isSubtitlesOn = true
+            }
         } catch (e: NoSuchElementException) {
             event.isSubtitlesOn = false
             event.subtitleSelectionLanguage = null

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -199,13 +199,12 @@ internal class CommandersActStreaming(
             val selectedFormat: Format = selectedAudioGroup.getTrackFormat(0)
             event.audioTrackLanguage = selectedFormat.language ?: C.LANGUAGE_UNDETERMINED
         } catch (e: NoSuchElementException) {
-            event.audioTrackLanguage = null
+            event.audioTrackLanguage = C.LANGUAGE_UNDETERMINED
         }
     }
 
     companion object {
         private const val TAG = "CommandersActTracker"
-        const val VALUE_UNKNOWN_LANGUAGE = "UND"
 
         internal var HEART_BEAT_DELAY = 30.seconds
         internal var UPTIME_PERIOD = 60.seconds


### PR DESCRIPTION
## Description

The goal of this pull request is to send to CommandersAct current audio and subtitle track selection. When the current subtitle track is forced, it has to be ignored. When audio track is disabled, always send `UND`.


## Changes made

- Handle audio and subtitles current track selection in `CommandersActStreaming.`

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
