### PR TITLE
Improve navigation bar in the TV demo app

### DIFF
--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
@@ -56,11 +56,6 @@ class MainActivity : ComponentActivity() {
                         TVDemoTopBar(
                             destinations = destinations,
                             selectedDestination = selectedDestination,
-                            modifier = Modifier
-                                .padding(
-                                    horizontal = HorizontalPadding,
-                                    vertical = VerticalPadding
-                                ),
                             onDestinationSelected = {
                                 selectedDestination = it
 
@@ -83,6 +78,5 @@ class MainActivity : ComponentActivity() {
 
     private companion object {
         private val HorizontalPadding = 58.dp
-        private val VerticalPadding = 16.dp
     }
 }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
@@ -8,7 +8,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.CompositionLocalProvider
@@ -17,8 +17,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import androidx.tv.material3.ExperimentalTvMaterial3Api
@@ -41,7 +39,7 @@ class MainActivity : ComponentActivity() {
 
         setContent {
             PillarboxTheme {
-                Box(
+                Column(
                     modifier = Modifier
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.surface)
@@ -49,41 +47,34 @@ class MainActivity : ComponentActivity() {
                     CompositionLocalProvider(
                         LocalContentColor provides MaterialTheme.colorScheme.onSurface
                     ) {
-                        Box {
-                            val density = LocalDensity.current
-                            val destinations = listOf(HomeDestination.Examples, HomeDestination.Lists)
-                            val navController = rememberNavController()
+                        val destinations = listOf(HomeDestination.Examples, HomeDestination.Lists)
+                        val navController = rememberNavController()
+                        val startDestination by remember(destinations) { mutableStateOf(destinations[0]) }
 
-                            var selectedDestination by remember { mutableStateOf(destinations[0]) }
-                            var topBarHeight by remember { mutableStateOf(0.dp) }
+                        var selectedDestination by remember { mutableStateOf(startDestination) }
 
-                            TVDemoTopBar(
-                                destinations = destinations,
-                                selectedDestination = selectedDestination,
-                                modifier = Modifier
-                                    .onSizeChanged {
-                                        topBarHeight = with(density) { it.height.toDp() }
-                                    }
-                                    .padding(
-                                        horizontal = HorizontalPadding,
-                                        vertical = VerticalPadding
-                                    ),
-                                onDestinationSelected = {
-                                    selectedDestination = it
+                        TVDemoTopBar(
+                            destinations = destinations,
+                            selectedDestination = selectedDestination,
+                            modifier = Modifier
+                                .padding(
+                                    horizontal = HorizontalPadding,
+                                    vertical = VerticalPadding
+                                ),
+                            onDestinationSelected = {
+                                selectedDestination = it
 
-                                    navController.navigate(it.route)
-                                }
-                            )
+                                navController.navigate(it.route)
+                            }
+                        )
 
-                            TVDemoNavigation(
-                                navController = navController,
-                                startDestination = HomeDestination.Examples,
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(top = topBarHeight)
-                                    .padding(horizontal = HorizontalPadding)
-                            )
-                        }
+                        TVDemoNavigation(
+                            navController = navController,
+                            startDestination = startDestination,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = HorizontalPadding)
+                        )
                     }
                 }
             }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
@@ -8,14 +8,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Text
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
 import ch.srgssr.pillarbox.demo.tv.examples.ExamplesHome
 import ch.srgssr.pillarbox.demo.tv.player.PlayerActivity
+import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 
 /**
  * The nav host of the demo app on TV.
@@ -48,5 +51,16 @@ fun TVDemoNavigation(
             // TODO Proper content will be created in https://github.com/SRGSSR/pillarbox-android/issues/293
             Text(text = stringResource(HomeDestination.Lists.labelResId))
         }
+    }
+}
+
+@Preview
+@Composable
+private fun TVDemoNavigationPreview() {
+    PillarboxTheme {
+        TVDemoNavigation(
+            navController = rememberNavController(),
+            startDestination = HomeDestination.Examples
+        )
     }
 }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.height
@@ -41,6 +42,7 @@ import androidx.tv.material3.TabRow
 import androidx.tv.material3.TabRowScope
 import androidx.tv.material3.Text
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
+import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 
 /**
  * Top bar displayed in the demo app on TV.
@@ -139,6 +141,18 @@ private fun TabRowScope.TabItem(
             text = stringResource(destination.labelResId),
             style = MaterialTheme.typography.titleSmall
                 .copy(color = MaterialTheme.colorScheme.onPrimaryContainer)
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun TVDemoTopBarPreview() {
+    PillarboxTheme {
+        TVDemoTopBar(
+            destinations = listOf(HomeDestination.Examples, HomeDestination.Lists),
+            selectedDestination = HomeDestination.Examples,
+            onDestinationSelected = {}
         )
     }
 }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
@@ -4,21 +4,13 @@
  */
 package ch.srgssr.pillarbox.demo.tv.ui
 
-import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateDpAsState
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -27,19 +19,13 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.DpRect
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.height
-import androidx.compose.ui.unit.width
-import androidx.compose.ui.zIndex
+import androidx.tv.foundation.lazy.list.TvLazyRow
+import androidx.tv.foundation.lazy.list.items
 import androidx.tv.material3.ExperimentalTvMaterial3Api
-import androidx.tv.material3.MaterialTheme
-import androidx.tv.material3.Tab
-import androidx.tv.material3.TabRow
-import androidx.tv.material3.TabRowScope
+import androidx.tv.material3.ListItem
 import androidx.tv.material3.Text
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
@@ -60,88 +46,30 @@ fun TVDemoTopBar(
     modifier: Modifier = Modifier,
     onDestinationSelected: (destination: HomeDestination) -> Unit
 ) {
-    Row(
+    var isTabRowFocused by remember { mutableStateOf(false) }
+
+    TvLazyRow(
         modifier = modifier
             .fillMaxWidth()
-            .padding(top = 16.dp)
-            .focusRestorer(),
+            .focusRestorer()
+            .onFocusChanged { isTabRowFocused = it.isFocused || it.hasFocus },
+        contentPadding = PaddingValues(
+            horizontal = 58.dp,
+            vertical = 16.dp
+        ),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        var isTabRowFocused by remember { mutableStateOf(false) }
-        val selectedDestinationIndex = destinations.indexOf(selectedDestination)
-
-        TabRow(
-            modifier = Modifier.onFocusChanged { isTabRowFocused = it.isFocused || it.hasFocus },
-            selectedTabIndex = selectedDestinationIndex,
-            indicator = { tabPositions, _ ->
-                TopBarItemIndicator(
-                    currentTabPosition = tabPositions[selectedDestinationIndex],
-                    isTabRowFocused = isTabRowFocused
-                )
-            }
-        ) {
-            destinations.forEachIndexed { index, destination ->
-                key(index) {
-                    TabItem(
-                        destination = destination,
-                        selected = index == selectedDestinationIndex,
-                        modifier = Modifier.height(32.dp),
-                        onDestinationSelected = { onDestinationSelected(destination) }
-                    )
+        items(destinations) { destination ->
+            ListItem(
+                selected = destination == selectedDestination,
+                onClick = { onDestinationSelected(destination) },
+                modifier = Modifier.width(IntrinsicSize.Max),
+                headlineContent = {
+                    Text(text = stringResource(destination.labelResId))
                 }
-            }
+            )
         }
-    }
-}
-
-@Composable
-@OptIn(ExperimentalTvMaterial3Api::class)
-private fun TopBarItemIndicator(
-    currentTabPosition: DpRect,
-    modifier: Modifier = Modifier,
-    activeColor: Color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.4f),
-    inactiveColor: Color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.4f),
-    isTabRowFocused: Boolean
-) {
-    val width by animateDpAsState(targetValue = currentTabPosition.width, label = "width")
-    val height = currentTabPosition.height
-    val leftOffset by animateDpAsState(targetValue = currentTabPosition.left, label = "leftOffset")
-    val topOffset = currentTabPosition.top
-    val pillColor by animateColorAsState(targetValue = if (isTabRowFocused) activeColor else inactiveColor, label = "pillColor")
-
-    Box(
-        modifier
-            .fillMaxWidth()
-            .wrapContentSize(Alignment.BottomStart)
-            .offset(x = leftOffset, y = topOffset)
-            .size(width = width, height = height)
-            .background(color = pillColor)
-            .zIndex(-1f)
-    )
-}
-
-@Composable
-@OptIn(ExperimentalTvMaterial3Api::class)
-private fun TabRowScope.TabItem(
-    destination: HomeDestination,
-    selected: Boolean,
-    modifier: Modifier = Modifier,
-    onDestinationSelected: () -> Unit
-) {
-    Tab(
-        modifier = modifier,
-        selected = selected,
-        onFocus = onDestinationSelected
-    ) {
-        Text(
-            modifier = Modifier
-                .fillMaxSize()
-                .wrapContentSize()
-                .padding(horizontal = 16.dp),
-            text = stringResource(destination.labelResId),
-            style = MaterialTheme.typography.titleSmall
-                .copy(color = MaterialTheme.colorScheme.onPrimaryContainer)
-        )
     }
 }
 


### PR DESCRIPTION
# Pull request

## Description

While working on #293, I discovered that there is already a component for TV to highlight an active item. So the goal of this PR is to simplify some of the changes made in #294.

## Changes made

- Simplify `MainActivity` by removing redundant nested `Box`es and use a `Column` instead
- Add previews to newly created components
- Simplify `TVDemoTopBar` by using existing native components

## Screenshots

New top bar with focus on the first element:
![72DFE02D-E1CB-40EF-A711-EE32EADFB6DD_1_201_a](https://github.com/SRGSSR/pillarbox-android/assets/1009664/68b94f71-d4a0-40e0-b3c5-5e2c83bde9ff)

New top bar without focus and first element selected:
![8992441C-64B5-46DF-9031-D736A3B90354_1_201_a](https://github.com/SRGSSR/pillarbox-android/assets/1009664/c4293d15-0f55-4854-8aea-bc5931f90eba)

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
