### PR TITLE
Move media icon type in the top left corner on TV

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
@@ -4,17 +4,41 @@
  */
 package ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data
 
+import java.text.DateFormat
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
+
 /**
  * Content to abstract content type.
  */
 sealed interface Content {
 
     /**
-     * Media
+     * Media.
      *
-     * @property media from Integration layer
+     * @property media The data received from the Integration Layer.
+     * @property date The date of the media.
+     * @property description The description of the media.
+     * @property duration The formatted duration of the media.
+     * @property imageTitle The image image of the media.
+     * @property imageUrl The image URL of the media.
+     * @property mediaType The type of media.
+     * @property showTitle The title of the optional related show.
+     * @property title The title of the media.
+     * @property urn The URN of the media.
      */
-    data class Media(val media: ch.srg.dataProvider.integrationlayer.data.remote.Media) : Content
+    @Suppress("OutdatedDocumentation", "UndocumentedPublicProperty") // Fixed in Detekt 1.23.0 (https://github.com/detekt/detekt/pull/6061)
+    data class Media(private val media: ch.srg.dataProvider.integrationlayer.data.remote.Media) : Content {
+        val date: String = DateFormat.getDateInstance().format(media.date)
+        val description = media.description
+        val duration = media.duration.toDuration(DurationUnit.MILLISECONDS).toString()
+        val imageTitle = media.imageTitle
+        val imageUrl = media.imageUrl.rawUrl
+        val mediaType = media.mediaType
+        val showTitle = media.show?.title
+        val title = media.title
+        val urn = media.urn
+    }
 
     /**
      * Show

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
@@ -41,11 +41,21 @@ sealed interface Content {
     }
 
     /**
-     * Show
+     * Show.
      *
-     * @property show from Integration layer
+     * @property show The data received from the Integration Layer.
+     * @property imageTitle The image image of the show.
+     * @property imageUrl The image URL of the show.
+     * @property title The title of the show.
+     * @property urn The URN of the show.
      */
-    data class Show(val show: ch.srg.dataProvider.integrationlayer.data.remote.Show) : Content
+    @Suppress("OutdatedDocumentation", "UndocumentedPublicProperty") // Fixed in Detekt 1.23.0 (https://github.com/detekt/detekt/pull/6061)
+    data class Show(private val show: ch.srg.dataProvider.integrationlayer.data.remote.Show) : Content {
+        val imageTitle = show.imageTitle
+        val imageUrl = show.imageUrl.rawUrl
+        val title = show.title
+        val urn = show.urn
+    }
 
     /**
      * Topic

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
@@ -12,7 +12,6 @@ import kotlin.time.toDuration
  * Content to abstract content type.
  */
 sealed interface Content {
-
     /**
      * Media.
      *
@@ -58,9 +57,19 @@ sealed interface Content {
     }
 
     /**
-     * Topic
+     * Topic.
      *
-     * @property topic from Integration layer
+     * @property topic The data received from the Integration Layer.
+     * @property imageTitle The image image of the topic.
+     * @property imageUrl The image URL of the topic.
+     * @property title The title of the topic.
+     * @property urn The URN of the topic.
      */
-    data class Topic(val topic: ch.srg.dataProvider.integrationlayer.data.remote.Topic) : Content
+    @Suppress("OutdatedDocumentation", "UndocumentedPublicProperty") // Fixed in Detekt 1.23.0 (https://github.com/detekt/detekt/pull/6061)
+    data class Topic(private val topic: ch.srg.dataProvider.integrationlayer.data.remote.Topic) : Content {
+        val imageTitle = topic.imageTitle
+        val imageUrl = topic.imageUrl?.rawUrl
+        val title = topic.title
+        val urn = topic.urn
+    }
 }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/Content.kt
@@ -30,7 +30,7 @@ sealed interface Content {
     data class Media(private val media: ch.srg.dataProvider.integrationlayer.data.remote.Media) : Content {
         val date: String = DateFormat.getDateInstance().format(media.date)
         val description = media.description
-        val duration = media.duration.toDuration(DurationUnit.MILLISECONDS).toString()
+        val duration = media.duration.toDuration(DurationUnit.MILLISECONDS).toString(unit = DurationUnit.MINUTES)
         val imageTitle = media.imageTitle
         val imageUrl = media.imageUrl.rawUrl
         val mediaType = media.mediaType

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -9,10 +9,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Headset
+import androidx.compose.material.icons.filled.Movie
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -61,6 +64,7 @@ import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
 import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.material3.Card
 import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
 import androidx.tv.material3.Text
 import ch.srg.dataProvider.integrationlayer.data.ImageUrl
@@ -88,6 +92,8 @@ import kotlinx.coroutines.flow.flowOf
 import java.text.DateFormat
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 /**
  * Screen of the "Lists" tab of the demo app on TV.
@@ -445,10 +451,27 @@ private fun MediaContent(
         Column(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .fillMaxWidth()
+                .fillMaxSize()
                 .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
                 .padding(8.dp)
         ) {
+            val mediaTypeIcon = when (media.mediaType) {
+                MediaType.AUDIO -> Icons.Default.Headset
+                MediaType.VIDEO -> Icons.Default.Movie
+            }
+            val showTitle = media.show?.title
+            val dateString = DateFormat.getDateInstance().format(media.date)
+            val durationString = media.duration.toDuration(DurationUnit.MILLISECONDS).toString()
+            val description = "$dateString - $durationString"
+
+            Icon(
+                imageVector = mediaTypeIcon,
+                contentDescription = null,
+                tint = Color.White
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
             Text(
                 text = media.title,
                 color = Color.White,
@@ -461,15 +484,8 @@ private fun MediaContent(
                     )
             )
 
-            val descriptionPrefix = when (media.mediaType) {
-                MediaType.AUDIO -> "🎧"
-                MediaType.VIDEO -> "🎬"
-            }
-            val showTitle = media.show?.title
-            val dateString = DateFormat.getDateInstance().format(media.date)
-
             Text(
-                text = "$descriptionPrefix ${showTitle ?: dateString}",
+                text = showTitle ?: description,
                 modifier = Modifier.padding(top = 8.dp),
                 color = Color.White,
                 overflow = TextOverflow.Ellipsis,
@@ -477,9 +493,9 @@ private fun MediaContent(
                 style = MaterialTheme.typography.labelSmall
             )
 
-            if (!showTitle.isNullOrBlank()) {
+            if (showTitle != null) {
                 Text(
-                    text = dateString,
+                    text = description,
                     modifier = Modifier.padding(top = 4.dp),
                     color = Color.White,
                     overflow = TextOverflow.Ellipsis,
@@ -512,27 +528,30 @@ private fun ShowTopicContent(
             )
         }
 
-        Text(
-            text = title,
+        Box(
             modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .fillMaxWidth()
+                .fillMaxSize()
                 .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
-                .padding(
-                    start = 8.dp,
-                    top = 8.dp,
-                    end = 8.dp,
-                    bottom = 4.dp
-                ),
-            color = Color.White,
-            textAlign = TextAlign.Center,
-            overflow = TextOverflow.Ellipsis,
-            style = MaterialTheme.typography.titleMedium
-                .copy(
-                    fontWeight = FontWeight.Bold,
-                    shadow = Shadow(blurRadius = 3f)
-                )
-        )
+        ) {
+            Text(
+                text = title,
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(
+                        start = 8.dp,
+                        top = 8.dp,
+                        end = 8.dp,
+                        bottom = 4.dp
+                    ),
+                color = Color.White,
+                overflow = TextOverflow.Ellipsis,
+                style = MaterialTheme.typography.titleMedium
+                    .copy(
+                        fontWeight = FontWeight.Bold,
+                        shadow = Shadow(blurRadius = 3f)
+                    )
+            )
+        }
     }
 }
 

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -89,11 +89,8 @@ import ch.srgssr.pillarbox.demo.tv.player.PlayerActivity
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 import coil.compose.AsyncImage
 import kotlinx.coroutines.flow.flowOf
-import java.text.DateFormat
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 /**
  * Screen of the "Lists" tab of the demo app on TV.
@@ -171,7 +168,7 @@ fun ListsHome(
                     onItemClick = { item ->
                         when (item) {
                             is Content.Media -> {
-                                val demoItem = DemoItem(title = item.media.title, uri = item.media.urn)
+                                val demoItem = DemoItem(title = item.title, uri = item.urn)
 
                                 PlayerActivity.startPlayer(context, demoItem)
                             }
@@ -406,9 +403,9 @@ private fun ListsSectionContent(
                     ) {
                         when (item) {
                             is Content.Media -> MediaContent(
-                                media = item.media,
-                                imageUrl = scaleImageUrl(item.media.imageUrl.rawUrl, containerWidth),
-                                imageTitle = item.media.imageTitle
+                                media = item,
+                                imageUrl = scaleImageUrl(item.imageUrl, containerWidth),
+                                imageTitle = item.imageTitle
                             )
 
                             is Content.Show -> ShowTopicContent(
@@ -435,7 +432,7 @@ private fun ListsSectionContent(
 @Composable
 @OptIn(ExperimentalTvMaterial3Api::class)
 private fun MediaContent(
-    media: Media,
+    media: Content.Media,
     imageUrl: String,
     imageTitle: String?,
     modifier: Modifier = Modifier
@@ -459,10 +456,7 @@ private fun MediaContent(
                 MediaType.AUDIO -> Icons.Default.Headset
                 MediaType.VIDEO -> Icons.Default.Movie
             }
-            val showTitle = media.show?.title
-            val dateString = DateFormat.getDateInstance().format(media.date)
-            val durationString = media.duration.toDuration(DurationUnit.MILLISECONDS).toString()
-            val description = "$dateString - $durationString"
+            val description = "${media.date} - ${media.duration}"
 
             Icon(
                 imageVector = mediaTypeIcon,
@@ -485,7 +479,7 @@ private fun MediaContent(
             )
 
             Text(
-                text = showTitle ?: description,
+                text = media.showTitle ?: description,
                 modifier = Modifier.padding(top = 8.dp),
                 color = Color.White,
                 overflow = TextOverflow.Ellipsis,
@@ -493,7 +487,7 @@ private fun MediaContent(
                 style = MaterialTheme.typography.labelSmall
             )
 
-            if (showTitle != null) {
+            if (media.showTitle != null) {
                 Text(
                     text = description,
                     modifier = Modifier.padding(top = 4.dp),

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -175,8 +175,8 @@ fun ListsHome(
 
                             is Content.Show -> {
                                 val show = ContentList.LatestMediaForShow(
-                                    urn = item.show.urn,
-                                    show = item.show.title,
+                                    urn = item.urn,
+                                    show = item.title,
                                 )
 
                                 navController.navigate(show.destinationRoute)
@@ -409,9 +409,9 @@ private fun ListsSectionContent(
                             )
 
                             is Content.Show -> ShowTopicContent(
-                                title = item.show.title,
-                                imageUrl = scaleImageUrl(item.show.imageUrl.rawUrl, containerWidth),
-                                imageTitle = item.show.imageTitle
+                                title = item.title,
+                                imageUrl = scaleImageUrl(item.imageUrl, containerWidth),
+                                imageTitle = item.imageTitle
                             )
 
                             is Content.Topic -> ShowTopicContent(

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -184,8 +184,8 @@ fun ListsHome(
 
                             is Content.Topic -> {
                                 val topic = ContentList.LatestMediaForTopic(
-                                    urn = item.topic.urn,
-                                    topic = item.topic.title
+                                    urn = item.urn,
+                                    topic = item.title
                                 )
 
                                 navController.navigate(topic.destinationRoute)
@@ -415,11 +415,11 @@ private fun ListsSectionContent(
                             )
 
                             is Content.Topic -> ShowTopicContent(
-                                title = item.topic.title,
-                                imageUrl = item.topic.imageUrl?.rawUrl?.let {
+                                title = item.title,
+                                imageUrl = item.imageUrl?.let {
                                     scaleImageUrl(it, containerWidth)
                                 },
-                                imageTitle = item.topic.imageTitle
+                                imageTitle = item.imageTitle
                             )
                         }
                     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
@@ -96,10 +96,10 @@ fun MainNavigation() {
                 val viewModel: SearchViewModel = viewModel(factory = SearchViewModel.Factory(ilRepository))
                 SearchView(searchViewModel = viewModel) {
                     val item = DemoItem(
-                        title = it.media.title,
-                        uri = it.media.urn,
-                        description = it.media.description,
-                        imageUrl = it.media.imageUrl.rawUrl
+                        title = it.title,
+                        uri = it.urn,
+                        description = it.description,
+                        imageUrl = it.imageUrl
                     )
 
                     SimplePlayerActivity.startActivity(context, item)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -47,8 +47,8 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
         when (content) {
             is Content.Show -> {
                 val contentList = ContentList.LatestMediaForShow(
-                    urn = content.show.urn,
-                    show = content.show.title
+                    urn = content.urn,
+                    show = content.title
                 )
 
                 navController.navigate(contentList.destinationRoute)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -56,8 +56,8 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
 
             is Content.Topic -> {
                 val contentList = ContentList.LatestMediaForTopic(
-                    urn = content.topic.urn,
-                    topic = content.topic.title
+                    urn = content.urn,
+                    topic = content.title
                 )
 
                 navController.navigate(contentList.destinationRoute)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -64,7 +64,7 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
             }
 
             is Content.Media -> {
-                val item = DemoItem(title = content.media.title, uri = content.media.urn)
+                val item = DemoItem(title = content.title, uri = content.urn)
                 SimplePlayerActivity.startActivity(navController.context, item)
             }
         }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
@@ -22,6 +22,8 @@ import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import java.text.DateFormat
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.toDuration
 
 /**
  * Content view.
@@ -69,7 +71,12 @@ private fun MediaView(
     }
     val showTitle = content.media.show?.title
     val dateString = DateFormat.getDateInstance().format(content.media.date)
-    val subtitle = showTitle?.let { "$it - $dateString" } ?: dateString
+    val durationString = content.media.duration.toDuration(DurationUnit.MILLISECONDS).toString()
+    val subtitle = if (showTitle != null) {
+        "$showTitle - $dateString - $durationString"
+    } else {
+        "$dateString - $durationString"
+    }
 
     DemoListItemView(
         title = content.media.title,

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
@@ -19,11 +19,8 @@ import ch.srg.dataProvider.integrationlayer.data.remote.Vendor
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.ui.DemoListItemView
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
-import java.text.DateFormat
 import java.util.Date
 import kotlin.time.Duration.Companion.seconds
-import kotlin.time.DurationUnit
-import kotlin.time.toDuration
 
 /**
  * Content view.
@@ -65,23 +62,20 @@ private fun MediaView(
     modifier: Modifier = Modifier,
     onClick: () -> Unit
 ) {
-    val subtitleSuffix = when (content.media.mediaType) {
+    val mediaTypeIcon = when (content.mediaType) {
         MediaType.AUDIO -> "🎧"
         MediaType.VIDEO -> "🎬"
     }
-    val showTitle = content.media.show?.title
-    val dateString = DateFormat.getDateInstance().format(content.media.date)
-    val durationString = content.media.duration.toDuration(DurationUnit.MILLISECONDS).toString()
-    val subtitle = if (showTitle != null) {
-        "$showTitle - $dateString - $durationString"
+    val subtitlePrefix = if (content.showTitle != null) {
+        "${content.showTitle} - "
     } else {
-        "$dateString - $durationString"
+        ""
     }
 
     DemoListItemView(
-        title = content.media.title,
+        title = content.title,
         modifier = modifier,
-        subtitle = "$subtitle $subtitleSuffix",
+        subtitle = "$subtitlePrefix ${content.date} - ${content.duration} $mediaTypeIcon",
         onClick = onClick
     )
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
@@ -37,7 +37,7 @@ fun ContentView(
 ) {
     when (content) {
         is Content.Topic -> DemoListItemView(
-            title = content.topic.title,
+            title = content.title,
             modifier = modifier.fillMaxWidth(),
             onClick = onClick
         )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentView.kt
@@ -43,7 +43,7 @@ fun ContentView(
         )
 
         is Content.Show -> DemoListItemView(
-            title = content.show.title,
+            title = content.title,
             modifier = modifier.fillMaxWidth(),
             onClick = onClick
         )


### PR DESCRIPTION
# Pull request

## Description

In this PR, I've moved the media type icon in the top left corner of the media card on TV. I've also added the duration of the media in both demo apps.

## Changes made

- Move the media type icon in the top left corner of the media card on TV.
- Display the media duration in both demo apps.
- Move some display logic in `pillarbox-demo-shared` to reduce code duplication.

## Screenshots

| Description | Light mode | Dark mode |
|-----|-----|-----|
| Media card on TV | N/A | ![Screenshot_20231122_110509](https://github.com/SRGSSR/pillarbox-android/assets/1009664/d23b9978-25a3-4f04-bd90-d4139b5a41a7) |
| Media card on mobile | ![Screenshot_20231122_110634](https://github.com/SRGSSR/pillarbox-android/assets/1009664/b3eb2735-1c48-40a6-ad49-ec848c98e348)| ![Screenshot_20231122_110641](https://github.com/SRGSSR/pillarbox-android/assets/1009664/61b4cb12-c7ed-42fa-99d0-d1884623fae0) |

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
