### PR TITLE
Adjust the layout of "Lists" to match "Examples"

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListSectionView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListSectionView.kt
@@ -5,6 +5,7 @@
 package ch.srgssr.pillarbox.demo.ui
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,7 +22,7 @@ import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 @Composable
 fun DemoListSectionView(
     modifier: Modifier = Modifier,
-    content: @Composable () -> Unit
+    content: @Composable ColumnScope.() -> Unit
 ) {
     Card(modifier = modifier) {
         Column {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
@@ -4,18 +4,20 @@
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
@@ -33,6 +35,7 @@ import ch.srg.dataProvider.integrationlayer.data.remote.Transmission
 import ch.srg.dataProvider.integrationlayer.data.remote.Type
 import ch.srg.dataProvider.integrationlayer.data.remote.Vendor
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
+import ch.srgssr.pillarbox.demo.ui.DemoListHeaderView
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import kotlinx.coroutines.flow.flowOf
 import java.util.Date
@@ -41,12 +44,14 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Display a paged list of [Content].
  *
+ * @param title The title of the list.
  * @param items The list of items to display.
  * @param modifier The [Modifier] to apply to the root of the list.
  * @param contentClick The action to perform when clicking on an item.
  */
 @Composable
 fun ContentListView(
+    title: String,
     items: LazyPagingItems<Content>,
     modifier: Modifier = Modifier,
     contentClick: (Content) -> Unit
@@ -59,17 +64,51 @@ fun ContentListView(
         } else {
             LazyColumn(
                 modifier = modifier,
-                contentPadding = PaddingValues(horizontal = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    bottom = 16.dp
+                ),
             ) {
-                items(count = items.itemCount, key = items.itemKey()) { index ->
+                item(contentType = "title") {
+                    DemoListHeaderView(
+                        title = title,
+                        modifier = Modifier.padding(start = 16.dp)
+                    )
+                }
+
+                items(
+                    count = items.itemCount,
+                    key = items.itemKey(),
+                    contentType = { "item" },
+                ) { index ->
                     items[index]?.let { item ->
+                        val shape = when (index) {
+                            0 -> RoundedCornerShape(
+                                topStart = 16.dp,
+                                topEnd = 16.dp,
+                            )
+
+                            items.itemCount - 1 -> RoundedCornerShape(
+                                bottomStart = 16.dp,
+                                bottomEnd = 16.dp,
+                            )
+
+                            else -> RectangleShape
+                        }
+
                         ContentView(
                             content = item,
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { contentClick(item) }
+                            modifier = Modifier.background(
+                                color = MaterialTheme.colorScheme.surfaceVariant,
+                                shape = shape
+                            ),
+                            onClick = { contentClick(item) }
                         )
+
+                        if (index < items.itemCount - 1) {
+                            Divider()
+                        }
                     }
                 }
             }
@@ -119,6 +158,7 @@ private fun ContentListViewLoadingPreview() {
 
     PillarboxTheme {
         ContentListView(
+            title = "Title loading",
             items = flowOf(items).collectAsLazyPagingItems(),
             contentClick = {}
         )
@@ -138,6 +178,7 @@ private fun ContentListViewEmptyPreview() {
 
     PillarboxTheme {
         ContentListView(
+            title = "Title empty",
             items = flowOf(items).collectAsLazyPagingItems(),
             contentClick = {}
         )
@@ -147,7 +188,6 @@ private fun ContentListViewEmptyPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun ContentListViewPreview() {
-    // TODO
     val items = PagingData.from(
         listOf(
             Content.Media(
@@ -196,6 +236,7 @@ private fun ContentListViewPreview() {
 
     PillarboxTheme {
         ContentListView(
+            title = "Title content",
             items = flowOf(items).collectAsLazyPagingItems(),
             contentClick = {}
         )
@@ -216,6 +257,7 @@ private fun ContentListViewErrorPreview() {
 
     PillarboxTheme {
         ContentListView(
+            title = "Title error",
             items = flowOf(items).collectAsLazyPagingItems(),
             contentClick = {}
         )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -4,15 +4,13 @@
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer
 
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Divider
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -28,10 +26,12 @@ import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentListViewModel
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
-import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ContentListSection
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ILRepository
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListFactories
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
+import ch.srgssr.pillarbox.demo.ui.DemoListHeaderView
+import ch.srgssr.pillarbox.demo.ui.DemoListItemView
+import ch.srgssr.pillarbox.demo.ui.DemoListSectionView
 import ch.srgssr.pillarbox.demo.ui.composable
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
@@ -102,53 +102,42 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
 
 @Composable
 private fun ContentListsView(onContentSelected: (ContentList) -> Unit) {
-    LazyColumn {
-        items(contentListSections) {
-            SectionItemView(
-                modifier = Modifier
-                    .padding(12.dp)
-                    .fillMaxWidth()
-                    .wrapContentHeight(),
-                sectionItem = it, onContentSelected = onContentSelected
+    LazyColumn(
+        contentPadding = PaddingValues(
+            start = 16.dp,
+            end = 16.dp,
+            bottom = 16.dp
+        ),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(contentListSections) { section ->
+            DemoListHeaderView(
+                title = section.title,
+                modifier = Modifier.padding(start = 16.dp)
             )
+
+            DemoListSectionView {
+                section.contentList.forEachIndexed { index, item ->
+                    DemoListItemView(
+                        title = item.destinationTitle,
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { onContentSelected(item) }
+                    )
+
+                    if (index < section.contentList.lastIndex) {
+                        Divider()
+                    }
+                }
+            }
         }
     }
 }
 
-@Preview
 @Composable
+@Preview(showBackground = true)
 private fun ContentListPreview() {
     PillarboxTheme {
         ContentListsView {
-        }
-    }
-}
-
-@Composable
-private fun SectionItemView(
-    sectionItem: ContentListSection,
-    onContentSelected: (ContentList) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Card(modifier = modifier) {
-        Column(modifier = Modifier.padding(12.dp)) {
-            Text(modifier = Modifier.padding(vertical = 6.dp), text = sectionItem.title.uppercase(), style = MaterialTheme.typography.bodyLarge)
-            for (content in sectionItem.contentList) {
-                val label = when (content) {
-                    is ContentList.ContentListWithBu -> content.bu.name
-                    is ContentList.ContentListWithRadioChannel -> content.radioChannel.label
-                    is ContentList.LatestMediaForShow -> content.show
-                    is ContentList.LatestMediaForTopic -> content.topic
-                }
-
-                Button(
-                    modifier = Modifier
-                        .fillMaxWidth(),
-                    onClick = { onContentSelected(content) }
-                ) {
-                    Text(text = label.uppercase())
-                }
-            }
         }
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -80,14 +80,16 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
             route = contentListFactory.route,
             pageView = DemoPageView(contentListFactory.trackerTitle, defaultListsLevels)
         ) { navBackStackEntry ->
+            val contentList = contentListFactory.parse(navBackStackEntry)
             val viewModel = viewModel<ContentListViewModel>(
                 factory = ContentListViewModel.Factory(
                     ilRepository = ilRepository,
-                    contentList = contentListFactory.parse(navBackStackEntry),
+                    contentList = contentList,
                 )
             )
 
             ContentListView(
+                title = contentList.destinationTitle,
                 items = viewModel.data.collectAsLazyPagingItems(),
                 modifier = Modifier.fillMaxWidth(),
                 contentClick = contentClick

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
@@ -4,16 +4,10 @@
  */
 package ch.srgssr.pillarbox.demo.ui.integrationLayer
 
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import ch.srg.dataProvider.integrationlayer.data.ImageUrl
 import ch.srg.dataProvider.integrationlayer.data.remote.Media
 import ch.srg.dataProvider.integrationlayer.data.remote.MediaType
@@ -23,62 +17,70 @@ import ch.srg.dataProvider.integrationlayer.data.remote.Transmission
 import ch.srg.dataProvider.integrationlayer.data.remote.Type
 import ch.srg.dataProvider.integrationlayer.data.remote.Vendor
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
+import ch.srgssr.pillarbox.demo.ui.DemoListItemView
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
-import java.text.SimpleDateFormat
+import java.text.DateFormat
 import java.util.Date
-import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 
 /**
- * Content view
+ * Content view.
  *
- * @param content
- * @param modifier
+ * @param content The content to display.
+ * @param modifier The [Modifier] to apply to the component.
+ * @param onClick The action to perform when clicking the component.
  */
 @Composable
-fun ContentView(content: Content, modifier: Modifier = Modifier) {
+fun ContentView(
+    content: Content,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
     when (content) {
-        is Content.Topic -> TopicView(content = content, modifier = modifier)
-        is Content.Show -> ShowView(content = content, modifier = modifier)
-        is Content.Media -> MediaView(content = content, modifier = modifier)
+        is Content.Topic -> DemoListItemView(
+            title = content.topic.title,
+            modifier = modifier.fillMaxWidth(),
+            onClick = onClick
+        )
+
+        is Content.Show -> DemoListItemView(
+            title = content.show.title,
+            modifier = modifier.fillMaxWidth(),
+            onClick = onClick
+        )
+
+        is Content.Media -> MediaView(
+            content = content,
+            modifier = modifier.fillMaxWidth(),
+            onClick = onClick
+        )
     }
 }
 
 @Composable
-private fun TopicView(content: Content.Topic, modifier: Modifier = Modifier) {
-    Card(modifier = modifier) {
-        Text(modifier = Modifier.padding(8.dp), text = content.topic.title)
+private fun MediaView(
+    content: Content.Media,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    val subtitleSuffix = when (content.media.mediaType) {
+        MediaType.AUDIO -> "🎧"
+        MediaType.VIDEO -> "🎬"
     }
+    val showTitle = content.media.show?.title
+    val dateString = DateFormat.getDateInstance().format(content.media.date)
+    val subtitle = showTitle?.let { "$it - $dateString" } ?: dateString
+
+    DemoListItemView(
+        title = content.media.title,
+        modifier = modifier,
+        subtitle = "$subtitle $subtitleSuffix",
+        onClick = onClick
+    )
 }
 
 @Composable
-private fun MediaView(content: Content.Media, modifier: Modifier = Modifier) {
-    val simpleDateFormat = SimpleDateFormat("EEE, d MMM yyyy", Locale.getDefault())
-    val dateString = simpleDateFormat.format(content.media.date)
-    val subtitle = content.media.show?.let {
-        "${it.title} - $dateString"
-    } ?: dateString
-
-    Card(modifier = modifier) {
-        Column(modifier = Modifier.padding(8.dp)) {
-            Text(text = content.media.title, style = MaterialTheme.typography.bodyLarge)
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.labelMedium,
-            )
-        }
-    }
-}
-
-@Composable
-private fun ShowView(content: Content.Show, modifier: Modifier = Modifier) {
-    Card(modifier = modifier) {
-        Text(modifier = Modifier.padding(8.dp), text = content.show.title)
-    }
-}
-
-@Preview
-@Composable
+@Preview(showBackground = true)
 private fun ShowPreview() {
     val show = Show(
         id = "id",
@@ -89,13 +91,17 @@ private fun ShowPreview() {
         transmission = Transmission.TV,
         imageUrl = ImageUrl("https://image1.png")
     )
-    PillarboxTheme() {
-        ShowView(modifier = Modifier.fillMaxWidth(), content = Content.Show(show))
+
+    PillarboxTheme {
+        ContentView(
+            content = Content.Show(show),
+            onClick = {}
+        )
     }
 }
 
-@Preview
 @Composable
+@Preview(showBackground = true)
 private fun TopicPreview() {
     val topic = Topic(
         id = "id",
@@ -105,13 +111,17 @@ private fun TopicPreview() {
         transmission = Transmission.TV,
         imageUrl = ImageUrl("https://imag2.png")
     )
-    PillarboxTheme() {
-        TopicView(modifier = Modifier.fillMaxWidth(), content = Content.Topic(topic))
+
+    PillarboxTheme {
+        ContentView(
+            content = Content.Topic(topic),
+            onClick = {}
+        )
     }
 }
 
-@Preview
 @Composable
+@Preview(showBackground = true)
 private fun MediaPreview() {
     val media = Media(
         id = "id",
@@ -126,7 +136,11 @@ private fun MediaPreview() {
         type = Type.CLIP,
         imageUrl = ImageUrl("https://image2.png")
     )
-    PillarboxTheme() {
-        MediaView(modifier = Modifier.fillMaxWidth(), content = Content.Media(media))
+
+    PillarboxTheme {
+        ContentView(
+            content = Content.Media(media),
+            onClick = {}
+        )
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
@@ -109,7 +109,7 @@ private fun TopicPreview() {
         urn = "urn:show:id",
         title = "Topic title",
         transmission = Transmission.TV,
-        imageUrl = ImageUrl("https://imag2.png")
+        imageUrl = ImageUrl("https://image2.png")
     )
 
     PillarboxTheme {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -5,7 +5,6 @@
 package ch.srgssr.pillarbox.demo.ui.integrationLayer
 
 import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -160,9 +159,8 @@ private fun SearchResultList(
                     content = mediaResult,
                     modifier = Modifier
                         .padding(bottom = 2.dp)
-                        .fillMaxWidth()
-                        .minimumInteractiveComponentSize()
-                        .clickable { contentClick(mediaResult) }
+                        .minimumInteractiveComponentSize(),
+                    onClick = { contentClick(mediaResult) }
                 )
             }
         }


### PR DESCRIPTION
# Pull request

## Description

This PR updates the layout of the "Lists" section of the mobile demo app.

## Changes made

- Display a title on subsection of "Lists"
- Align the design of each section to match what has been done in "Examples" and "Showcases"
- Display an icon on media list to indicate if it is a video or an audio content

## Screenshots

| Description | Light mode | Dark mode |
|-----|-----|-----|
| Main screen| ![Screenshot_20231121_090927](https://github.com/SRGSSR/pillarbox-android/assets/1009664/bf7a5eb5-fce0-45d8-8693-f3b0e2fe6e77) | ![Screenshot_20231121_091001](https://github.com/SRGSSR/pillarbox-android/assets/1009664/1fa84acd-c701-42cb-b645-1c4d990dd6ff) |
| Sub-section | ![Screenshot_20231121_090934](https://github.com/SRGSSR/pillarbox-android/assets/1009664/e408ca50-6b43-4206-a469-26e54f2b3e92) | ![Screenshot_20231121_091005](https://github.com/SRGSSR/pillarbox-android/assets/1009664/a74490a2-ef12-420b-b4c3-6eeea7894b10) |
| Video list | ![Screenshot_20231121_090939](https://github.com/SRGSSR/pillarbox-android/assets/1009664/7faa37e1-adbe-4c54-bd91-f7701dfe070b) | ![Screenshot_20231121_091010](https://github.com/SRGSSR/pillarbox-android/assets/1009664/05f3648a-aa70-4c8e-88f8-2c136c9b0ea2) |
| Audio list | ![Screenshot_20231121_090950](https://github.com/SRGSSR/pillarbox-android/assets/1009664/eb78b0d0-e19a-4831-b456-771d9e20755a) | ![Screenshot_20231121_091022](https://github.com/SRGSSR/pillarbox-android/assets/1009664/a22f5d5c-812c-4869-b458-e4eb4d74766f) |

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.