### PR TITLE
Adjust the layout of "Showcases" to match "Examples"

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListSectionView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListSectionView.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+
+/**
+ * Demo section view.
+ *
+ * @param modifier The [Modifier] to apply to the root of the section.
+ * @param content The content of the section.
+ */
+@Composable
+fun DemoListSectionView(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Card(modifier = modifier) {
+        Column {
+            content()
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun DemoListSectionViewPreview() {
+    PillarboxTheme {
+        DemoListSectionView {
+            Text(text = "Demo list section view")
+        }
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
@@ -5,7 +5,6 @@
 package ch.srgssr.pillarbox.demo.ui.examples
 
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -29,6 +28,7 @@ import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.demo.ui.DemoListHeaderView
 import ch.srgssr.pillarbox.demo.ui.DemoListItemView
+import ch.srgssr.pillarbox.demo.ui.DemoListSectionView
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 
@@ -80,19 +80,17 @@ private fun ListStreamView(
                 modifier = Modifier.padding(start = 16.dp)
             )
 
-            Card {
-                Column {
-                    playlist.items.forEachIndexed { index, item ->
-                        DemoListItemView(
-                            title = item.title,
-                            modifier = Modifier.fillMaxWidth(),
-                            subtitle = item.description,
-                            onClick = { onItemClicked(item) },
-                        )
+            DemoListSectionView {
+                playlist.items.forEachIndexed { index, item ->
+                    DemoListItemView(
+                        title = item.title,
+                        modifier = Modifier.fillMaxWidth(),
+                        subtitle = item.description,
+                        onClick = { onItemClicked(item) },
+                    )
 
-                        if (index < playlist.items.lastIndex) {
-                            Divider()
-                        }
+                    if (index < playlist.items.lastIndex) {
+                        Divider()
                     }
                 }
             }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseList.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseList.kt
@@ -5,12 +5,12 @@
 package ch.srgssr.pillarbox.demo.ui.showcases
 
 import android.content.Intent
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -23,18 +23,19 @@ import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
 import ch.srgssr.pillarbox.demo.ui.DemoListHeaderView
 import ch.srgssr.pillarbox.demo.ui.DemoListItemView
+import ch.srgssr.pillarbox.demo.ui.DemoListSectionView
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.player.mediacontroller.MediaControllerActivity
 
 /**
- * Showcases home page
+ * Showcases home page.
  *
- * @param navController The NavController to navigate into within MainNavigation.
+ * @param navController The [NavController] to navigate between screens.
  */
 @Composable
 fun ShowCaseList(navController: NavController) {
     val context = LocalContext.current
-    val listItems = remember {
+    val playlists = remember {
         listOf(
             Playlist.VideoUrls,
             Playlist.VideoUrns,
@@ -44,50 +45,122 @@ fun ShowCaseList(navController: NavController) {
             Playlist("Empty", emptyList())
         )
     }
-    val scrollState = rememberScrollState()
+    val titleModifier = remember {
+        Modifier.padding(
+            start = 16.dp,
+            top = 8.dp
+        )
+    }
+    val itemModifier = remember {
+        Modifier.fillMaxWidth()
+    }
+
     Column(
         modifier = Modifier
-            .verticalScroll(state = scrollState)
-            .padding(horizontal = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 16.dp)
     ) {
-        val itemModifier = Modifier.fillMaxWidth()
-        DemoListHeaderView(modifier = itemModifier, title = stringResource(id = R.string.layouts))
-        DemoListItemView(modifier = itemModifier, title = stringResource(id = R.string.simple_player)) {
-            navController.navigate(NavigationRoutes.simplePlayer)
-        }
-        DemoListItemView(modifier = itemModifier, title = stringResource(id = R.string.story)) {
-            navController.navigate(NavigationRoutes.story)
+        DemoListHeaderView(
+            title = stringResource(R.string.layouts),
+            modifier = Modifier.padding(start = 16.dp)
+        )
+
+        DemoListSectionView {
+            DemoListItemView(
+                title = stringResource(R.string.simple_player),
+                modifier = itemModifier,
+                onClick = { navController.navigate(NavigationRoutes.simplePlayer) }
+            )
+
+            Divider()
+
+            DemoListItemView(
+                title = stringResource(R.string.story),
+                modifier = itemModifier,
+                onClick = { navController.navigate(NavigationRoutes.story) }
+            )
         }
 
-        DemoListHeaderView(modifier = itemModifier, title = stringResource(id = R.string.playlists))
-        for (playlist in listItems) {
-            DemoListItemView(modifier = itemModifier, title = playlist.title) {
-                SimplePlayerActivity.startActivity(context, playlist)
+        DemoListHeaderView(
+            title = stringResource(R.string.playlists),
+            modifier = titleModifier
+        )
+
+        DemoListSectionView {
+            playlists.forEachIndexed { index, item ->
+                DemoListItemView(
+                    title = item.title,
+                    modifier = itemModifier,
+                    onClick = { SimplePlayerActivity.startActivity(context, item) }
+                )
+
+                if (index < playlists.lastIndex) {
+                    Divider()
+                }
             }
         }
-        DemoListHeaderView(modifier = itemModifier, title = stringResource(id = R.string.system_integration))
-        DemoListItemView(modifier = itemModifier, title = stringResource(id = R.string.auto)) {
-            val intent = Intent(context, MediaControllerActivity::class.java)
-            context.startActivity(intent)
+
+        DemoListHeaderView(
+            title = stringResource(R.string.system_integration),
+            modifier = titleModifier
+        )
+
+        DemoListSectionView {
+            DemoListItemView(
+                title = stringResource(R.string.auto),
+                modifier = itemModifier,
+                onClick = {
+                    val intent = Intent(context, MediaControllerActivity::class.java)
+                    context.startActivity(intent)
+                }
+            )
         }
 
-        DemoListHeaderView(modifier = itemModifier, title = stringResource(id = R.string.embeddings))
-        DemoListItemView(modifier = itemModifier, title = stringResource(id = R.string.adaptive)) {
-            navController.navigate(NavigationRoutes.adaptive)
-        }
-        DemoListItemView(modifier = itemModifier, title = stringResource(id = R.string.player_swap)) {
-            navController.navigate(NavigationRoutes.playerSwap)
+        DemoListHeaderView(
+            title = stringResource(R.string.embeddings),
+            modifier = titleModifier
+        )
+
+        DemoListSectionView {
+            DemoListItemView(
+                title = stringResource(R.string.adaptive),
+                modifier = itemModifier,
+                onClick = { navController.navigate(NavigationRoutes.adaptive) }
+            )
+
+            Divider()
+
+            DemoListItemView(
+                title = stringResource(R.string.player_swap),
+                modifier = itemModifier,
+                onClick = { navController.navigate(NavigationRoutes.playerSwap) }
+            )
         }
 
-        DemoListHeaderView(modifier = itemModifier, title = stringResource(id = R.string.exoplayer))
-        DemoListItemView(modifier = itemModifier, title = stringResource(id = R.string.exoplayer_view)) {
-            navController.navigate(NavigationRoutes.exoPlayerSample)
+        DemoListHeaderView(
+            title = stringResource(R.string.exoplayer),
+            modifier = titleModifier
+        )
+
+        DemoListSectionView {
+            DemoListItemView(
+                title = stringResource(R.string.exoplayer_view),
+                modifier = itemModifier,
+                onClick = { navController.navigate(NavigationRoutes.exoPlayerSample) }
+            )
         }
 
-        DemoListHeaderView(modifier = itemModifier, title = stringResource(id = R.string.tracking))
-        DemoListItemView(modifier = itemModifier, title = stringResource(id = R.string.tracker_example)) {
-            navController.navigate(NavigationRoutes.trackingSample)
+        DemoListHeaderView(
+            title = stringResource(R.string.tracking),
+            modifier = titleModifier
+        )
+
+        DemoListSectionView(modifier = Modifier.padding(bottom = 16.dp)) {
+            DemoListItemView(
+                title = stringResource(R.string.tracker_example),
+                modifier = itemModifier,
+                onClick = { navController.navigate(NavigationRoutes.trackingSample) }
+            )
         }
     }
 }


### PR DESCRIPTION
# Pull request

## Description

This PR updates the layout of the "Showcases" section of the mobile demo app.

## Changes made

- Created a new `DemoListSectionView` component
- Adjusted the "Showcases" layout to match what has been done in "Examples" in #312 

## Screenshots

| Light mode | Dark mode |
|-----|-----|
| ![Screenshot_20231120_111426](https://github.com/SRGSSR/pillarbox-android/assets/1009664/5ef8fa83-d6d0-4333-b519-af9f49734c77) | ![Screenshot_20231120_111436](https://github.com/SRGSSR/pillarbox-android/assets/1009664/09fabb66-6ebd-465a-8cdf-e28600901440) |

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.