### PR TITLE
Display "No result" when necessary

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -107,6 +107,10 @@ private fun SearchResultList(
     buClicked: (Bu) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val hasNoResult = lazyPagingItems.loadState.refresh is LoadState.NotLoading &&
+        lazyPagingItems.itemCount == 1 &&
+        lazyPagingItems[0] is SearchContent.BuSelector
+
     LazyColumn(modifier = modifier) {
         items(count = lazyPagingItems.itemCount, key = lazyPagingItems.itemKey()) { index ->
             val item = lazyPagingItems[index]
@@ -134,8 +138,7 @@ private fun SearchResultList(
                 }
             }
         }
-        // We didn't receive any results
-        if (lazyPagingItems.itemCount == 1 && lazyPagingItems[0] is SearchContent.BuSelector) {
+        if (hasNoResult) {
             item {
                 NoResult(
                     modifier = Modifier

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
@@ -53,7 +53,7 @@ class SearchViewModel(private val ilRepository: ILRepository) : ViewModel() {
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     val result: Flow<PagingData<SearchContent>> = config.flatMapLatest { config ->
-        if (config.query.isNotBlank() || config.query.length >= 3) {
+        if (config.query.length >= 3) {
             ilRepository.search(config.bu, config.query).map { mediaPagingData ->
                 val pagingData: PagingData<SearchContent> = mediaPagingData.map { item -> SearchContent.MediaResult(Content.Media(item)) }
                 pagingData.insertHeaderItem(item = SearchContent.BuSelector)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
@@ -19,6 +19,7 @@ import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.ILRepository
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -31,15 +32,20 @@ import kotlinx.coroutines.flow.map
  * @constructor Create empty Search view model
  */
 class SearchViewModel(private val ilRepository: ILRepository) : ViewModel() {
+    private val _bu = MutableStateFlow(Bu.RTS)
+
     /**
-     * Current  selected [Bu].
+     * Currently selected [Bu].
      */
-    val bu = MutableStateFlow(Bu.RTS)
+    val bu: StateFlow<Bu> = _bu
+
+    private val _query = MutableStateFlow("")
 
     /**
      * Current search query string.
      */
-    val query = MutableStateFlow("")
+    val query: StateFlow<String> = _query
+
     private val config = combine(bu, query) { bu, query -> Config(bu, query) }
 
     /**
@@ -70,7 +76,16 @@ class SearchViewModel(private val ilRepository: ILRepository) : ViewModel() {
      * Clear search query parameter.
      */
     fun clear() {
-        query.value = ""
+        _query.value = ""
+    }
+
+    /**
+     * Set the search query.
+     *
+     * @param query The search query
+     */
+    fun setQuery(query: String) {
+        _query.value = query
     }
 
     /**
@@ -79,7 +94,7 @@ class SearchViewModel(private val ilRepository: ILRepository) : ViewModel() {
      * @param bu The [Bu] to select.
      */
     fun selectBu(bu: Bu) {
-        this.bu.value = bu
+        _bu.value = bu
     }
 
     internal data class Config(val bu: Bu, val query: String)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
@@ -21,9 +21,11 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Search view model to search media for the chosen bu
@@ -46,7 +48,7 @@ class SearchViewModel(private val ilRepository: ILRepository) : ViewModel() {
      */
     val query: StateFlow<String> = _query
 
-    private val config = combine(bu, query) { bu, query -> Config(bu, query) }
+    private val config = combine(bu, query) { bu, query -> Config(bu, query) }.debounce(600.milliseconds)
 
     /**
      * Result of the search trigger by [bu] and [query]


### PR DESCRIPTION
# Pull request

## Description

When a query returned no results, the search view would only display the BU selector, and nothing else.
Now we display the BU selector, followed by the "No result" message.

## Changes made

- Display "No result" when we receive only the BU selector
- Simplify state management in the search view

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
