### PR TITLE
Android 14 support

### DIFF
--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -6,7 +6,7 @@ import java.util.*
 
 object AppConfig {
     const val minSdk = 21
-    const val targetSdk = 33
+    const val targetSdk = 34
     const val compileSdk = 34
     // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
     const val composeCompiler = "1.5.1"

--- a/pillarbox-analytics/build.gradle.kts
+++ b/pillarbox-analytics/build.gradle.kts
@@ -14,7 +14,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        targetSdk = AppConfig.targetSdk
         version = VersionConfig.versionName()
         group = VersionConfig.GROUP
 

--- a/pillarbox-core-business/build.gradle.kts
+++ b/pillarbox-core-business/build.gradle.kts
@@ -15,7 +15,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        targetSdk = AppConfig.targetSdk
         version = VersionConfig.versionName()
         group = VersionConfig.GROUP
 

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
     <application
         android:name=".DemoApplication"
         android:allowBackup="true"

--- a/pillarbox-player-testutils/build.gradle.kts
+++ b/pillarbox-player-testutils/build.gradle.kts
@@ -13,7 +13,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        targetSdk = AppConfig.targetSdk
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -14,7 +14,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        targetSdk = AppConfig.targetSdk
         version = VersionConfig.versionName()
         group = VersionConfig.GROUP
 

--- a/pillarbox-player/docs/README.md
+++ b/pillarbox-player/docs/README.md
@@ -138,6 +138,12 @@ And enable foreground service in the top of the manifest:
 <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 ```
 
+And since Android 14 (targetApiVersion = 34) a new permission have to be added:
+
+```xml
+<uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+```
+
 Then in the code you have to use `MediaController` to handle playback, not `PillarboxPlayer`. Pillarbox provide an easy way to retrieve that
 `MediaController` with `MediaControllerConnection`.
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaLibraryService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaLibraryService.kt
@@ -22,6 +22,7 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  *
  * ```xml
  *      <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+ *      <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
  * ```
  * And add your PlaybackService to the application manifest as follow :
  *

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaSessionService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaSessionService.kt
@@ -24,6 +24,8 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  *
  * ```xml
  *      <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+ *      <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+ *
  * ```
  * And add your PlaybackService to the application manifest as follow :
  *

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PlaybackService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PlaybackService.kt
@@ -25,6 +25,8 @@ import ch.srgssr.pillarbox.player.notification.PillarboxMediaDescriptionAdapter
  *
  * ```xml
  *      <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+ *      <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+ *
  * ```
  * And add your PlaybackService to the application manifest as follow :
  *

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -15,7 +15,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        targetSdk = AppConfig.targetSdk
         version = VersionConfig.versionName()
         group = VersionConfig.GROUP
 


### PR DESCRIPTION
# Pull request

## Description

Add support for the upcoming Android 14 (sdk version 34).

## Changes made

- Add required permission to the demo manifest. `android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK`.

Service permission for background playback are not set in the library manifest as not all application needs them.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
