### PR TITLE
Block media if at least one segment has a block reason.

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
@@ -67,12 +67,11 @@ class MediaCompositionMediaItemSource(
         require(!MediaUrn.isValid(mediaUri.toString())) { "Uri can't be a urn" }
         val result = mediaCompositionDataSource.getMediaCompositionByUrn(mediaItem.mediaId).getOrThrow()
         val chapter = result.mainChapter
-        if (!chapter.blockReason.isNullOrEmpty()) {
-            throw BlockReasonException(chapter.blockReason)
+        chapter.blockReason?.let {
+            throw BlockReasonException(it)
         }
-        val blockedSegment = chapter.listSegment?.firstOrNull { !it.blockReason.isNullOrEmpty() }
-        if (blockedSegment != null) {
-            throw BlockReasonException(blockedSegment.blockReason!!)
+        chapter.listSegment?.firstNotNullOfOrNull { it.blockReason }?.let {
+            throw BlockReasonException(it)
         }
 
         val resource = resourceSelector.selectResourceFromChapter(chapter) ?: throw ResourceNotFoundException

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
@@ -70,6 +70,11 @@ class MediaCompositionMediaItemSource(
         if (!chapter.blockReason.isNullOrEmpty()) {
             throw BlockReasonException(chapter.blockReason)
         }
+        val blockedSegment = chapter.listSegment?.firstOrNull { !it.blockReason.isNullOrEmpty() }
+        if (blockedSegment != null) {
+            throw BlockReasonException(blockedSegment.blockReason!!)
+        }
+
         val resource = resourceSelector.selectResourceFromChapter(chapter) ?: throw ResourceNotFoundException
         var uri = Uri.parse(resource.url)
         if (resource.tokenType == Resource.TokenType.AKAMAI) {

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/SRGErrorMessageProvider.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/SRGErrorMessageProvider.kt
@@ -20,7 +20,7 @@ class SRGErrorMessageProvider : ErrorMessageProvider<PlaybackException> {
     override fun getErrorMessage(throwable: PlaybackException): Pair<Int, String> {
         return when (val cause = throwable.cause) {
             is BlockReasonException -> {
-                Pair.create(0, cause.blockReason)
+                Pair.create(0, cause.blockReason.name)
             }
             // When using MediaController, RemoteException is send instead of HttpException.
             is RemoteException ->

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
@@ -4,12 +4,16 @@
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data
 
-import kotlinx.serialization.Serializable
-
 /**
- * Segment
- *
- * @property blockReason
+ * Block reason
  */
-@Serializable
-data class Segment(val blockReason: BlockReason? = null)
+enum class BlockReason {
+    GEOBLOCK,
+    LEGAL,
+    COMMERCIAL,
+    AGERATING18,
+    AGERATING12,
+    STARTDATE,
+    ENDDATE,
+    UNKNOWN,
+}

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReasonException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReasonException.kt
@@ -7,6 +7,6 @@ package ch.srgssr.pillarbox.core.business.integrationlayer.data
 /**
  * Block reason exception
  *
- * @property blockReason the reason a [Chapter] is blocked.
+ * @property blockReason the reason a [Chapter] or a [Segment] is blocked.
  */
-class BlockReasonException(val blockReason: String) : RuntimeException(blockReason)
+class BlockReasonException(val blockReason: BlockReason) : RuntimeException(blockReason.name)

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Chapter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Chapter.kt
@@ -28,7 +28,7 @@ data class Chapter(
     val imageUrl: String,
     val lead: String? = null,
     val description: String? = null,
-    val blockReason: String? = null,
+    val blockReason: BlockReason? = null,
     @SerialName("segmentList")
     val listSegment: List<Segment>? = null,
     @SerialName("resourceList") val listResource: List<Resource>? = null,

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Chapter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Chapter.kt
@@ -16,6 +16,7 @@ import kotlinx.serialization.Serializable
  * @property lead
  * @property description
  * @property blockReason
+ * @property listSegment
  * @property listResource
  * @property comScoreAnalyticsLabels
  * @property analyticsLabels
@@ -28,6 +29,8 @@ data class Chapter(
     val lead: String? = null,
     val description: String? = null,
     val blockReason: String? = null,
+    @SerialName("segmentList")
+    val listSegment: List<Segment>? = null,
     @SerialName("resourceList") val listResource: List<Resource>? = null,
     @SerialName("analyticsData")
     override val comScoreAnalyticsLabels: Map<String, String>? = null,

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Segment.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Segment.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.core.business.integrationlayer.data
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Segment
+ *
+ * @property blockReason
+ */
+@Serializable
+data class Segment(val blockReason: String? = null)

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSourceTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSourceTest.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.core.business
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import ch.srgssr.pillarbox.core.business.integrationlayer.data.BlockReason
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.BlockReasonException
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
@@ -145,7 +146,7 @@ class MediaCompositionMediaItemSourceTest {
                 URN_BLOCK_REASON -> {
                     val chapter = Chapter(
                         urn = urn,
-                        title = "Blocked media", blockReason = "A block reason",
+                        title = "Blocked media", blockReason = BlockReason.UNKNOWN,
                         listResource = listOf(createResource(Resource.Type.HLS)),
                         imageUrl = DUMMY_IMAGE_URL,
                         listSegment = listOf(Segment(), Segment())
@@ -160,7 +161,7 @@ class MediaCompositionMediaItemSourceTest {
                         blockReason = null,
                         listResource = listOf(createResource(Resource.Type.HLS)),
                         imageUrl = DUMMY_IMAGE_URL,
-                        listSegment = listOf(Segment(), Segment("SEGMENT_BLOCK_REASON"))
+                        listSegment = listOf(Segment(), Segment(blockReason = BlockReason.UNKNOWN))
                     )
                     Result.success(MediaComposition(chapterUrn = urn, listChapter = listOf(chapter)))
                 }

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.core.business
 
+import ch.srgssr.pillarbox.core.business.integrationlayer.data.BlockReason
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
 import kotlinx.serialization.SerializationException
@@ -13,27 +14,34 @@ import org.junit.Test
 
 class TestJsonSerialization {
 
-    val jsonSerializer = Json { ignoreUnknownKeys = true }
+    private val jsonSerializer = Json { ignoreUnknownKeys = true }
 
     @Test
     fun testChapterValidJson() {
-        val json = "{\"urn\":\"urn:srf:video:12343\",\"title\":\"Chapter title\",\"imageUrl\":\"https://image.png\"}"
+        val json = "{\"urn\":\"urn:srf:video:12343\",\"title\":\"Chapter title\",\"imageUrl\":\"https://image.png\",\"blockReason\": \"UNKNOWN\"}"
         val chapter = jsonSerializer.decodeFromString<Chapter>(json)
         Assert.assertNotNull(chapter)
+        Assert.assertEquals(BlockReason.UNKNOWN, chapter.blockReason)
+    }
+
+    @Test(expected = SerializationException::class)
+    fun testChapterValidJsonUnknownBlockreason() {
+        val json = "{\"urn\":\"urn:srf:video:12343\",\"title\":\"Chapter title\",\"imageUrl\":\"https://image.png\",\"blockReason\": \"TOTO\"}"
+        val chapter = jsonSerializer.decodeFromString<Chapter>(json)
+        Assert.assertNotNull(chapter)
+        Assert.assertNotNull(chapter.blockReason)
     }
 
     @Test(expected = SerializationException::class)
     fun testChapterWithNullUrnJson() {
         val json = "{\"title\":\"Chapter title\",\"imageUrl\":\"https://image.png\"}"
-        val chapter = jsonSerializer.decodeFromString<Chapter>(json)
-        Assert.assertNotNull(chapter)
+        jsonSerializer.decodeFromString<Chapter>(json)
     }
 
     @Test(expected = SerializationException::class)
     fun testMediaCompositionWithInvalidJson() {
         val json = "{\"title\":\"Chapter title\",\"imageUrl\":\"https://image.png\"}"
-        val mediaComposition = jsonSerializer.decodeFromString<MediaComposition>(json)
-        Assert.assertNotNull(mediaComposition)
+        jsonSerializer.decodeFromString<MediaComposition>(json)
     }
 
     @Test(expected = SerializationException::class)


### PR DESCRIPTION
## Description

Self-explanatory

## Changes made
- Parse `Segment` block reason only in `Chapter`.
- Block reason is parsed as `BlockReason` enum instead of a string.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
