### PR TITLE
Simplify navigation graph definition in "Lists"

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentList.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentList.kt
@@ -21,15 +21,23 @@ sealed interface ContentList {
         val bu: Bu
     }
 
+    interface ContentListFactory<T : ContentList> {
+        val route: String
+        val trackerTitle: String
+
+        fun parse(backStackEntry: NavBackStackEntry): T
+    }
+
     data class TvTopics(override val bu: Bu) : ContentListWithBu {
         override fun getDestinationRoute(): String {
             return "$RootRoute/$bu/tv/topics"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/tv/topics"
+        companion object : ContentListFactory<TvTopics> {
+            override val route = "$RootRoute/{bu}/tv/topics"
+            override val trackerTitle = "tv topics"
 
-            fun parse(backStackEntry: NavBackStackEntry): TvTopics {
+            override fun parse(backStackEntry: NavBackStackEntry): TvTopics {
                 return TvTopics(backStackEntry.readBu())
             }
         }
@@ -40,10 +48,11 @@ sealed interface ContentList {
             return "$RootRoute/latestMediaByTopic/$urn"
         }
 
-        companion object {
-            const val route = "$RootRoute/latestMediaByTopic/{topicUrn}"
+        companion object : ContentListFactory<LatestMediaForTopic> {
+            override val route = "$RootRoute/latestMediaByTopic/{topicUrn}"
+            override val trackerTitle = "Latest media for topic"
 
-            fun parse(backStackEntry: NavBackStackEntry): LatestMediaForTopic {
+            override fun parse(backStackEntry: NavBackStackEntry): LatestMediaForTopic {
                 return LatestMediaForTopic(urn = backStackEntry.arguments?.getString("topicUrn")!!)
             }
         }
@@ -54,10 +63,11 @@ sealed interface ContentList {
             return "$RootRoute/latestMediaByShow/$urn"
         }
 
-        companion object {
-            const val route = "$RootRoute/latestMediaByShow/{showUrn}"
+        companion object : ContentListFactory<LatestMediaForShow> {
+            override val route = "$RootRoute/latestMediaByShow/{showUrn}"
+            override val trackerTitle = "Latest media for show"
 
-            fun parse(backStackEntry: NavBackStackEntry): LatestMediaForShow {
+            override fun parse(backStackEntry: NavBackStackEntry): LatestMediaForShow {
                 return LatestMediaForShow(urn = backStackEntry.arguments?.getString("showUrn")!!)
             }
         }
@@ -68,10 +78,11 @@ sealed interface ContentList {
             return "$RootRoute/$bu/tv/shows"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/tv/shows"
+        companion object : ContentListFactory<TvShows> {
+            override val route = "$RootRoute/{bu}/tv/shows"
+            override val trackerTitle = "tv shows"
 
-            fun parse(backStackEntry: NavBackStackEntry): TvShows {
+            override fun parse(backStackEntry: NavBackStackEntry): TvShows {
                 return TvShows(backStackEntry.readBu())
             }
         }
@@ -82,10 +93,11 @@ sealed interface ContentList {
             return "$RootRoute/$bu/tv/latestMedia"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/tv/latestMedia"
+        companion object : ContentListFactory<TVLatestMedias> {
+            override val route = "$RootRoute/{bu}/tv/latestMedia"
+            override val trackerTitle = "tv latest medias"
 
-            fun parse(backStackEntry: NavBackStackEntry): TVLatestMedias {
+            override fun parse(backStackEntry: NavBackStackEntry): TVLatestMedias {
                 return TVLatestMedias(backStackEntry.readBu())
             }
         }
@@ -96,10 +108,11 @@ sealed interface ContentList {
             return "$RootRoute/$bu/tv/livestream"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/tv/livestream"
+        companion object : ContentListFactory<TVLivestreams> {
+            override val route = "$RootRoute/{bu}/tv/livestream"
+            override val trackerTitle = "tv livestreams"
 
-            fun parse(backStackEntry: NavBackStackEntry): TVLivestreams {
+            override fun parse(backStackEntry: NavBackStackEntry): TVLivestreams {
                 return TVLivestreams(backStackEntry.readBu())
             }
         }
@@ -110,10 +123,11 @@ sealed interface ContentList {
             return "$RootRoute/$bu/tv/livecenter"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/tv/livecenter"
+        companion object : ContentListFactory<TVLiveCenter> {
+            override val route = "$RootRoute/{bu}/tv/livecenter"
+            override val trackerTitle = "tv live center"
 
-            fun parse(backStackEntry: NavBackStackEntry): TVLiveCenter {
+            override fun parse(backStackEntry: NavBackStackEntry): TVLiveCenter {
                 return TVLiveCenter(backStackEntry.readBu())
             }
         }
@@ -124,10 +138,11 @@ sealed interface ContentList {
             return "$RootRoute/$bu/tv/liveweb"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/tv/liveweb"
+        companion object : ContentListFactory<TVLiveWeb> {
+            override val route = "$RootRoute/{bu}/tv/liveweb"
+            override val trackerTitle = "tv live web"
 
-            fun parse(backStackEntry: NavBackStackEntry): TVLiveWeb {
+            override fun parse(backStackEntry: NavBackStackEntry): TVLiveWeb {
                 return TVLiveWeb(backStackEntry.readBu())
             }
         }
@@ -138,10 +153,11 @@ sealed interface ContentList {
             return "$RootRoute/$bu/radio/livestream"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/radio/livestream"
+        companion object : ContentListFactory<RadioLiveStreams> {
+            override val route = "$RootRoute/{bu}/radio/livestream"
+            override val trackerTitle = "Radio livestreams"
 
-            fun parse(backStackEntry: NavBackStackEntry): RadioLiveStreams {
+            override fun parse(backStackEntry: NavBackStackEntry): RadioLiveStreams {
                 return RadioLiveStreams(backStackEntry.readBu())
             }
         }
@@ -152,10 +168,11 @@ sealed interface ContentList {
             return "$RootRoute/${radioChannel.bu}/radio/shows/$radioChannel"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/radio/shows/{radioChannel}"
+        companion object : ContentListFactory<RadioShows> {
+            override val route = "$RootRoute/{bu}/radio/shows/{radioChannel}"
+            override val trackerTitle = "Radio shows"
 
-            fun parse(backStackEntry: NavBackStackEntry): RadioShows {
+            override fun parse(backStackEntry: NavBackStackEntry): RadioShows {
                 return RadioShows(backStackEntry.readRadioChannel())
             }
         }
@@ -166,10 +183,11 @@ sealed interface ContentList {
             return "$RootRoute/${radioChannel.bu}/radio/latestMedia/$radioChannel"
         }
 
-        companion object {
-            const val route = "$RootRoute/{bu}/radio/latestMedia/{radioChannel}"
+        companion object : ContentListFactory<RadioLatestMedias> {
+            override val route = "$RootRoute/{bu}/radio/latestMedia/{radioChannel}"
+            override val trackerTitle = "Radio latest medias"
 
-            fun parse(backStackEntry: NavBackStackEntry): RadioLatestMedias {
+            override fun parse(backStackEntry: NavBackStackEntry): RadioLatestMedias {
                 return RadioLatestMedias(backStackEntry.readRadioChannel())
             }
         }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentList.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentList.kt
@@ -28,17 +28,17 @@ sealed interface ContentList {
         fun parse(backStackEntry: NavBackStackEntry): T
     }
 
-    data class TvTopics(override val bu: Bu) : ContentListWithBu {
+    data class TVTopics(override val bu: Bu) : ContentListWithBu {
         override fun getDestinationRoute(): String {
             return "$RootRoute/$bu/tv/topics"
         }
 
-        companion object : ContentListFactory<TvTopics> {
+        companion object : ContentListFactory<TVTopics> {
             override val route = "$RootRoute/{bu}/tv/topics"
-            override val trackerTitle = "tv topics"
+            override val trackerTitle = "tv-topics"
 
-            override fun parse(backStackEntry: NavBackStackEntry): TvTopics {
-                return TvTopics(backStackEntry.readBu())
+            override fun parse(backStackEntry: NavBackStackEntry): TVTopics {
+                return TVTopics(backStackEntry.readBu())
             }
         }
     }
@@ -50,6 +50,8 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<LatestMediaForTopic> {
             override val route = "$RootRoute/latestMediaByTopic/{topicUrn}"
+
+            // TODO Return the topic once https://github.com/SRGSSR/pillarbox-android/pull/306 is merged
             override val trackerTitle = "Latest media for topic"
 
             override fun parse(backStackEntry: NavBackStackEntry): LatestMediaForTopic {
@@ -65,6 +67,8 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<LatestMediaForShow> {
             override val route = "$RootRoute/latestMediaByShow/{showUrn}"
+
+            // TODO Return the show once https://github.com/SRGSSR/pillarbox-android/pull/306 is merged
             override val trackerTitle = "Latest media for show"
 
             override fun parse(backStackEntry: NavBackStackEntry): LatestMediaForShow {
@@ -73,17 +77,17 @@ sealed interface ContentList {
         }
     }
 
-    data class TvShows(override val bu: Bu) : ContentListWithBu {
+    data class TVShows(override val bu: Bu) : ContentListWithBu {
         override fun getDestinationRoute(): String {
             return "$RootRoute/$bu/tv/shows"
         }
 
-        companion object : ContentListFactory<TvShows> {
+        companion object : ContentListFactory<TVShows> {
             override val route = "$RootRoute/{bu}/tv/shows"
-            override val trackerTitle = "tv shows"
+            override val trackerTitle = "tv-shows"
 
-            override fun parse(backStackEntry: NavBackStackEntry): TvShows {
-                return TvShows(backStackEntry.readBu())
+            override fun parse(backStackEntry: NavBackStackEntry): TVShows {
+                return TVShows(backStackEntry.readBu())
             }
         }
     }
@@ -95,7 +99,7 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<TVLatestMedias> {
             override val route = "$RootRoute/{bu}/tv/latestMedia"
-            override val trackerTitle = "tv latest medias"
+            override val trackerTitle = "tv-latest-videos"
 
             override fun parse(backStackEntry: NavBackStackEntry): TVLatestMedias {
                 return TVLatestMedias(backStackEntry.readBu())
@@ -110,7 +114,7 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<TVLivestreams> {
             override val route = "$RootRoute/{bu}/tv/livestream"
-            override val trackerTitle = "tv livestreams"
+            override val trackerTitle = "tv-livestreams"
 
             override fun parse(backStackEntry: NavBackStackEntry): TVLivestreams {
                 return TVLivestreams(backStackEntry.readBu())
@@ -125,7 +129,7 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<TVLiveCenter> {
             override val route = "$RootRoute/{bu}/tv/livecenter"
-            override val trackerTitle = "tv live center"
+            override val trackerTitle = "live-center"
 
             override fun parse(backStackEntry: NavBackStackEntry): TVLiveCenter {
                 return TVLiveCenter(backStackEntry.readBu())
@@ -140,7 +144,7 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<TVLiveWeb> {
             override val route = "$RootRoute/{bu}/tv/liveweb"
-            override val trackerTitle = "tv live web"
+            override val trackerTitle = "live-web"
 
             override fun parse(backStackEntry: NavBackStackEntry): TVLiveWeb {
                 return TVLiveWeb(backStackEntry.readBu())
@@ -155,7 +159,7 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<RadioLiveStreams> {
             override val route = "$RootRoute/{bu}/radio/livestream"
-            override val trackerTitle = "Radio livestreams"
+            override val trackerTitle = "radio-livestreams"
 
             override fun parse(backStackEntry: NavBackStackEntry): RadioLiveStreams {
                 return RadioLiveStreams(backStackEntry.readBu())
@@ -170,7 +174,7 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<RadioShows> {
             override val route = "$RootRoute/{bu}/radio/shows/{radioChannel}"
-            override val trackerTitle = "Radio shows"
+            override val trackerTitle = "shows"
 
             override fun parse(backStackEntry: NavBackStackEntry): RadioShows {
                 return RadioShows(backStackEntry.readRadioChannel())
@@ -185,7 +189,7 @@ sealed interface ContentList {
 
         companion object : ContentListFactory<RadioLatestMedias> {
             override val route = "$RootRoute/{bu}/radio/latestMedia/{radioChannel}"
-            override val trackerTitle = "Radio latest medias"
+            override val trackerTitle = "latest-audios"
 
             override fun parse(backStackEntry: NavBackStackEntry): RadioLatestMedias {
                 return RadioLatestMedias(backStackEntry.readRadioChannel())

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
@@ -23,3 +23,20 @@ val contentListSections = listOf(
     ContentListSection("Radio Latest medias", RadioChannel.entries.map { ContentList.RadioLatestMedias(it) }),
     ContentListSection("Radio Shows", RadioChannel.entries.map { ContentList.RadioShows(it) }),
 )
+
+/**
+ * All the types of content list in the "Lists" tab.
+ */
+val contentListFactories = listOf(
+    ContentList.TvTopics,
+    ContentList.TvShows,
+    ContentList.TVLatestMedias,
+    ContentList.TVLivestreams,
+    ContentList.TVLiveCenter,
+    ContentList.TVLiveWeb,
+    ContentList.RadioLiveStreams,
+    ContentList.RadioLatestMedias,
+    ContentList.RadioShows,
+    ContentList.LatestMediaForShow,
+    ContentList.LatestMediaForTopic
+)

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
@@ -13,14 +13,14 @@ private val bus = listOf(Bu.RTS, Bu.SRF, Bu.RSI, Bu.RTR, Bu.SWI)
  * All the sections available in the "Lists" tab.
  */
 val contentListSections = listOf(
-    ContentListSection("TV Topics", bus.map { ContentList.TvTopics(it) }),
-    ContentListSection("TV Shows", bus.map { ContentList.TvShows(it) }),
-    ContentListSection("TV Latest medias", bus.map { ContentList.TVLatestMedias(it) }),
+    ContentListSection("TV Topics", bus.map { ContentList.TVTopics(it) }),
+    ContentListSection("TV Shows", bus.map { ContentList.TVShows(it) }),
+    ContentListSection("TV Latest Videos", bus.map { ContentList.TVLatestMedias(it) }),
     ContentListSection("TV Livestreams", bus.map { ContentList.TVLivestreams(it) }),
-    ContentListSection("TV Live center", bus.map { ContentList.TVLiveCenter(it) }),
-    ContentListSection("TV Live web", bus.map { ContentList.TVLiveWeb(it) }),
-    ContentListSection("Radio livestream", bus.map { ContentList.RadioLiveStreams(it) }),
-    ContentListSection("Radio Latest medias", RadioChannel.entries.map { ContentList.RadioLatestMedias(it) }),
+    ContentListSection("TV Live Center", bus.map { ContentList.TVLiveCenter(it) }),
+    ContentListSection("TV Live Web", bus.map { ContentList.TVLiveWeb(it) }),
+    ContentListSection("Radio Livestreams", bus.map { ContentList.RadioLiveStreams(it) }),
+    ContentListSection("Radio Latest Audios", RadioChannel.entries.map { ContentList.RadioLatestMedias(it) }),
     ContentListSection("Radio Shows", RadioChannel.entries.map { ContentList.RadioShows(it) }),
 )
 
@@ -28,8 +28,8 @@ val contentListSections = listOf(
  * All the types of content list in the "Lists" tab.
  */
 val contentListFactories = listOf(
-    ContentList.TvTopics,
-    ContentList.TvShows,
+    ContentList.TVTopics,
+    ContentList.TVShows,
     ContentList.TVLatestMedias,
     ContentList.TVLivestreams,
     ContentList.TVLiveCenter,

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -43,6 +43,7 @@ import androidx.tv.material3.Text
 import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ContentListSection
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListFactories
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 
@@ -107,150 +108,22 @@ fun ListsHome(
             )
         }
 
-        composable(
-            route = ContentList.TvTopics.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.TvTopics.parse(it)
+        contentListFactories.forEach { contentListFactory ->
+            composable(
+                route = contentListFactory.route,
+                arguments = listOf(
+                    navArgument("bu") { type = NavType.StringType }
+                )
+            ) {
+                val contentList = contentListFactory.parse(it)
 
-            BackHandler {
-                navController.popBackStack()
+                BackHandler {
+                    navController.popBackStack()
+                }
+
+                // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
+                Text(text = contentList.toString())
             }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.TvShows.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.TvShows.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.TVLatestMedias.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.TVLatestMedias.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.TVLivestreams.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.TVLivestreams.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.TVLiveCenter.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.TVLiveCenter.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.TVLiveWeb.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.TVLiveWeb.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.RadioLiveStreams.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.RadioLiveStreams.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.RadioLatestMedias.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType },
-                navArgument("radioChannel") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.RadioLatestMedias.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
-        }
-
-        composable(
-            route = ContentList.RadioShows.route,
-            arguments = listOf(
-                navArgument("bu") { type = NavType.StringType },
-                navArgument("radioChannel") { type = NavType.StringType }
-            )
-        ) {
-            val contentList = ContentList.RadioShows.parse(it)
-
-            BackHandler {
-                navController.popBackStack()
-            }
-
-            // TODO Integrate content (https://github.com/SRGSSR/pillarbox-android/issues/298)
-            Text(text = contentList.toString())
         }
     }
 }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -109,12 +109,7 @@ fun ListsHome(
         }
 
         contentListFactories.forEach { contentListFactory ->
-            composable(
-                route = contentListFactory.route,
-                arguments = listOf(
-                    navArgument("bu") { type = NavType.StringType }
-                )
-            ) {
+            composable(route = contentListFactory.route) {
                 val contentList = contentListFactory.parse(it)
 
                 BackHandler {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListViewModel.kt
@@ -48,13 +48,13 @@ class ContentListViewModel(
                 }
             }
 
-            is ContentList.TvShows -> {
+            is ContentList.TVShows -> {
                 ilRepository.getTVShows(contentList.bu).map { pagingData ->
                     pagingData.map { show -> Content.Show(show) }
                 }
             }
 
-            is ContentList.TvTopics -> {
+            is ContentList.TVTopics -> {
                 ilRepository.getTvTopics(contentList.bu).map { pagingData ->
                     pagingData.map { topic -> Content.Topic(topic) }
                 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -26,6 +26,7 @@ import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ContentListSection
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListFactories
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
 import ch.srgssr.pillarbox.demo.ui.composable
 import ch.srgssr.pillarbox.demo.ui.integrationLayer.data.Content
@@ -64,114 +65,20 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
         }
     }
 
-    composable(route = ContentList.TvTopics.route, DemoPageView("tv topics", defaultListsLevels)) { navBackStackEntry ->
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.TvTopics.parse(navBackStackEntry),
+    contentListFactories.forEach { contentListFactory ->
+        composable(
+            route = contentListFactory.route,
+            pageView = DemoPageView(contentListFactory.trackerTitle, defaultListsLevels)
+        ) { navBackStackEntry ->
+            val viewModel = viewModel<ContentListViewModel>(
+                factory = ContentListViewModel.Factory(
+                    ilRepository = ilRepository,
+                    contentList = contentListFactory.parse(navBackStackEntry),
+                )
             )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
 
-    composable(route = ContentList.TvShows.route, DemoPageView("tv shows", defaultListsLevels)) { navBackStackEntry ->
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.TvShows.parse(navBackStackEntry),
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.TVLatestMedias.route, DemoPageView("tv latest medias", defaultListsLevels)) { navBackStackEntry ->
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.TVLatestMedias.parse(navBackStackEntry),
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.TVLivestreams.route, DemoPageView("tv livestreams", defaultListsLevels)) { navBackStackEntry ->
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.TVLivestreams.parse(navBackStackEntry),
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.TVLiveCenter.route, DemoPageView("tv live center", defaultListsLevels)) { navBackStackEntry ->
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.TVLiveCenter.parse(navBackStackEntry),
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.TVLiveWeb.route, DemoPageView(" tv live web", defaultListsLevels)) { navBackStackEntry ->
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.TVLiveWeb.parse(navBackStackEntry),
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.RadioLatestMedias.route, DemoPageView("Radio latest medias", defaultListsLevels)) {
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.RadioLatestMedias.parse(it)
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.RadioShows.route, DemoPageView("Radio shows", defaultListsLevels)) {
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.RadioShows.parse(it)
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.RadioLiveStreams.route, DemoPageView("Radio livestreams", defaultListsLevels)) {
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.RadioLiveStreams.parse(it)
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.LatestMediaForShow.route, DemoPageView("Latest media for show", defaultListsLevels)) {
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.LatestMediaForShow.parse(it)
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
-    }
-
-    composable(route = ContentList.LatestMediaForTopic.route, DemoPageView("Latest media for topic", defaultListsLevels)) {
-        val viewModel: ContentListViewModel = viewModel(
-            factory = ContentListViewModel.Factory(
-                ilRepository = ilRepository,
-                contentList = ContentList.LatestMediaForTopic.parse(it)
-            )
-        )
-        ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
+            ContentListView(contentListViewModel = viewModel, contentClick = contentClick)
+        }
     }
 
     composable("content/error", DemoPageView("error", defaultListsLevels)) {


### PR DESCRIPTION
# Pull request

## Description

As reported by @waliid in https://github.com/SRGSSR/pillarbox-android/pull/299#discussion_r1392044295, there is quite some code duplication in the demo apps in order to handle the various content list in the navigation graph definition. This PR simplifies that by making the code more generic.

## Changes made

- Introduce a `ContentListFactory` interface to group the code required to create a content list
- Use that interface to dynamically create each relevant entry in the navigation graph definition

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.