### PR TITLE
Revert "Enable gradle cache (#241)"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,9 +7,6 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# Enable gradle cache
-# https://docs.gradle.org/current/userguide/configuration_cache.html
-org.gradle.configuration-cache=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
@@ -26,4 +23,3 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.nonFinalResIds=false
 android.defaults.buildfeatures.buildconfig = true
-org.gradle.unsafe.configuration-cache=true

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -5,6 +5,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.kapt)
     `maven-publish`
 }
 


### PR DESCRIPTION
## Description

Revert commit 63f02c9e43bef8857b3f27b9c9221ab6abcb76e6 that breaks release workflow. Gradle configuration cache make update package to fail. It can read github token en username.

## Changes made

This reverts commit 63f02c9e43bef8857b3f27b9c9221ab6abcb76e6.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
