### PR TITLE
Improve BU selector in search view

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -8,14 +8,17 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -59,7 +62,6 @@ fun SearchView(searchViewModel: SearchViewModel, onSearchClicked: (Content.Media
         !searchViewModel.hasValidSearchQuery()
 
     Column(
-        modifier = Modifier.padding(8.dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
         BuSelector(
@@ -71,6 +73,7 @@ fun SearchView(searchViewModel: SearchViewModel, onSearchClicked: (Content.Media
         TextField(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(horizontal = 8.dp)
                 .focusRequester(focusRequester),
             trailingIcon = {
                 IconButton(onClick = searchViewModel::clear) {
@@ -90,7 +93,7 @@ fun SearchView(searchViewModel: SearchViewModel, onSearchClicked: (Content.Media
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(12.dp),
+                    .padding(horizontal = 8.dp),
                 contentAlignment = Alignment.Center
             ) {
                 Text(text = "No content")
@@ -99,7 +102,8 @@ fun SearchView(searchViewModel: SearchViewModel, onSearchClicked: (Content.Media
         SearchResultList(
             lazyPagingItems = lazyItems,
             contentClick = onSearchClicked,
-            searchViewModel = searchViewModel
+            searchViewModel = searchViewModel,
+            modifier = Modifier.padding(horizontal = 8.dp)
         )
     }
 
@@ -138,7 +142,7 @@ private fun SearchResultList(
                 NoResult(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(12.dp)
+                        .padding(horizontal = 8.dp)
                 )
             }
         }
@@ -160,16 +164,20 @@ private fun SearchResultList(
 }
 
 @Composable
+@OptIn(ExperimentalMaterial3Api::class)
 private fun BuSelector(listBu: List<Bu>, selectedBu: Bu, onBuSelected: (Bu) -> Unit, modifier: Modifier = Modifier) {
-    Row(
+    LazyRow(
         modifier = modifier,
+        contentPadding = PaddingValues(horizontal = 8.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        for (bu in listBu) {
-            Button(onClick = { onBuSelected(bu) }, enabled = bu != selectedBu) {
-                Text(text = bu.name.uppercase())
-            }
+        items(listBu) { bu ->
+            FilterChip(
+                selected = bu == selectedBu,
+                onClick = { onBuSelected(bu) },
+                label = { Text(text = bu.name.uppercase()) },
+            )
         }
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -12,8 +13,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CircularProgressIndicator
@@ -28,8 +31,12 @@ import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -64,12 +71,16 @@ fun SearchView(searchViewModel: SearchViewModel, onSearchClicked: (Content.Media
     Column(
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        BuSelector(
-            modifier = Modifier.fillMaxWidth(),
-            listBu = bus,
-            selectedBu = currentBu,
-            onBuSelected = searchViewModel::selectBu
-        )
+        var showBuSelector by remember { mutableStateOf(true) }
+
+        AnimatedVisibility(visible = showBuSelector) {
+            BuSelector(
+                listBu = bus,
+                selectedBu = currentBu,
+                onBuSelected = searchViewModel::selectBu
+            )
+        }
+
         TextField(
             modifier = Modifier
                 .fillMaxWidth()
@@ -81,6 +92,13 @@ fun SearchView(searchViewModel: SearchViewModel, onSearchClicked: (Content.Media
                         imageVector = Icons.Default.Close,
                         contentDescription = "Clear search"
                     )
+                }
+            },
+            prefix = if (showBuSelector) {
+                null
+            } else {
+                {
+                    Text(text = "[${currentBu.name.uppercase()}] ")
                 }
             },
             singleLine = true,
@@ -102,6 +120,7 @@ fun SearchView(searchViewModel: SearchViewModel, onSearchClicked: (Content.Media
         SearchResultList(
             lazyPagingItems = lazyItems,
             contentClick = onSearchClicked,
+            onScroll = { showBuSelector = it },
             searchViewModel = searchViewModel,
             modifier = Modifier.padding(horizontal = 8.dp)
         )
@@ -117,13 +136,23 @@ private fun SearchResultList(
     searchViewModel: SearchViewModel,
     lazyPagingItems: LazyPagingItems<Content.Media>,
     contentClick: (Content.Media) -> Unit,
+    onScroll: (scrollUp: Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
     val hasNoResult = lazyPagingItems.itemCount == 0 &&
         lazyPagingItems.loadState.refresh is LoadState.NotLoading &&
         searchViewModel.hasValidSearchQuery()
+    val scrollState = rememberLazyListState()
+    val isScrollingUp = scrollState.isScrollingUp()
 
-    LazyColumn(modifier = modifier) {
+    LaunchedEffect(isScrollingUp) {
+        onScroll(isScrollingUp)
+    }
+
+    LazyColumn(
+        modifier = modifier,
+        state = scrollState
+    ) {
         items(count = lazyPagingItems.itemCount, key = lazyPagingItems.itemKey()) { index ->
             val item = lazyPagingItems[index]
             item?.let { mediaResult ->
@@ -161,6 +190,27 @@ private fun SearchResultList(
             }
         }
     }
+}
+
+// Snippet from a Google Codelab:
+// https://github.com/android/codelab-android-compose/blob/main/AnimationCodelab/finished/src/main/java/com/example/android/codelab/animation/ui/home/Home.kt#L339
+@Composable
+private fun LazyListState.isScrollingUp(): Boolean {
+    var previousIndex by remember(this) { mutableIntStateOf(firstVisibleItemIndex) }
+    var previousScrollOffset by remember(this) { mutableIntStateOf(firstVisibleItemScrollOffset) }
+
+    return remember(this) {
+        derivedStateOf {
+            if (previousIndex != firstVisibleItemIndex) {
+                previousIndex > firstVisibleItemIndex
+            } else {
+                previousScrollOffset >= firstVisibleItemScrollOffset
+            }.also {
+                previousIndex = firstVisibleItemIndex
+                previousScrollOffset = firstVisibleItemScrollOffset
+            }
+        }
+    }.value
 }
 
 @Composable


### PR DESCRIPTION
# Pull request

## Description

Previously, the selection of the BU was only available once we received some results from the backend (ie. the user had to enter at least 3 characters).
Now the BU selector is displayed above the search bar, visible by default, and it hides when we scroll in the search results.

## Changes made

- Move the BU selector out of the search results, above the search bar
- Make the BU selector horizontally scrollable
- Hide the BU selector when scrolling down, and show it when scrolling up

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
