### PR TITLE
Don't remove query parameters when applying akamai token

### DIFF
--- a/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/AkamaiTokenProviderTest.kt
+++ b/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/AkamaiTokenProviderTest.kt
@@ -62,4 +62,22 @@ class AkamaiTokenProviderTest {
         Assert.assertNotNull(acl)
         Assert.assertEquals(expectedAcl, acl)
     }
+
+    @Test
+    fun testAclWithQueryParameters() {
+        val uri = Uri.parse("https://srgssrch.akamaized.net/hls/live/2022027/srgssr-hls-stream15-ch-dvr/master.m3u8?start=1697860830&end=1697867100")
+        val expectedAcl = "/hls/live/2022027/srgssr-hls-stream15-ch-dvr/*"
+        val acl = AkamaiTokenProvider.getAcl(uri)
+        Assert.assertNotNull(acl)
+        Assert.assertEquals(expectedAcl, acl)
+    }
+
+    @Test
+    fun testAppendTokenToUri() {
+        val uri = Uri.parse("https://srgssrch.akamaized.net/hls/live/2022027/srgssr-hls-stream15-ch-dvr/master.m3u8?start=1697860830&end=1697867100")
+        val fakeToken = AkamaiTokenProvider.Token(authParams = "Token")
+        val actual = AkamaiTokenProvider.appendTokenToUri(uri, fakeToken)
+        Assert.assertNotEquals(uri, actual)
+        Assert.assertTrue("Contains base url", actual.toString().contains(uri.toString()))
+    }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR fix the way `AkamaiTokenProvider` append token to the base Uri.

## Changes made

- Use like in SRGLetterbox a UrlSanitizer to extract encoded query parameters and keys.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
