### PR TITLE
Create first levels in "Lists"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ espresso = "3.5.1"
 media3 = "1.1.1"
 media = "1.6.0"
 guava = "31.1-android"
-navigationCompose = "2.7.4"
+navigation = "2.7.4"
 pagingCompose = "3.2.1"
 okhttp = "4.10.0"
 retrofit2KotlinxSerializationConverter = "1.0.0"
@@ -38,7 +38,8 @@ accompanist-navigation-material = { module = "com.google.accompanist:accompanist
 accompanist-systemuicontroller = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleViewmodelCompose" }
-androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
+androidx-navigation-common = { module = "androidx.navigation:navigation-common", version.ref = "navigation" }
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
 androidx-paging-compose = { module = "androidx.paging:paging-compose", version.ref = "pagingCompose" }
 androidx-tv-foundation = { module = "androidx.tv:tv-foundation", version.ref = "tvCompose" }
 androidx-tv-material = { module = "androidx.tv:tv-material", version.ref = "tvCompose" }

--- a/pillarbox-demo-shared/build.gradle.kts
+++ b/pillarbox-demo-shared/build.gradle.kts
@@ -39,4 +39,6 @@ dependencies {
     implementation(libs.androidx.ktx)
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.material.icons.extended)
+    implementation(libs.androidx.navigation.common)
+    implementation(libs.srg.dataprovider.retrofit)
 }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentList.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentList.kt
@@ -2,11 +2,11 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.demo.ui.integrationLayer
+package ch.srgssr.pillarbox.demo.shared.ui.integrationLayer
 
 import androidx.navigation.NavBackStackEntry
 import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
-import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.RadioChannel
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.RadioChannel
 
 private const val RootRoute = "content"
 

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSection.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSection.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data
+
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
+
+/**
+ * Represents a section in the "Lists" tab.
+ *
+ * @property title The title of the section.
+ * @property contentList The list of elements in the section.
+ */
+data class ContentListSection(
+    val title: String,
+    val contentList: List<ContentList>
+)

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data
+
+import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
+
+private val bus = listOf(Bu.RTS, Bu.SRF, Bu.RSI, Bu.RTR, Bu.SWI)
+
+/**
+ * All the sections available in the "Lists" tab.
+ */
+val contentListSections = listOf(
+    ContentListSection("TV Topics", bus.map { ContentList.TvTopics(it) }),
+    ContentListSection("TV Shows", bus.map { ContentList.TvShows(it) }),
+    ContentListSection("TV Latest medias", bus.map { ContentList.TVLatestMedias(it) }),
+    ContentListSection("TV Livestreams", bus.map { ContentList.TVLivestreams(it) }),
+    ContentListSection("TV Live center", bus.map { ContentList.TVLiveCenter(it) }),
+    ContentListSection("TV Live web", bus.map { ContentList.TVLiveWeb(it) }),
+    ContentListSection("Radio livestream", bus.map { ContentList.RadioLiveStreams(it) }),
+    ContentListSection("Radio Latest medias", RadioChannel.entries.map { ContentList.RadioLatestMedias(it) }),
+    ContentListSection("Radio Shows", RadioChannel.entries.map { ContentList.RadioShows(it) }),
+)

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/RadioChannel.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/RadioChannel.kt
@@ -2,7 +2,7 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.demo.ui.integrationLayer.data
+package ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data
 
 import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
 

--- a/pillarbox-demo-tv/build.gradle.kts
+++ b/pillarbox-demo-tv/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation(project(mapOf("path" to ":pillarbox-demo-shared")))
     implementation(libs.androidx.ktx)
     implementation(libs.leanback)
+    implementation(libs.srg.dataprovider.retrofit)
 
     val composeBom = libs.androidx.compose.bom
     implementation(platform(composeBom))

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
@@ -7,17 +7,16 @@ package ch.srgssr.pillarbox.demo.tv.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.tv.material3.ExperimentalTvMaterial3Api
-import androidx.tv.material3.Text
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
 import ch.srgssr.pillarbox.demo.tv.examples.ExamplesHome
 import ch.srgssr.pillarbox.demo.tv.player.PlayerActivity
+import ch.srgssr.pillarbox.demo.tv.ui.integrationLayer.ListsHome
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 
 /**
@@ -28,7 +27,6 @@ import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
  * @param modifier The [Modifier] to apply to the [NavHost].
  */
 @Composable
