### PR TITLE
No seek event while in pause

### DIFF
--- a/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/CommandersActTrackerTest.kt
+++ b/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/CommandersActTrackerTest.kt
@@ -130,8 +130,6 @@ class CommandersActTrackerTest {
         val expected = listOf(
             MediaEventType.Play.toString(),
             MediaEventType.Pause.toString(),
-            MediaEventType.Seek.toString(),
-            MediaEventType.Pause.toString(),
             MediaEventType.Stop.toString()
         )
         launch(Dispatchers.Main) {

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -141,7 +141,7 @@ internal class CommandersActStreaming(
     }
 
     private fun notifyPause() {
-        if (state == State.Idle) return
+        if (state != State.Playing) return
         this.state = State.Paused
         notifyEvent(MediaEventType.Pause, player.currentPosition.milliseconds)
         stopHeartBeat()
@@ -155,7 +155,7 @@ internal class CommandersActStreaming(
     }
 
     private fun notifySeek(seekStartPosition: Duration) {
-        if (state == State.Seeking || state == State.Idle) return
+        if (state != State.Playing) return
         state = State.Seeking
         notifyEvent(MediaEventType.Seek, seekStartPosition)
     }


### PR DESCRIPTION
# Pull request

## Description

To align CommandersAct tracking with other Pillarbox platform. This PR modify the behaviors of seek event when the player is not playing.

## Changes made

- Don't send `seek` event to CommandersAct when playing is in pause state.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
