### PR TITLE
Demo multiple drm stream not working on some device.

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.ui.player.DemoPlayerSurface
+import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerError
 import ch.srgssr.pillarbox.demo.ui.player.controls.PlayingControls
+import ch.srgssr.pillarbox.ui.playerErrorAsState
 
 /**
  * Demo of 2 player swapping view
@@ -82,6 +84,17 @@ fun MultiPlayer() {
 
 @Composable
 private fun PlayerView(player: Player, modifier: Modifier) {
+    val playbackError = player.playerErrorAsState()
+    if (playbackError != null) {
+        PlayerError(
+            modifier = modifier,
+            playerError = playbackError
+        ) {
+            player.prepare()
+            player.play()
+        }
+        return
+    }
     DemoPlayerSurface(modifier = modifier, player = player) {
         PlayingControls(modifier = Modifier.matchParentSize(), player = player, autoHideEnabled = false)
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayerViewModel.kt
@@ -6,8 +6,8 @@ package ch.srgssr.pillarbox.demo.ui.showcases.multiplayer
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
-import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import ch.srgssr.pillarbox.demo.data.DemoItem
 import ch.srgssr.pillarbox.demo.di.PlayerModule
 
 /**
@@ -21,8 +21,14 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
     private val player2 = PlayerModule.provideDefaultPlayer(application)
 
     init {
-        player1.setMediaItem(MediaItem.Builder().setMediaId("urn:rts:video:6820736").build())
-        player2.setMediaItem(MediaItem.fromUri("https://storage.googleapis.com/wvmedia/clear/hevc/tears/tears.mpd"))
+        /*
+         * On some device playing drm content on multiple player may not work.
+         * One of the player will receive a PlaybackException with ERROR_CODE_DECODER_INIT_FAILED.
+         * It may happen on low hand device like :
+         *  - Samsung Galaxy A13
+         */
+        player1.setMediaItem(DemoItem.LiveVideo.toMediaItem())
+        player2.setMediaItem(DemoItem.DvrVideo.toMediaItem())
         preparePlayer(player1)
         preparePlayer(player2)
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayerViewModel.kt
@@ -22,10 +22,9 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
 
     init {
         /*
-         * On some device playing drm content on multiple player may not work.
-         * One of the player will receive a PlaybackException with ERROR_CODE_DECODER_INIT_FAILED.
-         * It may happen on low hand device like :
-         *  - Samsung Galaxy A13
+         * On some devices playing DRM content on multiple players may not work.
+         * One of the players will receive a PlaybackException with ERROR_CODE_DECODER_INIT_FAILED.
+         * It may happen on low-end devices like Samsung Galaxy A13, for example.
          */
         player1.setMediaItem(DemoItem.LiveVideo.toMediaItem())
         player2.setMediaItem(DemoItem.DvrVideo.toMediaItem())

--- a/pillarbox-player/docs/README.md
+++ b/pillarbox-player/docs/README.md
@@ -20,8 +20,8 @@ More information can be found on the [top level README](../docs/README.md)
 - [Tracking](./MediaItemTracking.md)
 
 ## Known issues
-- Playing DRM content on two instance of `PillarboxPlayer` is not supported on all devices.
-  - Current known devices: Samsung Galaxy A13
+- Playing DRM content on two instances of `PillarboxPlayer` is not supported on all devices.
+  - Currently known device: Samsung Galaxy A13
 
 ## Getting started
 

--- a/pillarbox-player/docs/README.md
+++ b/pillarbox-player/docs/README.md
@@ -19,6 +19,10 @@ More information can be found on the [top level README](../docs/README.md)
 - [Getting started](#getting-started)
 - [Tracking](./MediaItemTracking.md)
 
+## Known issues
+- Playing DRM content on two instance of `PillarboxPlayer` is not supported on all devices.
+  - Current known devices: Samsung Galaxy A13
+
 ## Getting started
 
 ### Create a MediaItemSource

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurfaceView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/PlayerSurfaceView.kt
@@ -7,7 +7,6 @@ package ch.srgssr.pillarbox.ui
 import android.content.Context
 import android.view.SurfaceView
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.viewinterop.AndroidView
@@ -19,9 +18,12 @@ import androidx.media3.common.Player
  * @param player The player to render on the SurfaceView.
  * @param modifier The modifier to be applied to the layout.
  */
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun PlayerSurfaceView(player: Player, modifier: Modifier = Modifier) {
+    val playerError = player.playerErrorAsState()
+    if (playerError != null) {
+        return
+    }
     AndroidView(
         /*
          * On some devices (Pixel 2 XL Android 11)


### PR DESCRIPTION
## Description

Update demo with multiplayer with two DRM content. It demonstrate that on some device it is not supported.

## Changes made
- Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
