### PR TITLE
Centralise padding values

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListHeaderView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListHeaderView.kt
@@ -10,8 +10,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
  * Demo list header view.
@@ -27,8 +27,8 @@ fun DemoListHeaderView(
     Text(
         text = title,
         modifier = modifier.padding(
-            top = 16.dp,
-            bottom = 8.dp
+            top = MaterialTheme.paddings.baseline,
+            bottom = MaterialTheme.paddings.small
         ),
         style = MaterialTheme.typography.bodyLarge
     )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListItemView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/DemoListItemView.kt
@@ -15,8 +15,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
  * Demo item view.
@@ -38,8 +38,8 @@ fun DemoListItemView(
             .clickable { onClick() }
             .minimumInteractiveComponentSize()
             .padding(
-                horizontal = 16.dp,
-                vertical = 8.dp
+                horizontal = MaterialTheme.paddings.baseline,
+                vertical = MaterialTheme.paddings.small
             )
     ) {
         Text(
@@ -52,7 +52,7 @@ fun DemoListItemView(
         if (!subtitle.isNullOrBlank()) {
             Text(
                 text = subtitle,
-                modifier = Modifier.padding(top = 2.dp),
+                modifier = Modifier.padding(top = MaterialTheme.paddings.micro),
                 color = MaterialTheme.colorScheme.outline,
                 overflow = TextOverflow.Ellipsis,
                 maxLines = 1,

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/InfoView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/InfoView.kt
@@ -14,9 +14,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import ch.srgssr.pillarbox.demo.BuildConfig
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
  * Display current version name
@@ -26,7 +26,7 @@ fun InfoView() {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .padding(8.dp)
+            .padding(MaterialTheme.paddings.small)
     ) {
         Text(
             text = BuildConfig.VERSION_NAME,

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/ExamplesHome.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.srgssr.pillarbox.demo.BuildConfig
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
@@ -31,6 +30,7 @@ import ch.srgssr.pillarbox.demo.ui.DemoListItemView
 import ch.srgssr.pillarbox.demo.ui.DemoListSectionView
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
  * Examples home page.
@@ -55,17 +55,17 @@ private fun ListStreamView(
 ) {
     LazyColumn(
         contentPadding = PaddingValues(
-            horizontal = 16.dp,
-            vertical = 8.dp
+            horizontal = MaterialTheme.paddings.baseline,
+            vertical = MaterialTheme.paddings.small
         ),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.small),
     ) {
         item(contentType = "url_urn_input") {
             Card(modifier = Modifier.fillMaxWidth()) {
                 InsertContentView(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(8.dp),
+                        .padding(MaterialTheme.paddings.small),
                     onPlayClick = onItemClicked
                 )
             }
@@ -77,7 +77,7 @@ private fun ListStreamView(
         ) { playlist ->
             DemoListHeaderView(
                 title = playlist.title,
-                modifier = Modifier.padding(start = 16.dp)
+                modifier = Modifier.padding(start = MaterialTheme.paddings.baseline)
             )
 
             DemoListSectionView {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -31,10 +32,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import ch.srgssr.pillarbox.demo.R
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 private data class InsertContentData(
     val uri: String = "",
@@ -68,8 +69,8 @@ fun InsertContentView(
     }
 
     Column(
-        modifier = modifier.padding(bottom = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
+        modifier = modifier.padding(bottom = MaterialTheme.paddings.small),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.small),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         InsertContentTextField(
@@ -77,7 +78,7 @@ fun InsertContentView(
             label = stringResource(R.string.enter_url_or_urn),
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 4.dp),
+                .padding(horizontal = MaterialTheme.paddings.mini),
             onValueChange = { insertContentData = insertContentData.copy(uri = it) },
             onClearClick = { insertContentData = InsertContentData() }
         )
@@ -88,7 +89,7 @@ fun InsertContentView(
                 label = stringResource(R.string.licence_url),
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 4.dp),
+                    .padding(horizontal = MaterialTheme.paddings.mini),
                 onValueChange = { insertContentData = insertContentData.copy(licenseUrl = it) },
                 onClearClick = { insertContentData = insertContentData.copy(licenseUrl = "") }
             )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
 import androidx.paging.PagingData
@@ -37,6 +36,7 @@ import ch.srg.dataProvider.integrationlayer.data.remote.Vendor
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.ui.DemoListHeaderView
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import kotlinx.coroutines.flow.flowOf
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
@@ -65,15 +65,15 @@ fun ContentListView(
             LazyColumn(
                 modifier = modifier,
                 contentPadding = PaddingValues(
-                    start = 16.dp,
-                    end = 16.dp,
-                    bottom = 16.dp
+                    start = MaterialTheme.paddings.baseline,
+                    end = MaterialTheme.paddings.baseline,
+                    bottom = MaterialTheme.paddings.baseline
                 ),
             ) {
                 item(contentType = "title") {
                     DemoListHeaderView(
                         title = title,
-                        modifier = Modifier.padding(start = 16.dp)
+                        modifier = Modifier.padding(start = MaterialTheme.paddings.baseline)
                     )
                 }
 
@@ -85,13 +85,13 @@ fun ContentListView(
                     items[index]?.let { item ->
                         val shape = when (index) {
                             0 -> RoundedCornerShape(
-                                topStart = 16.dp,
-                                topEnd = 16.dp,
+                                topStart = MaterialTheme.paddings.baseline,
+                                topEnd = MaterialTheme.paddings.baseline,
                             )
 
                             items.itemCount - 1 -> RoundedCornerShape(
-                                bottomStart = 16.dp,
-                                bottomEnd = 16.dp,
+                                bottomStart = MaterialTheme.paddings.baseline,
+                                bottomEnd = MaterialTheme.paddings.baseline,
                             )
 
                             else -> RectangleShape

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -11,11 +11,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -35,6 +35,7 @@ import ch.srgssr.pillarbox.demo.ui.DemoListSectionView
 import ch.srgssr.pillarbox.demo.ui.composable
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 private val defaultListsLevels = listOf("app", "pillarbox", "lists")
 
@@ -106,16 +107,16 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
 private fun ContentListsView(onContentSelected: (ContentList) -> Unit) {
     LazyColumn(
         contentPadding = PaddingValues(
-            start = 16.dp,
-            end = 16.dp,
-            bottom = 16.dp
+            start = MaterialTheme.paddings.baseline,
+            end = MaterialTheme.paddings.baseline,
+            bottom = MaterialTheme.paddings.baseline
         ),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.small)
     ) {
         items(contentListSections) { section ->
             DemoListHeaderView(
                 title = section.title,
-                modifier = Modifier.padding(start = 16.dp)
+                modifier = Modifier.padding(start = MaterialTheme.paddings.baseline)
             )
 
             DemoListSectionView {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -64,6 +64,7 @@ import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
 import ch.srgssr.pillarbox.demo.R
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 private val bus = listOf(Bu.RSI, Bu.RTR, Bu.RTS, Bu.SRF, Bu.SWI)
 
@@ -86,8 +87,8 @@ fun SearchView(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(horizontal = 16.dp),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+            .padding(horizontal = MaterialTheme.paddings.baseline),
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.baseline)
     ) {
         SearchInput(
             query = searchQuery,
@@ -133,13 +134,13 @@ private fun SearchResultList(
                         items[index]?.let { item ->
                             val shape = when (index) {
                                 0 -> RoundedCornerShape(
-                                    topStart = 16.dp,
-                                    topEnd = 16.dp,
+                                    topStart = MaterialTheme.paddings.baseline,
+                                    topEnd = MaterialTheme.paddings.baseline,
                                 )
 
                                 items.itemCount - 1 -> RoundedCornerShape(
-                                    bottomStart = 16.dp,
-                                    bottomEnd = 16.dp,
+                                    bottomStart = MaterialTheme.paddings.baseline,
+                                    bottomEnd = MaterialTheme.paddings.baseline,
                                 )
 
                                 else -> RectangleShape
@@ -196,7 +197,7 @@ private fun SearchInput(
 
             Row(
                 modifier = Modifier
-                    .padding(end = 8.dp)
+                    .padding(end = MaterialTheme.paddings.small)
                     .clickable(
                         interactionSource = remember { MutableInteractionSource() },
                         indication = null
@@ -205,8 +206,8 @@ private fun SearchInput(
                     }
                     .fillMaxHeight()
                     .padding(
-                        start = 16.dp,
-                        end = 8.dp
+                        start = MaterialTheme.paddings.baseline,
+                        end = MaterialTheme.paddings.small
                     ),
                 verticalAlignment = Alignment.CenterVertically
             ) {
@@ -227,7 +228,10 @@ private fun SearchInput(
             DropdownMenu(
                 expanded = showBuSelector,
                 onDismissRequest = { showBuSelector = false },
-                offset = DpOffset(x = 0.dp, y = 8.dp)
+                offset = DpOffset(
+                    x = 0.dp,
+                    y = MaterialTheme.paddings.small
+                )
             ) {
                 bus.forEach { bu ->
                     DropdownMenuItem(
@@ -287,7 +291,7 @@ private fun NoContent(modifier: Modifier = Modifier) {
 
         Text(
             text = stringResource(R.string.empty_search_query),
-            modifier = Modifier.padding(top = 8.dp)
+            modifier = Modifier.padding(top = MaterialTheme.paddings.small)
         )
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -17,7 +18,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -26,6 +26,7 @@ import ch.srgssr.pillarbox.demo.ui.ShowSystemUi
 import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerBottomToolbar
 import ch.srgssr.pillarbox.demo.ui.player.playlist.PlaylistView
 import ch.srgssr.pillarbox.demo.ui.player.settings.PlaybackSettingsContent
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.ScaleMode
 import com.google.accompanist.navigation.material.ExperimentalMaterialNavigationApi
 import com.google.accompanist.navigation.material.ModalBottomSheetLayout
@@ -143,7 +144,7 @@ private fun PlayerContent(
                 modifier = Modifier
                     .weight(1.0f)
                     .fillMaxWidth()
-                    .padding(horizontal = 12.dp),
+                    .padding(horizontal = MaterialTheme.paddings.baseline),
                 player = player
             )
         }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlaybackSettingsDropDownMenu.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlaybackSettingsDropDownMenu.kt
@@ -11,11 +11,12 @@ import androidx.compose.material3.Divider
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.extension.playbackSpeedAsState
 
 private val speeds = mapOf(
@@ -43,7 +44,10 @@ fun PlaybackSettingsDropDownMenu(
 ) {
     val currentPlaybackSpeed = player.playbackSpeedAsState()
     DropdownMenu(expanded = expanded, onDismissRequest = onDismissed) {
-        Text(modifier = Modifier.padding(horizontal = 12.dp), text = "Playbacks options")
+        Text(
+            text = "Playbacks options",
+            modifier = Modifier.padding(horizontal = MaterialTheme.paddings.baseline)
+        )
         Divider()
         for (speed in speeds) {
             val selected = speed.value == currentPlaybackSpeed

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/MediaItemLibrary.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/MediaItemLibrary.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.window.Dialog
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
  * Media item library dialog
@@ -59,7 +60,7 @@ fun MediaItemLibraryDialog(
                 listDemoItem = mediaItemLibrary,
                 modifier = Modifier
                     .fillMaxHeight(0.9f)
-                    .padding(12.dp),
+                    .padding(MaterialTheme.paddings.baseline),
                 onAddClick = {
                     onItemSelected(selectedItems)
                 },
@@ -87,19 +88,18 @@ private fun DialogContent(
 ) {
     Column(
         modifier = modifier,
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.small)
     ) {
         Text(
-            modifier = Modifier,
             text = "Add to the playlist",
             style = MaterialTheme.typography.headlineMedium
         )
-        Divider(modifier = Modifier)
+        Divider()
         LazyColumn(
             modifier = Modifier
                 .weight(0.5f)
-                .padding(horizontal = 8.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+                .padding(horizontal = MaterialTheme.paddings.small),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.baseline)
         ) {
             items(listDemoItem) {
                 val selected = selectedItems.contains(it)
@@ -113,7 +113,7 @@ private fun DialogContent(
                 )
             }
         }
-        Divider(modifier = Modifier)
+        Divider()
         Row(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.SpaceBetween
@@ -132,7 +132,7 @@ private fun DialogContent(
 private fun SelectableDemoItem(modifier: Modifier, demoItem: DemoItem, selected: Boolean) {
     Row(
         modifier,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.mini),
         verticalAlignment = Alignment.CenterVertically
     ) {
         RadioButton(selected = selected, onClick = null)
@@ -149,7 +149,7 @@ private fun MediaItemLibraryPreview() {
         DialogContent(
             modifier = Modifier
                 .fillMaxHeight(0.9f)
-                .padding(12.dp),
+                .padding(MaterialTheme.paddings.baseline),
             listDemoItem = list,
             selectedItems = selectedItems,
             onItemToggleClick = { _, _ -> },

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
@@ -32,12 +32,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.extension.currentMediaItemIndexAsState
 import ch.srgssr.pillarbox.ui.extension.getCurrentMediaItemsAsState
 import ch.srgssr.pillarbox.ui.extension.shuffleModeEnabledAsState
@@ -166,7 +166,7 @@ private fun PlaylistView(
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(40.dp),
+                        .padding(MaterialTheme.paddings.medium),
                     contentAlignment = Alignment.Center
                 ) {
                     Text(

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseList.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseList.kt
@@ -11,12 +11,12 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import ch.srgssr.pillarbox.demo.R
 import ch.srgssr.pillarbox.demo.shared.data.Playlist
@@ -26,6 +26,7 @@ import ch.srgssr.pillarbox.demo.ui.DemoListItemView
 import ch.srgssr.pillarbox.demo.ui.DemoListSectionView
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.player.mediacontroller.MediaControllerActivity
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
  * Showcases home page.
@@ -45,24 +46,20 @@ fun ShowCaseList(navController: NavController) {
             Playlist("Empty", emptyList())
         )
     }
-    val titleModifier = remember {
-        Modifier.padding(
-            start = 16.dp,
-            top = 8.dp
-        )
-    }
-    val itemModifier = remember {
-        Modifier.fillMaxWidth()
-    }
+    val titleModifier = Modifier.padding(
+        start = MaterialTheme.paddings.baseline,
+        top = MaterialTheme.paddings.small
+    )
+    val itemModifier = Modifier.fillMaxWidth()
 
     Column(
         modifier = Modifier
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 16.dp)
+            .padding(horizontal = MaterialTheme.paddings.baseline)
     ) {
         DemoListHeaderView(
             title = stringResource(R.string.layouts),
-            modifier = Modifier.padding(start = 16.dp)
+            modifier = Modifier.padding(start = MaterialTheme.paddings.baseline)
         )
 
         DemoListSectionView {
@@ -155,7 +152,7 @@ fun ShowCaseList(navController: NavController) {
             modifier = titleModifier
         )
 
-        DemoListSectionView(modifier = Modifier.padding(bottom = 16.dp)) {
+        DemoListSectionView(modifier = Modifier.padding(bottom = MaterialTheme.paddings.baseline)) {
             DemoListItemView(
                 title = stringResource(R.string.tracker_example),
                 modifier = itemModifier,

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/adaptive/AdaptivePlayer.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/adaptive/AdaptivePlayer.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -28,10 +29,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.ScaleMode
 import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 
@@ -66,12 +67,12 @@ private fun AdaptivePlayer(player: Player, modifier: Modifier = Modifier) {
         mutableStateOf(ScaleMode.Fit)
     }
     var widthPercent by remember {
-        mutableStateOf(1f)
+        mutableFloatStateOf(1f)
     }
     var heightPercent by remember {
-        mutableStateOf(1f)
+        mutableFloatStateOf(1f)
     }
-    BoxWithConstraints(modifier = modifier.padding(12.dp)) {
+    BoxWithConstraints(modifier = modifier.padding(MaterialTheme.paddings.baseline)) {
         Box(
             modifier = Modifier
                 .size(maxWidth * widthPercent, maxHeight * heightPercent),
@@ -96,7 +97,7 @@ private fun AdaptivePlayer(player: Player, modifier: Modifier = Modifier) {
             SliderWithLabel(label = "W: ", value = widthPercent, onValueChange = { widthPercent = it })
             SliderWithLabel(label = "H :", value = heightPercent, onValueChange = { heightPercent = it })
             Row {
-                for (mode in ScaleMode.values()) {
+                for (mode in ScaleMode.entries) {
                     RadioButtonWithLabel(label = mode.name, selected = mode == resizeMode) {
                         resizeMode = mode
                     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/multiplayer/MultiPlayer.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -20,10 +21,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.ui.player.PlayerView
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
  * Demo of 2 player swapping view
@@ -47,14 +48,14 @@ fun MultiPlayer() {
                     modifier = Modifier
                         .weight(1.0f)
                         .aspectRatio(AspectRatio)
-                        .padding(4.dp),
+                        .padding(MaterialTheme.paddings.mini),
                     player = playerLeft
                 )
                 PlayerView(
                     modifier = Modifier
                         .weight(1.0f)
                         .aspectRatio(AspectRatio)
-                        .padding(4.dp),
+                        .padding(MaterialTheme.paddings.mini),
                     player = playerRight
                 )
             }
@@ -64,14 +65,14 @@ fun MultiPlayer() {
                     modifier = Modifier
                         .weight(1.0f)
                         .aspectRatio(AspectRatio)
-                        .padding(4.dp),
+                        .padding(MaterialTheme.paddings.mini),
                     player = playerLeft
                 )
                 PlayerView(
                     modifier = Modifier
                         .weight(1.0f)
                         .aspectRatio(AspectRatio)
-                        .padding(4.dp),
+                        .padding(MaterialTheme.paddings.mini),
                     player = playerRight
                 )
             }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/story/OptimizedStory.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerDefaults
 import androidx.compose.foundation.pager.PagerSnapDistance
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -32,6 +33,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.viewmodel.compose.viewModel
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.ScaleMode
 import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 
@@ -45,7 +47,7 @@ import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
     val lifecycleOwner: LifecycleOwner = LocalLifecycleOwner.current
 
-    val pagerState = rememberPagerState() {
+    val pagerState = rememberPagerState {
         storyViewModel.playlist.items.size
     }
     DisposableEffect(lifecycleOwner) {
@@ -100,14 +102,14 @@ fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
             Modifier
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
-                .padding(bottom = 12.dp),
+                .padding(bottom = MaterialTheme.paddings.baseline),
             horizontalArrangement = Arrangement.Center
         ) {
             repeat(playlist.size) { iteration ->
                 val color = if (pagerState.currentPage == iteration) ColorIndicatorCurrent else ColorIndicator
                 Box(
                     modifier = Modifier
-                        .padding(2.dp)
+                        .padding(MaterialTheme.paddings.micro)
                         .size(IndicatorSize)
                         .drawBehind {
                             drawCircle(color)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Paddings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Paddings.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.ui.theme
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Stores all the paddings used in this demo application.
+ *
+ * @property medium
+ * @property baseline
+ * @property small
+ * @property mini
+ * @property micro
+ */
+@Immutable
+class Paddings(
+    val medium: Dp = 32.dp,
+    val baseline: Dp = 16.dp,
+    val small: Dp = 8.dp,
+    val mini: Dp = 4.dp,
+    val micro: Dp = 2.dp
+)
+
+/**
+ * Retrieves the current [Paddings] at the call site's position in the hierarchy.
+ */
+@Suppress("UnusedReceiverParameter")
+val MaterialTheme.paddings: Paddings
+    @Composable
+    @ReadOnlyComposable
+    get() = LocalPaddings.current
+
+internal val LocalPaddings = staticCompositionLocalOf { Paddings() }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Theme.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/Theme.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -146,12 +147,14 @@ private val lightColorScheme = lightColorScheme(
  *
  * @param darkTheme `true` if the app uses a dark theme, `false` otherwise.
  * @param useDynamicColors `true` to use a dynamic color scheme, `false` otherwise.
+ * @param paddings The paddings to use inside `PillarboxTheme`.
  * @param content The content to display on the screen.
  */
 @Composable
 fun PillarboxTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     useDynamicColors: Boolean = true,
+    paddings: Paddings = MaterialTheme.paddings,
     content: @Composable () -> Unit
 ) {
     val colorScheme = if (useDynamicColors && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -179,8 +182,9 @@ fun PillarboxTheme(
         }
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        content = content
-    )
+    MaterialTheme(colorScheme = colorScheme) {
+        CompositionLocalProvider(LocalPaddings provides paddings) {
+            content()
+        }
+    }
 }


### PR DESCRIPTION
# Pull request

## Description

As suggested in https://github.com/SRGSSR/pillarbox-android/pull/328#discussion_r1400665699, I've grouped every padding values in a common place available under `MaterialTheme.paddings.*`.

## Changes made

- Added an extension on `MaterialTheme` to provide a `Paddings` instance with every supported paddings
- Replaced every padding values in `pillarbox-demo` with the values from `MaterialTheme.paddings`

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.