### PR TITLE
Cache Bitmap to avoid image reload on android 10.

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
@@ -8,36 +8,37 @@ import android.app.PendingIntent
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.net.Uri
 import android.text.TextUtils
+import android.util.LruCache
 import androidx.media3.common.Player
 import androidx.media3.ui.PlayerNotificationManager
 import androidx.media3.ui.PlayerNotificationManager.MediaDescriptionAdapter
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.MainScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import java.net.URL
 
 /**
- * Pillarbox media description adapter that handle image loading with Glide.
+ * Pillarbox media description adapter
  *
- * @property context
- * @property pendingIntent
+ * @property pendingIntent [PendingIntent] to use when a user click the notification.
+ * @constructor
+ *
+ * @param context Context of the application.
  */
-class PillarboxMediaDescriptionAdapter(private val context: Context, private val pendingIntent: PendingIntent?) : MediaDescriptionAdapter {
+class PillarboxMediaDescriptionAdapter(private val pendingIntent: PendingIntent?, context: Context) : MediaDescriptionAdapter {
     private val imageMaxWidth: Int = context.resources.getDimensionPixelSize(
         androidx.media3.ui.R.dimen
             .compat_notification_large_icon_max_width
     )
     private val imageMaxHeight: Int = context.resources.getDimensionPixelSize(androidx.media3.ui.R.dimen.compat_notification_large_icon_max_height)
-    private var job: Job? = null
+    private val bitmapCache = LruCache<Uri, Bitmap>(3)
 
     override fun getCurrentContentTitle(player: Player): CharSequence {
         val displayTitle = player.mediaMetadata.displayTitle
         if (!TextUtils.isEmpty(displayTitle)) {
             return displayTitle!!
         }
-
         val title = player.mediaMetadata.title
         return title ?: ""
     }
@@ -54,25 +55,39 @@ class PillarboxMediaDescriptionAdapter(private val context: Context, private val
     }
 
     override fun getCurrentLargeIcon(player: Player, callback: PlayerNotificationManager.BitmapCallback): Bitmap? {
-        job?.cancel()
-        job = null
-        return if (player.mediaMetadata.artworkData != null) {
-            val data = player.mediaMetadata.artworkData!!
-            BitmapFactory.decodeByteArray(data, /* offset= */0, data.size)
-        } else if (player.mediaMetadata.artworkUri != null) {
-            val imageUri = player.mediaMetadata.artworkUri!!
-            val imageUrl = URL(imageUri.toString())
-            val opts = BitmapFactory.Options().apply {
-                outWidth = imageMaxWidth
-                outHeight = imageMaxHeight
+        return when {
+            player.mediaMetadata.artworkData != null -> {
+                val data = player.mediaMetadata.artworkData!!
+                BitmapFactory.decodeByteArray(data, /* offset= */0, data.size)
             }
-            job = MainScope().launch(Dispatchers.IO) {
-                val bitmap = BitmapFactory.decodeStream(imageUrl.openStream(), null, opts)
-                bitmap?.let { callback.onBitmap(bitmap) }
+
+            player.mediaMetadata.artworkUri != null -> {
+                val imageUri = player.mediaMetadata.artworkUri!!
+                val artworkBitmap = bitmapCache.get(imageUri)
+                if (artworkBitmap == null) {
+                    loadBitmapFromUri(imageUri, callback)
+                }
+                artworkBitmap // FIXME could return placeholder.
             }
-            null
-        } else {
-            null
+
+            else -> {
+                null // FIXME could return placeholder.
+            }
+        }
+    }
+
+    private fun loadBitmapFromUri(imageUri: Uri, callback: PlayerNotificationManager.BitmapCallback) {
+        val imageUrl = URL(imageUri.toString())
+        val opts = BitmapFactory.Options().apply {
+            outWidth = imageMaxWidth
+            outHeight = imageMaxHeight
+        }
+        runBlocking(Dispatchers.IO) {
+            val bitmap = BitmapFactory.decodeStream(imageUrl.openStream(), null, opts)
+            bitmap?.let {
+                bitmapCache.put(imageUri, it)
+                callback.onBitmap(it)
+            }
         }
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxNotificationManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxNotificationManager.kt
@@ -33,7 +33,7 @@ object PillarboxNotificationManager {
          */
         fun setMediaSession(mediaSession: MediaSession): Builder {
             this.mediaSession = mediaSession
-            setMediaDescriptionAdapter(PillarboxMediaDescriptionAdapter(context, mediaSession.sessionActivity))
+            setMediaDescriptionAdapter(PillarboxMediaDescriptionAdapter(context = context, pendingIntent = mediaSession.sessionActivity))
             return this
         }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PlaybackService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PlaybackService.kt
@@ -61,7 +61,7 @@ abstract class PlaybackService : Service() {
         return PlayerNotificationManager.Builder(this, DEFAULT_NOTIFICATION_ID, DEFAULT_CHANNEL_ID)
             .setChannelImportance(NotificationUtil.IMPORTANCE_LOW)
             .setChannelNameResourceId(androidx.media3.session.R.string.default_notification_channel_name)
-            .setMediaDescriptionAdapter(PillarboxMediaDescriptionAdapter(this, pendingIntent()))
+            .setMediaDescriptionAdapter(PillarboxMediaDescriptionAdapter(context = this, pendingIntent = pendingIntent()))
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
# Pull request

## Description

On some device, tested on Android 10 device, the artwork image is flickering when playback state changed. This PR fixe the issue by adding a Lru Bitmap cache. We choose to cache 3 bitmaps.

## Changes made

- Add Lru cache for notification image in `PillarboxMediaDescriptionAdapter`.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
