### PR TITLE
Remove ExoPlayer.Builder from PillarboxPlayer

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
@@ -5,16 +5,12 @@
 package ch.srgssr.pillarbox.demo.shared.di
 
 import android.content.Context
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import ch.srgssr.pillarbox.core.business.DefaultPillarbox
 import ch.srgssr.pillarbox.core.business.MediaCompositionMediaItemSource
-import ch.srgssr.pillarbox.core.business.akamai.AkamaiTokenDataSource
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.DefaultMediaCompositionDataSource
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.Vector.getVector
-import ch.srgssr.pillarbox.core.business.tracker.DefaultMediaItemTrackerRepository
 import ch.srgssr.pillarbox.demo.shared.data.MixedMediaItemSource
 import ch.srgssr.pillarbox.player.PillarboxPlayer
-import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
 
 /**
  * Dependencies to make custom Dependency Injection
@@ -35,13 +31,6 @@ object PlayerModule {
      * Provide default player that allow to play urls and urns content from the SRG
      */
     fun provideDefaultPlayer(context: Context): PillarboxPlayer {
-        val builder = DefaultPillarbox.Builder(context)
-        builder.setMediaSourceFactory(
-            PillarboxMediaSourceFactory(
-                mediaItemSource = provideMixedItemSource(context),
-                defaultMediaSourceFactory = DefaultMediaSourceFactory(AkamaiTokenDataSource.Factory())
-            )
-        )
-        return PillarboxPlayer(builder, DefaultMediaItemTrackerRepository())
+        return DefaultPillarbox(context = context, mediaItemSource = provideMixedItemSource(context))
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -62,11 +62,6 @@ class PillarboxPlayer internal constructor(
         }
     }
 
-    constructor(builder: ExoPlayer.Builder, mediaItemTrackerProvider: MediaItemTrackerProvider? = null) : this(
-        exoPlayer = builder.build(),
-        mediaItemTrackerProvider = mediaItemTrackerProvider
-    )
-
     constructor(
         context: Context,
         mediaItemSource: MediaItemSource,


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to remove some complexity to the integrator by removing `ExoPlayer.Builder` from `PillarboxPlayer`.
For SRG SSR integrators we provide a `DefaultPillarbox` that create a `PillarboxPlayer` that handle SRG content and setup SRGAnalytics trackers.

## Changes made
- Remove `ExoPlayer.Builder` from `PillarboxPlayer` constructor.
- Add parameters to `DefaultPillarbox` to match `PillarboxPlayer` constructor parameters.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