-@OptIn(ExperimentalTvMaterial3Api::class)
 fun TVDemoNavigation(
     navController: NavHostController,
     startDestination: HomeDestination,
@@ -48,8 +46,9 @@ fun TVDemoNavigation(
         }
 
         composable(HomeDestination.Lists.route) {
-            // TODO Proper content will be created in https://github.com/SRGSSR/pillarbox-android/issues/293
-            Text(text = stringResource(HomeDestination.Lists.labelResId))
+            ListsHome(
+                sections = contentListSections
+            )
         }
     }
 }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.tv.ui.integrationLayer
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavType
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
+import androidx.tv.foundation.lazy.grid.TvGridCells
+import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
+import androidx.tv.foundation.lazy.grid.itemsIndexed
+import androidx.tv.material3.Card
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ContentListSection
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
+import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
+
+/**
+ * Screen of the "Lists" tab of the demo app on TV.
+ *
+ * @param sections The list of section to display.
+ * @param modifier The [Modifier] to apply to this screen.
+ *
+ * @see ContentListSection
+ */
+@Composable
+@OptIn(ExperimentalTvMaterial3Api::class)
+fun ListsHome(
+    sections: List<ContentListSection>,
+    modifier: Modifier = Modifier
+) {
+    val navController = rememberNavController()
+
+    NavHost(
+        navController = navController,
+        startDestination = NavigationRoutes.contentLists,
+        modifier = modifier.fillMaxSize()
+    ) {
+        composable(NavigationRoutes.contentLists) {
+            ListsSection(
+                items = sections,
+                itemToString = { it.title },
+                onItemClick = { index, _ ->
+                    navController.navigate("${NavigationRoutes.contentList}/$index")
+                }
+            )
+        }
+
+        composable(
+            route = "${NavigationRoutes.contentList}/{index}",
+            arguments = listOf(
+                navArgument("index") { type = NavType.IntType }
+            )
+        ) {
+            val sectionIndex = it.arguments?.getInt("index") ?: 0
+            val section = sections[sectionIndex]
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            ListsSection(
+                title = section.title,
+                items = section.contentList,
+                itemToString = { item ->
+                    when (item) {
+                        is ContentList.ContentListWithBu -> item.bu.name.uppercase()
+                        is ContentList.RadioLatestMedias -> item.radioChannel.label
+                        is ContentList.RadioShows -> item.radioChannel.label
+                        else -> ""
+                    }
+                },
+                onItemClick = { _, contentList ->
+                    navController.navigate(contentList.getDestinationRoute())
+                }
+            )
+        }
+
+        composable(
+            route = ContentList.TvTopics.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.TvTopics.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.TvShows.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.TvShows.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.TVLatestMedias.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.TVLatestMedias.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.TVLivestreams.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.TVLivestreams.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.TVLiveCenter.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.TVLiveCenter.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.TVLiveWeb.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.TVLiveWeb.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.RadioLiveStreams.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.RadioLiveStreams.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.RadioLatestMedias.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType },
+                navArgument("radioChannel") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.RadioLatestMedias.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+
+        composable(
+            route = ContentList.RadioShows.route,
+            arguments = listOf(
+                navArgument("bu") { type = NavType.StringType },
+                navArgument("radioChannel") { type = NavType.StringType }
+            )
+        ) {
+            val contentList = ContentList.RadioShows.parse(it)
+
+            BackHandler {
+                navController.popBackStack()
+            }
+
+            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+            Text(text = contentList.toString())
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalComposeUiApi::class, ExperimentalTvMaterial3Api::class)
+private fun <T> ListsSection(
+    modifier: Modifier = Modifier,
+    title: String? = null,
+    items: List<T>,
+    itemToString: (item: T) -> String,
+    onItemClick: (index: Int, item: T) -> Unit
+) {
+    var focusedIndex by remember(items) { mutableIntStateOf(0) }
+
+    Column(
+        modifier = modifier.padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        if (title != null) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.headlineLarge
+            )
+        }
+
+        TvLazyVerticalGrid(
+            columns = TvGridCells.Fixed(4),
+            modifier = Modifier.focusRestorer(),
+            contentPadding = PaddingValues(vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            itemsIndexed(items = items) { index, item ->
+                val focusRequester = remember { FocusRequester() }
+
+                Card(
+                    onClick = { focusedIndex = index; onItemClick(index, item) },
+                    modifier = Modifier
+                        .height(96.dp)
+                        .focusRequester(focusRequester)
+                        .onGloballyPositioned {
+                            if (index == focusedIndex) {
+                                focusRequester.requestFocus()
+                            }
+                        }
+                        .onFocusChanged {
+                            if (it.hasFocus) {
+                                focusedIndex = index
+                            }
+                        }
+                ) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = itemToString(item),
+                            modifier = Modifier.padding(16.dp),
+                            textAlign = TextAlign.Center,
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ContentListsViewPreview() {
+    PillarboxTheme {
+        ListsHome(sections = contentListSections)
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
 import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.ILRepository
 import kotlinx.coroutines.flow.Flow

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -21,32 +21,17 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
-import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
 import ch.srgssr.pillarbox.demo.DemoPageView
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ContentListSection
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
 import ch.srgssr.pillarbox.demo.ui.composable
 import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.ILRepository
-import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.RadioChannel
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
-
-private val bus = listOf(Bu.RTS, Bu.SRF, Bu.RSI, Bu.RTR, Bu.SWI)
-
-private data class SectionItem(val title: String, val listContent: List<ContentList>)
-
-private val sections = listOf(
-    SectionItem("TV Topics", bus.map { ContentList.TvTopics(it) }),
-    SectionItem("TV Shows", bus.map { ContentList.TvShows(it) }),
-    SectionItem("TV Latest medias", bus.map { ContentList.TVLatestMedias(it) }),
-    SectionItem("TV Livestreams", bus.map { ContentList.TVLivestreams(it) }),
-    SectionItem("TV Live center", bus.map { ContentList.TVLiveCenter(it) }),
-    SectionItem("TV Live web", bus.map { ContentList.TVLiveWeb(it) }),
-    SectionItem("Radio livestream", bus.map { ContentList.RadioLiveStreams(it) }),
-    SectionItem("Radio Latest medias", RadioChannel.entries.map { ContentList.RadioLatestMedias(it) }),
-    SectionItem("Radio Shows", RadioChannel.entries.map { ContentList.RadioShows(it) }),
-)
 
 private val defaultListsLevels = listOf("app", "pillarbox", "lists")
 
@@ -197,7 +182,7 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
 @Composable
 private fun ContentListsView(onContentSelected: (ContentList) -> Unit) {
     LazyColumn {
-        items(sections) {
+        items(contentListSections) {
             SectionItemView(
                 modifier = Modifier
                     .padding(12.dp)
@@ -212,22 +197,22 @@ private fun ContentListsView(onContentSelected: (ContentList) -> Unit) {
 @Preview
 @Composable
 private fun ContentListPreview() {
-    PillarboxTheme() {
-        ContentListsView() {
+    PillarboxTheme {
+        ContentListsView {
         }
     }
 }
 
 @Composable
 private fun SectionItemView(
-    sectionItem: SectionItem,
+    sectionItem: ContentListSection,
     onContentSelected: (ContentList) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Card(modifier = modifier) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(modifier = Modifier.padding(vertical = 6.dp), text = sectionItem.title.uppercase(), style = MaterialTheme.typography.bodyLarge)
-            for (content in sectionItem.listContent) {
+            for (content in sectionItem.contentList) {
                 val label = when (content) {
                     is ContentList.ContentListWithBu -> content.bu.name
                     is ContentList.RadioLatestMedias -> content.radioChannel.label

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/ILRepository.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/ILRepository.kt
@@ -21,6 +21,7 @@ import ch.srg.dataProvider.integrationlayer.request.parameters.IlPaging.Unlimite
 import ch.srg.dataProvider.integrationlayer.request.parameters.IlTransmission
 import ch.srgssr.dataprovider.paging.DataProviderPaging
 import ch.srgssr.dataprovider.paging.datasource.NextUrlPagingSource
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.RadioChannel
 import kotlinx.coroutines.flow.Flow
 
 /**


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to add the first two levels of navigations in the "Lists" section of the demo app for TV:
- TV Topics
  - All BUs
- TV Shows
  - All BUs
- TV Latest medias
  - All BUs
- TV Livestreams
  - All BUs
- TV Live center
  - All BUs
- TV Live web
  - All BUs
- Radio livestream
  - All BUs
- Radio Latest medias
  - All radio channels
- Radio Shows
  - All radio channels

## Video

[Screen_recording_20231113_125515.webm](https://github.com/SRGSSR/pillarbox-android/assets/1009664/0fce630d-db6d-4e95-a89e-2da58b8c8953)

## Changes made

- Move some code from the mobile demo app to the shared module, so it can be used in the TV demo app
- Display each item as an actionnable card that can be selected to go to the next level

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
