### PR TITLE
Remove year from copyright info

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,9 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 import io.gitlab.arturbosch.detekt.Detekt
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed
 plugins {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 plugins {

--- a/buildSrc/src/main/java/AppConfig.kt
+++ b/buildSrc/src/main/java/AppConfig.kt
@@ -1,13 +1,14 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-import java.util.*
+import java.util.Date
 
 object AppConfig {
     const val minSdk = 21
     const val targetSdk = 34
     const val compileSdk = 34
+
     // https://developer.android.com/jetpack/androidx/releases/compose-kotlin
     const val composeCompiler = "1.5.3"
 

--- a/buildSrc/src/main/java/VersionConfig.kt
+++ b/buildSrc/src/main/java/VersionConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (c) 2022.  SRG SSR. All rights reserved.
+# Copyright (c) SRG SSR. All rights reserved.
 # License information is available from the LICENSE file.
 #
 echo "Running detekt check..."

--- a/lint.xml
+++ b/lint.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <lint>
@@ -8,7 +8,7 @@
     </issue>
     <!-- https://youtrack.jetbrains.com/issue/KTOR-3690 -->
     <issue id="InvalidPackage">
-        <ignore regexp="io.ktor:ktor-utils-jvm"/>
+        <ignore regexp="io.ktor:ktor-utils-jvm" />
     </issue>
     <issue id="UnsafeOptInUsageError">
         <ignore regexp='\(markerClass = androidx\.media3\.common\.util\.UnstableApi\.class\)' />

--- a/pillarbox-analytics/build.gradle.kts
+++ b/pillarbox-analytics/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestComScoreSrg.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestComScoreSrg.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestCommandersAct.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestCommandersAct.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestUtils.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-analytics/src/main/AndroidManifest.xml
+++ b/pillarbox-analytics/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @file:Suppress("MemberVisibilityCanBePrivate")

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/UserConsent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/UserConsent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersAct.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersAct.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActEvent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActLabels.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActLabels.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActPageView.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActPageView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrg.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrg.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/MediaEventType.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/MediaEventType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCEventExtensions.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCEventExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.commandersact

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScore.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.comscore

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreLabel.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreLabel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.comscore

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScorePageView.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScorePageView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.comscore

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.comscore

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreUserConsent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreUserConsent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics.comscore

--- a/pillarbox-analytics/src/main/res/values-car/analytics.xml
+++ b/pillarbox-analytics/src/main/res/values-car/analytics.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-analytics/src/main/res/values-sw600dp/analytics.xml
+++ b/pillarbox-analytics/src/main/res/values-sw600dp/analytics.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-analytics/src/main/res/values-television/analytics.xml
+++ b/pillarbox-analytics/src/main/res/values-television/analytics.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-analytics/src/main/res/values/analytics.xml
+++ b/pillarbox-analytics/src/main/res/values/analytics.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/ComScoreEventTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/ComScoreEventTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/CommandersActEventTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/CommandersActEventTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics
@@ -9,10 +9,6 @@ import ch.srgssr.pillarbox.analytics.commandersact.CommandersActPageView
 import org.junit.Assert
 import org.junit.Test
 
-/*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
- * License information is available from the LICENSE file.
- */
 class CommandersActEventTest {
 
     @Test
@@ -59,7 +55,7 @@ class CommandersActEventTest {
         val tcEvent = pageView.toTCPageViewEvent(AnalyticsConfig.Vendor.RTS)
         val expected = hashMapOf(
             Pair("navigation_bu_distributer", "RTS"),
-            Pair("Key1","value1")
+            Pair("Key1", "value1")
         )
         val actual = tcEvent.additionalProperties
         Assert.assertEquals(expected, actual)

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/TestSRGAnalyticsPageViews.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/TestSRGAnalyticsPageViews.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.analytics

--- a/pillarbox-core-business/build.gradle.kts
+++ b/pillarbox-core-business/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/AkamaiTokenProviderTest.kt
+++ b/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/AkamaiTokenProviderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/CommandersActTrackerTest.kt
+++ b/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/CommandersActTrackerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/LocalMediaCompositionDataSource.kt
+++ b/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/LocalMediaCompositionDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/images/DefaultImageScalingServiceTest.kt
+++ b/pillarbox-core-business/src/androidTest/java/ch/srgssr/pillarbox/core/business/images/DefaultImageScalingServiceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.images

--- a/pillarbox-core-business/src/main/AndroidManifest.xml
+++ b/pillarbox-core-business/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/DefaultPillarbox.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/DefaultPillarbox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/HttpResultException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/HttpResultException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaItemUrn.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/MediaItemUrn.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/SRGErrorMessageProvider.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/SRGErrorMessageProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/TrackerDataProvider.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/TrackerDataProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/akamai/AkamaiTokenDataSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/akamai/AkamaiTokenDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.akamai

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/akamai/AkamaiTokenProvider.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/akamai/AkamaiTokenProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.akamai

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.exception

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/DataParsingException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/DataParsingException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.exception

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/ResourceNotFoundException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/ResourceNotFoundException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.exception

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/BlockReason.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/BlockReason.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.extension

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/images/DefaultImageScalingService.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/images/DefaultImageScalingService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.images

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/images/ImageScalingService.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/images/ImageScalingService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.images

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Chapter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Chapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/DataWithAnalytics.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/DataWithAnalytics.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Drm.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Drm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/MediaComposition.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/MediaComposition.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/MediaUrn.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/MediaUrn.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Resource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Resource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Segment.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/Segment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.data

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/DefaultHttpClient.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/DefaultHttpClient.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.service

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/DefaultMediaCompositionDataSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/DefaultMediaCompositionDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.service

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionDataSource.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/MediaCompositionDataSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.service

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/Vector.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/Vector.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.integrationlayer.service

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/DefaultMediaItemTrackerRepository.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/DefaultMediaItemTrackerRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.tracker

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.tracker

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/TotalPlaytimeCounter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/TotalPlaytimeCounter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.tracker

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.tracker.commandersact

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.tracker.commandersact

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business.tracker.comscore

--- a/pillarbox-core-business/src/main/res/values-de/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-de/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-core-business/src/main/res/values-en/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-en/strings.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-core-business/src/main/res/values-fr/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-fr/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-core-business/src/main/res/values-it/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-it/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-core-business/src/main/res/values-rm/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-rm/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-core-business/src/main/res/values/strings.xml
+++ b/pillarbox-core-business/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSourceTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/MediaCompositionMediaItemSourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/MediaUrnTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/MediaUrnTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/ResourceSelectorTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/ResourceSelectorTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.core.business

--- a/pillarbox-demo-shared/build.gradle.kts
+++ b/pillarbox-demo-shared/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-demo-shared/src/main/AndroidManifest.xml
+++ b/pillarbox-demo-shared/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoBrowser.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoBrowser.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.shared.data

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoItem.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @file:Suppress("MaximumLineLength", "MaxLineLength")

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/MixedMediaItemSource.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/MixedMediaItemSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.shared.data

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.shared.data
@@ -266,7 +266,6 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem.UnifiedStreamingOnDemand_Dash_AlternateAudioLanguage,
                 DemoItem.UnifiedStreamingOnDemand_Dash_Multiple_Audio_Codec,
                 DemoItem.UnifiedStreamingOnDemand_Dash_AccessibilityAudio,
-
             )
         )
 

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.shared.di

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/HomeDestination.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/HomeDestination.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.shared.ui

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/NavigationRoutes.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/NavigationRoutes.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.shared.ui

--- a/pillarbox-demo-shared/src/main/res/values/strings.xml
+++ b/pillarbox-demo-shared/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-demo-tv/build.gradle.kts
+++ b/pillarbox-demo-tv/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-demo-tv/src/main/AndroidManifest.xml
+++ b/pillarbox-demo-tv/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/examples/Examples.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/examples/Examples.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.examples

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/item/DemoItemView.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/item/DemoItemView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.item

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/item/PlaylistHeader.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/item/PlaylistHeader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.item

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/PlayerActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/PlayerActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.player

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/TvPlaybackRow.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/TvPlaybackRow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.player.compose

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/TvPlayerView.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/TvPlayerView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.player.compose

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/leanback/LeanbackPlayerActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/leanback/LeanbackPlayerActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.player.leanback

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/leanback/LeanbackPlayerFragment.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/leanback/LeanbackPlayerFragment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.player.leanback

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.ui

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.ui

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/theme/PillarboxTheme.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/theme/PillarboxTheme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.tv.ui.theme

--- a/pillarbox-demo-tv/src/main/res/layout/activity_player.xml
+++ b/pillarbox-demo-tv/src/main/res/layout/activity_player.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"

--- a/pillarbox-demo-tv/src/main/res/values/themes.xml
+++ b/pillarbox-demo-tv/src/main/res/values/themes.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-demo/src/debug/res/values/strings.xml
+++ b/pillarbox-demo/src/debug/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoPageView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoPageView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.service

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaSessionService.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaSessionService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.service

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoPlaybackService.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoPlaybackService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.service

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoItemView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoItemView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListHeaderView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListHeaderView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/InfoView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/InfoView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/SystemUiExtension.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/SystemUiExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExampleViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExampleViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.examples

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.examples

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.examples

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentList.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/Content.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/Content.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer.data

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/ILRepository.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/ILRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer.data

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/RadioChannel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/data/RadioChannel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer.data

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/di/IntegrationLayerModule.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/di/IntegrationLayerModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer.di

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/PlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/PlayerView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlaybackSettingsDropDownMenu.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlaybackSettingsDropDownMenu.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerError.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerError.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerNoContent.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerNoContent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerPlaybackRow.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerPlaybackRow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerTimeSlider.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerTimeSlider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/mediacontroller/MediaControllerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/mediacontroller/MediaControllerActivity.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.mediacontroller

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/mediacontroller/MediaControllerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/mediacontroller/MediaControllerViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.mediacontroller

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/MediaItemLibrary.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/MediaItemLibrary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.playlist

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistItemView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistItemView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.playlist

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.playlist

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSettingsContent.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSettingsContent.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.settings

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSpeedSettings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSpeedSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.settings

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlayerSettingsViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlayerSettingsViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.settings

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/SettingsOption.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/SettingsOption.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.settings

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.player.settings
@@ -61,19 +61,28 @@ fun TrackSelectionSettings(
             Divider()
         }
         item {
-            SettingsOption(modifier = itemModifier, selected = disabled, onClick = {
-                onTrackSelection(TrackSelectionAction.Disable)
-            }, content = {
+            SettingsOption(
+                modifier = itemModifier,
+                selected = disabled,
+                onClick = {
+                    onTrackSelection(TrackSelectionAction.Disable)
+                },
+                content = {
                     Text(text = "Disabled")
-                })
+                }
+            )
             Divider()
         }
         for (group in listTracksGroup) {
             items(group.length) { trackIndex ->
                 val format = group.getTrackFormat(trackIndex)
-                SettingsOption(modifier = itemModifier, selected = group.isTrackSelected(trackIndex), onClick = {
-                    onTrackSelection(TrackSelectionAction.Selection(trackIndex = trackIndex, format = format, group = group))
-                }, content = {
+                SettingsOption(
+                    modifier = itemModifier,
+                    selected = group.isTrackSelected(trackIndex),
+                    onClick = {
+                        onTrackSelection(TrackSelectionAction.Selection(trackIndex = trackIndex, format = format, group = group))
+                    },
+                    content = {
                         when (group.type) {
                             C.TRACK_TYPE_AUDIO -> {
                                 val str = StringBuilder()
@@ -101,7 +110,8 @@ fun TrackSelectionSettings(
                                 }
                             }
                         }
-                    })
+                    }
+                )
             }
             item {
                 Divider()

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ExoPlayerSample.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ExoPlayerSample.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseList.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseNavigation.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseNavigation.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/SimplePlayerIntegration.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/SimplePlayerIntegration.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/adaptive/AdaptivePlayer.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/adaptive/AdaptivePlayer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.adaptive

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.multiplayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayerViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.multiplayer

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.story

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/SimpleStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/SimpleStory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.story

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryHome.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.story

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryLoadControl.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryLoadControl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.story

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/StoryViewModel.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.story

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/tracking/TrackingToggleSample.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/tracking/TrackingToggleSample.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.tracking

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Color.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Color.kt
@@ -1,6 +1,6 @@
 @file:SuppressWarnings("UndocumentedPublicProperty")
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.theme

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Theme.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Theme.kt
@@ -1,8 +1,9 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @file:SuppressWarnings("UndocumentedPublicProperty")
+
 package ch.srgssr.pillarbox.demo.ui.theme
 
 import android.app.Activity

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Type.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Type.kt
@@ -1,6 +1,6 @@
 @file:SuppressWarnings("UndocumentedPublicProperty")
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.demo.ui.theme

--- a/pillarbox-demo/src/main/res/values/strings.xml
+++ b/pillarbox-demo/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-demo/src/main/res/xml/automotive_app_desc.xml
+++ b/pillarbox-demo/src/main/res/xml/automotive_app_desc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <automotiveApp>

--- a/pillarbox-demo/src/main/res/xml/backup_rules.xml
+++ b/pillarbox-demo/src/main/res/xml/backup_rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <!--

--- a/pillarbox-demo/src/main/res/xml/data_extraction_rules.xml
+++ b/pillarbox-demo/src/main/res/xml/data_extraction_rules.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <!--

--- a/pillarbox-demo/src/main/res/xml/network_security.xml
+++ b/pillarbox-demo/src/main/res/xml/network_security.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <network-security-config>

--- a/pillarbox-demo/src/nightly/res/values/strings.xml
+++ b/pillarbox-demo/src/nightly/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-demo/src/nightlyDebug/res/values/strings.xml
+++ b/pillarbox-demo/src/nightlyDebug/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <resources>

--- a/pillarbox-player-testutils/build.gradle.kts
+++ b/pillarbox-player-testutils/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-player-testutils/src/main/AndroidManifest.xml
+++ b/pillarbox-player-testutils/src/main/AndroidManifest.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?><!--
-  ~ Copyright (c) 2023. SRG SSR. All rights reserved.
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <manifest xmlns:tools="http://schemas.android.com/tools"
     xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <application android:usesCleartextTraffic="true"
+    <application
+        android:usesCleartextTraffic="true"
         tools:targetApi="m" />
 </manifest>

--- a/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/AnalyticsListenerCommander.kt
+++ b/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/AnalyticsListenerCommander.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.test.utils

--- a/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/PlayerListenerCommander.kt
+++ b/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/PlayerListenerCommander.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.test.utils

--- a/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/TestPlayer.kt
+++ b/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/TestPlayer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.test.utils

--- a/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/TestTimeline.kt
+++ b/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/TestTimeline.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.test.utils

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/IsPlayingAllTypeOfContentTest.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/IsPlayingAllTypeOfContentTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/MediaItemSourceTest.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/MediaItemSourceTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/TestIsPlaybackSpeedPossibleAtPosition.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/TestIsPlaybackSpeedPossibleAtPosition.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/utils/ContentUrls.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/utils/ContentUrls.kt
@@ -1,12 +1,13 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.utils
 
 object ContentUrls {
     const val VOD_HLS = "https://swi-vod.akamaized.net/videoJson/47603186/master.m3u8"
-    const val VOD_MP4 = "https://media.swissinfo.ch/media/video/dddaff93-c2cd-4b6e-bdad-55f75a519480/rendition/154a844b-de1d-4854-93c1-5c61cd07e98c.mp4"
+    const val VOD_MP4 =
+        "https://media.swissinfo.ch/media/video/dddaff93-c2cd-4b6e-bdad-55f75a519480/rendition/154a844b-de1d-4854-93c1-5c61cd07e98c.mp4"
     const val VOD_DASH_H264 = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd"
     const val VOD_DASH_H265 = "https://storage.googleapis.com/wvmedia/clear/hevc/tears/tears.mpd"
     const val LIVE_HLS = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0"

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/utils/UniqueMediaItemSource.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/utils/UniqueMediaItemSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.utils

--- a/pillarbox-player/src/main/AndroidManifest.xml
+++ b/pillarbox-player/src/main/AndroidManifest.xml
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/SeekIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/data/MediaItemSource.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/data/MediaItemSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.data

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/ExoPlayerBuilder.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/ExoPlayerBuilder.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.extension

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.extension

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaItem.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaItem.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.extension

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Player.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Player.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.extension

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/PlayerCommands.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/PlayerCommands.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @file:Suppress("unused")

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/PlayerTracks.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/PlayerTracks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.extension

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @file:SuppressWarnings("UnusedPrivateMember")

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Tracks.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Tracks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.extension

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/VideoSize.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/VideoSize.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.extension

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.notification

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxNotificationManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxNotificationManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.notification

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/DefaultMediaSessionCallback.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/DefaultMediaSessionCallback.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.service

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaLibraryService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaLibraryService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.service

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaSessionService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PillarboxMediaSessionService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.service

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PlaybackService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/service/PlaybackService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.service

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.source

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.tracker

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.tracker

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerData.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.tracker

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerList.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.tracker

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerProvider.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerProvider.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.tracker

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.tracker

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/DebugLogger.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/DebugLogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.utils

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PendingIntentUtils.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PendingIntentUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.utils

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/StringUtil.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/StringUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player.utils

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestAspectRatio.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestAspectRatio.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player
@@ -9,10 +9,6 @@ import ch.srgssr.pillarbox.player.extension.computeAspectRatio
 import org.junit.Assert
 import org.junit.Test
 
-/*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
- * License information is available from the LICENSE file.
- */
 class TestAspectRatio {
 
     @Test

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestFormatExtension.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestFormatExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerList.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player
@@ -46,7 +46,7 @@ class TestMediaItemTrackerRepository {
 
         }
 
-        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs:Long) {
+        override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
 
         }
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPlayerCallbackFlow.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPlayerCallbackFlow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestTracksExtension.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestTracksExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player
@@ -105,7 +105,7 @@ class TestTracksExtension {
 
         fun createTrackGroup(listFormat: List<Format>): Tracks.Group {
             val trackGroup = TrackGroup(*listFormat.toTypedArray())
-            val trackSupport = IntArray(listFormat.size){
+            val trackSupport = IntArray(listFormat.size) {
                 C.FORMAT_HANDLED
             }
             val selected = BooleanArray(listFormat.size)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestUnsupportedTracks.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestUnsupportedTracks.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.player

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 @Suppress("DSL_SCOPE_VIOLATION") // TODO Remove once KTIJ-19369 is fixed

--- a/pillarbox-ui/src/main/AndroidManifest.xml
+++ b/pillarbox-ui/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~ Copyright (c) 2022. SRG SSR. All rights reserved.
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ProgressTracker.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ProgressTracker.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ScaleMode.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ScaleMode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerControlView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerControlView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.exoplayer

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.exoplayer

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoplayerSubtitleView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoplayerSubtitleView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.exoplayer

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/SubtitleTextSize.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/SubtitleTextSize.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.exoplayer

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.extension

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/DPadExtensions.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/DPadExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.extension

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/DelayedVisibilityState.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/DelayedVisibilityState.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.widget

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/KeepScreenOn.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/KeepScreenOn.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.widget

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/ToggleableBox.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/ToggleableBox.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.widget

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerSurfaceView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerSurfaceView.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.widget.player

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023. SRG SSR. All rights reserved.
+ * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
 package ch.srgssr.pillarbox.ui.widget.player


### PR DESCRIPTION
# Pull request

## Description

As suggested in https://github.com/SRGSSR/pillarbox-android/pull/294#discussion_r1386721749 by @defagos, I've removed the year from the copyright info in every file.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
