### PR TITLE
Send pause when no surface is connected to player

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
@@ -35,8 +35,8 @@ class ComScoreTracker : MediaItemTracker {
     private lateinit var latestData: Data
 
     /**
-     * A surface is connected to the player when its [ExoPlayer.getSurfaceSize] is not [Size.ZERO].
-     * When use with MediaSessionService or MediaBrowser the size is always [Size.UNKNOWN] but then not connect is is [Size.ZERO].
+     * A surface is connected to the player when its [ExoPlayer.getSurfaceSize] is different from [Size.ZERO].
+     * When used with MediaSessionService or MediaBrowser the size is always [Size.UNKNOWN]. When not connected the size is [Size.ZERO].
      */
     private var isSurfaceConnected: Boolean = false
 


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to update `ComScoreTracker` to handle background state correctly. We have to send a pause event when the video is not visible by the user and send a play event with the new position when video is visible again.

# Solution

We assume that a player with no surface size is a player with no surface attached to it and so actually not visible by the user.

## Changes made

- Improve background / foreground video tracking for ComScore.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
