### PR TITLE
Add search to TV demo

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
@@ -11,6 +11,7 @@ import ch.srgssr.dataprovider.paging.DataProviderPaging
 import ch.srgssr.pillarbox.core.business.DefaultPillarbox
 import ch.srgssr.pillarbox.core.business.MediaCompositionMediaItemSource
 import ch.srgssr.pillarbox.core.business.images.DefaultImageScalingService
+import ch.srgssr.pillarbox.core.business.images.ImageScalingService
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.DefaultMediaCompositionDataSource
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.IlHost
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.Vector.getVector
@@ -27,7 +28,7 @@ object PlayerModule {
     private fun provideIntegrationLayerItemSource(context: Context): MediaCompositionMediaItemSource =
         MediaCompositionMediaItemSource(
             mediaCompositionDataSource = DefaultMediaCompositionDataSource(vector = context.getVector()),
-            imageScalingService = DefaultImageScalingService()
+            imageScalingService = provideImageScalingService()
         )
 
     /**
@@ -51,6 +52,13 @@ object PlayerModule {
         val okHttp = OkHttpModule.createOkHttpClient(context)
         val ilService = IlServiceModule.createIlService(okHttp, ilHost = providerIlHostFromUrl(ilHost))
         return ILRepository(dataProviderPaging = DataProviderPaging(ilService), ilService = ilService)
+    }
+
+    /**
+     * Provide a default implementation for the image scaling service.
+     */
+    fun provideImageScalingService(): ImageScalingService {
+        return DefaultImageScalingService()
     }
 
     private fun providerIlHostFromUrl(ilHost: URL): ch.srg.dataProvider.integrationlayer.request.IlHost {

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentListViewModel.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/ContentListViewModel.kt
@@ -12,10 +12,10 @@ import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
 import ch.srg.dataProvider.integrationlayer.data.IlImage
-import ch.srgssr.pillarbox.core.business.images.DefaultImageScalingService
 import ch.srgssr.pillarbox.core.business.images.ImageScalingService
 import ch.srgssr.pillarbox.core.business.images.ImageScalingService.ImageFormat
 import ch.srgssr.pillarbox.core.business.images.ImageScalingService.ImageWidth
+import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ILRepository
 import kotlinx.coroutines.flow.Flow
@@ -34,7 +34,7 @@ import kotlinx.coroutines.flow.map
 class ContentListViewModel(
     private val ilRepository: ILRepository,
     private val contentList: ContentList,
-    private val imageScalingService: ImageScalingService = DefaultImageScalingService()
+    private val imageScalingService: ImageScalingService
 ) : ViewModel() {
 
     /**
@@ -118,9 +118,10 @@ class ContentListViewModel(
     class Factory(
         private var ilRepository: ILRepository,
         private val contentList: ContentList,
+        private val imageScalingService: ImageScalingService = PlayerModule.provideImageScalingService()
     ) : ViewModelProvider.NewInstanceFactory() {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            return ContentListViewModel(ilRepository, contentList) as T
+            return ContentListViewModel(ilRepository, contentList, imageScalingService) as T
         }
     }
 }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentListSections.kt
@@ -7,7 +7,10 @@ package ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data
 import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.ContentList
 
-private val bus = listOf(Bu.RSI, Bu.RTR, Bu.RTS, Bu.SRF, Bu.SWI)
+/**
+ * All the supported BUs.
+ */
+val bus = listOf(Bu.RSI, Bu.RTR, Bu.RTS, Bu.SRF, Bu.SWI)
 
 /**
  * All the sections available in the "Lists" tab.

--- a/pillarbox-demo-shared/src/main/res/values/strings.xml
+++ b/pillarbox-demo-shared/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="lists">Lists</string>
     <string name="search">Search</string>
     <string name="showcases">Showcases</string>
+    <string name="search_placeholder">Search for content</string>
+    <string name="no_results">No results</string>
+    <string name="empty_search_query">Enter something to search</string>
 </resources>

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/MainActivity.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.demo.tv
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -43,6 +44,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.surface)
+                        .padding(horizontal = 58.dp)
                 ) {
                     CompositionLocalProvider(
                         LocalContentColor provides MaterialTheme.colorScheme.onSurface
@@ -59,30 +61,27 @@ class MainActivity : ComponentActivity() {
                                 ?.let { selectedDestination = it }
                         }
 
-                        TVDemoTopBar(
-                            destinations = destinations,
-                            selectedDestination = selectedDestination,
-                            onDestinationSelected = {
-                                selectedDestination = it
+                        AnimatedVisibility(visible = selectedDestination != HomeDestination.Search) {
+                            TVDemoTopBar(
+                                destinations = destinations,
+                                selectedDestination = selectedDestination,
+                                modifier = Modifier.padding(vertical = 16.dp),
+                                onDestinationClick = { destination ->
+                                    selectedDestination = destination
 
-                                navController.navigate(it.route)
-                            }
-                        )
+                                    navController.navigate(destination.route)
+                                }
+                            )
+                        }
 
                         TVDemoNavigation(
                             navController = navController,
                             startDestination = startDestination,
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .padding(horizontal = HorizontalPadding)
+                            modifier = Modifier.fillMaxSize()
                         )
                     }
                 }
             }
         }
-    }
-
-    private companion object {
-        private val HorizontalPadding = 58.dp
     }
 }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoNavigation.kt
@@ -4,19 +4,26 @@
  */
 package ch.srgssr.pillarbox.demo.tv.ui
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.SearchViewModel
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
 import ch.srgssr.pillarbox.demo.tv.examples.ExamplesHome
 import ch.srgssr.pillarbox.demo.tv.player.PlayerActivity
 import ch.srgssr.pillarbox.demo.tv.ui.integrationLayer.ListsHome
+import ch.srgssr.pillarbox.demo.tv.ui.integrationLayer.SearchView
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 
 /**
@@ -48,6 +55,22 @@ fun TVDemoNavigation(
         composable(HomeDestination.Lists.route) {
             ListsHome(
                 sections = contentListSections
+            )
+        }
+
+        composable(HomeDestination.Search.route) {
+            val context = LocalContext.current
+            val ilRepository = remember {
+                PlayerModule.createIlRepository(context)
+            }
+
+            val searchViewModel = viewModel<SearchViewModel>(
+                factory = SearchViewModel.Factory(ilRepository)
+            )
+
+            SearchView(
+                searchViewModel = searchViewModel,
+                modifier = Modifier.padding(top = 16.dp)
             )
         }
     }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
@@ -6,26 +6,25 @@ package ch.srgssr.pillarbox.demo.tv.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.IntrinsicSize
-import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusRestorer
-import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.tv.foundation.lazy.list.TvLazyRow
-import androidx.tv.foundation.lazy.list.items
 import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.Icon
 import androidx.tv.material3.ListItem
+import androidx.tv.material3.ListItemDefaults
 import androidx.tv.material3.Text
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
@@ -36,7 +35,7 @@ import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
  * @param destinations The list of destinations to display.
  * @param selectedDestination The currently selected destination.
  * @param modifier The [Modifier] to apply to the top bar.
- * @param onDestinationSelected The action to perform the selected a destination.
+ * @param onDestinationClick The action to perform the selected a destination.
  */
 @Composable
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTvMaterial3Api::class)
@@ -44,43 +43,51 @@ fun TVDemoTopBar(
     destinations: List<HomeDestination>,
     selectedDestination: HomeDestination,
     modifier: Modifier = Modifier,
-    onDestinationSelected: (destination: HomeDestination) -> Unit
+    onDestinationClick: (destination: HomeDestination) -> Unit
 ) {
-    var isTabRowFocused by remember { mutableStateOf(false) }
-
-    TvLazyRow(
+    Row(
         modifier = modifier
             .fillMaxWidth()
-            .focusRestorer()
-            .onFocusChanged { isTabRowFocused = it.isFocused || it.hasFocus },
-        contentPadding = PaddingValues(
-            horizontal = 58.dp,
-            vertical = 16.dp
-        ),
+            .focusRestorer(),
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        items(destinations) { destination ->
+        destinations.forEach { destination ->
             ListItem(
                 selected = destination == selectedDestination,
-                onClick = { onDestinationSelected(destination) },
+                onClick = { onDestinationClick(destination) },
                 modifier = Modifier.width(IntrinsicSize.Max),
                 headlineContent = {
                     Text(text = stringResource(destination.labelResId))
                 }
             )
         }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        ListItem(
+            selected = selectedDestination == HomeDestination.Search,
+            onClick = { onDestinationClick(HomeDestination.Search) },
+            modifier = Modifier.width(IntrinsicSize.Max),
+            shape = ListItemDefaults.shape(CircleShape),
+            headlineContent = {
+                Icon(
+                    imageVector = Icons.Default.Search,
+                    contentDescription = stringResource(HomeDestination.Search.labelResId)
+                )
+            }
+        )
     }
 }
 
-@Preview
 @Composable
+@Preview(showBackground = true)
 private fun TVDemoTopBarPreview() {
     PillarboxTheme {
         TVDemoTopBar(
             destinations = listOf(HomeDestination.Examples, HomeDestination.Lists),
             selectedDestination = HomeDestination.Examples,
-            onDestinationSelected = {}
+            onDestinationClick = {}
         )
     }
 }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/SearchView.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.tv.ui.integrationLayer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.tv.material3.ExperimentalTvMaterial3Api
+import androidx.tv.material3.FilterChip
+import androidx.tv.material3.Icon
+import androidx.tv.material3.LocalContentColor
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.Text
+import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
+import ch.srgssr.pillarbox.demo.shared.R
+import ch.srgssr.pillarbox.demo.shared.data.DemoItem
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.SearchViewModel
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.bus
+import ch.srgssr.pillarbox.demo.tv.player.PlayerActivity
+import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
+
+/**
+ * Display the list of search results.
+ *
+ * @param searchViewModel The [SearchViewModel] used to perform the search.
+ * @param modifier The [Modifier] to apply to the list.
+ */
+@Composable
+fun SearchView(
+    searchViewModel: SearchViewModel,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+    val query by searchViewModel.query.collectAsState()
+    val selectedBu by searchViewModel.bu.collectAsState()
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        SearchRow(
+            query = query,
+            bus = bus,
+            selectedBu = selectedBu,
+            modifier = Modifier.fillMaxWidth(),
+            onQueryChange = searchViewModel::setQuery,
+            onBuChange = searchViewModel::selectBu
+        )
+
+        ListsSection(
+            items = searchViewModel.result.collectAsLazyPagingItems(),
+            focusFirstItem = false,
+            scaleImageUrl = { imageUrl, containerWidth ->
+                searchViewModel.getScaledImageUrl(imageUrl, containerWidth)
+            },
+            onItemClick = { item ->
+                val demoItem = DemoItem(
+                    title = item.title,
+                    uri = item.urn,
+                    description = item.description,
+                    imageUrl = item.imageUrl
+                )
+
+                PlayerActivity.startPlayer(context, demoItem)
+            },
+            emptyScreen = { emptyScreenModifier ->
+                if (searchViewModel.hasValidSearchQuery()) {
+                    NoResults(modifier = emptyScreenModifier.fillMaxSize())
+                } else {
+                    NoContent(emptyScreenModifier.fillMaxSize())
+                }
+            }
+        )
+    }
+}
+
+@Composable
+@OptIn(ExperimentalTvMaterial3Api::class)
+private fun SearchRow(
+    query: String,
+    bus: List<Bu>,
+    selectedBu: Bu,
+    modifier: Modifier = Modifier,
+    onQueryChange: (query: String) -> Unit,
+    onBuChange: (bu: Bu) -> Unit
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        SearchInput(
+            query = query,
+            modifier = Modifier.fillMaxWidth(),
+            onQueryChange = onQueryChange
+        )
+
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            bus.forEach { bu ->
+                FilterChip(
+                    selected = bu == selectedBu,
+                    onClick = { onBuChange(bu) }
+                ) {
+                    Text(text = bu.name.uppercase())
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@OptIn(ExperimentalTvMaterial3Api::class)
+private fun SearchInput(
+    query: String,
+    modifier: Modifier = Modifier,
+    onQueryChange: (query: String) -> Unit
+) {
+    val focusRequest = remember { FocusRequester() }
+
+    BasicTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = modifier
+            .focusRequester(focusRequest)
+            .background(
+                color = MaterialTheme.colorScheme.surfaceVariant,
+                shape = MaterialTheme.shapes.small
+            ),
+        textStyle = MaterialTheme.typography.titleSmall
+            .copy(color = MaterialTheme.colorScheme.onSurface),
+        keyboardOptions = KeyboardOptions(
+            autoCorrect = false,
+            imeAction = ImeAction.Search
+        ),
+        singleLine = true,
+        cursorBrush = Brush.verticalGradient(
+            colors = listOf(LocalContentColor.current, LocalContentColor.current)
+        ),
+        decorationBox = { innerTextField ->
+            Box(modifier = Modifier.padding(16.dp)) {
+                innerTextField()
+
+                if (query.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.search_placeholder),
+                        modifier = Modifier.graphicsLayer { alpha = 0.6f },
+                        style = MaterialTheme.typography.titleSmall
+                    )
+                }
+            }
+        }
+    )
+
+    LaunchedEffect(Unit) {
+        focusRequest.requestFocus()
+    }
+}
+
+@Composable
+@OptIn(ExperimentalTvMaterial3Api::class)
+private fun NoResults(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = stringResource(R.string.no_results))
+    }
+}
+
+@Composable
+@OptIn(ExperimentalTvMaterial3Api::class)
+private fun NoContent(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = null,
+            modifier = Modifier.size(56.dp)
+        )
+
+        Text(
+            text = stringResource(R.string.empty_search_query),
+            modifier = Modifier.padding(top = 8.dp)
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun SearchRowPreview() {
+    PillarboxTheme {
+        SearchRow(
+            query = "Query",
+            bus = bus,
+            selectedBu = Bu.RTS,
+            onQueryChange = {},
+            onBuChange = {}
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun SearchInputPreview() {
+    PillarboxTheme {
+        SearchInput(
+            query = "Query",
+            onQueryChange = {}
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun NoResultsPreview() {
+    PillarboxTheme {
+        NoResults()
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun NoContentPreview() {
+    PillarboxTheme {
+        NoContent()
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
@@ -42,10 +42,10 @@ import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
 import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.SearchViewModel
 import ch.srgssr.pillarbox.demo.trackPagView
 import ch.srgssr.pillarbox.demo.ui.examples.ExamplesHome
 import ch.srgssr.pillarbox.demo.ui.integrationLayer.SearchView
-import ch.srgssr.pillarbox.demo.ui.integrationLayer.SearchViewModel
 import ch.srgssr.pillarbox.demo.ui.integrationLayer.listNavGraph
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.showcases.showCasesNavGraph

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -62,11 +62,12 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import ch.srg.dataProvider.integrationlayer.request.parameters.Bu
 import ch.srgssr.pillarbox.demo.R
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.SearchViewModel
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
+import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.bus
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
-
-private val bus = listOf(Bu.RSI, Bu.RTR, Bu.RTS, Bu.SRF, Bu.SWI)
+import ch.srgssr.pillarbox.demo.shared.R as sharedR
 
 /**
  * Search view
@@ -191,7 +192,7 @@ private fun SearchInput(
         active = false,
         onActiveChange = {},
         modifier = modifier.focusRequester(focusRequester),
-        placeholder = { Text(text = stringResource(R.string.search_placeholder)) },
+        placeholder = { Text(text = stringResource(sharedR.string.search_placeholder)) },
         leadingIcon = {
             var showBuSelector by remember { mutableStateOf(false) }
 
@@ -290,7 +291,7 @@ private fun NoContent(modifier: Modifier = Modifier) {
         )
 
         Text(
-            text = stringResource(R.string.empty_search_query),
+            text = stringResource(sharedR.string.empty_search_query),
             modifier = Modifier.padding(top = MaterialTheme.paddings.small)
         )
     }
@@ -302,7 +303,7 @@ private fun NoResult(modifier: Modifier = Modifier) {
         modifier = modifier,
         contentAlignment = Alignment.Center
     ) {
-        Text(text = stringResource(R.string.no_results))
+        Text(text = stringResource(sharedR.string.no_results))
     }
 }
 
@@ -333,21 +334,6 @@ private fun ErrorView(error: Throwable, modifier: Modifier = Modifier) {
 @Composable
 @Preview(showBackground = true)
 private fun SearchInputPreview() {
-    PillarboxTheme {
-        SearchInput(
-            query = "Query",
-            bus = bus,
-            selectedBu = Bu.RTS,
-            onBuChange = {},
-            onClearClick = {},
-            onQueryChange = {}
-        )
-    }
-}
-
-@Composable
-@Preview(showBackground = true)
-private fun SearchInputWithPrefixPreview() {
     PillarboxTheme {
         SearchInput(
             query = "Query",

--- a/pillarbox-demo/src/main/res/values/strings.xml
+++ b/pillarbox-demo/src/main/res/values/strings.xml
@@ -21,7 +21,4 @@
     <string name="clear">Clear</string>
     <string name="licence_url">License URL</string>
     <string name="play">Play</string>
-    <string name="empty_search_query">Enter something to search</string>
-    <string name="search_placeholder">Search for content</string>
-    <string name="no_results">No results</string>
 </resources>


### PR DESCRIPTION
# Pull request

## Description

This PR adds the search to the demo app for TV.

## Changes made

- Move the `SearchViewModel` to `pillarbox-demo-shared` to be able to reuse it on TV
- Add a search icon in the top navigation to access the search
- Make the existing media list component public so it can be reused in the search
  - Add new arguments to address the needs of the search: don't display a title, custom empty state, don't auto focus the first item
- Create a search screen allowing the user to input a query, and select a BU

## Screenshots

| Description | Screenshot |
|-----|-----|
| Access to the search | ![Screenshot_20231124_110636](https://github.com/SRGSSR/pillarbox-android/assets/1009664/5bce617c-9f26-49e1-a8e9-baa7f1c4839e) |
| Empty screen | ![Screenshot_20231124_110438](https://github.com/SRGSSR/pillarbox-android/assets/1009664/86e6dee4-0786-4ab4-8ec8-742a9fe7546a) |
| Search results | ![Screenshot_20231124_110628](https://github.com/SRGSSR/pillarbox-android/assets/1009664/ef0b0736-abbc-4b98-9890-44a55356995a) |
| No results | ![Screenshot_20231124_110512](https://github.com/SRGSSR/pillarbox-android/assets/1009664/eb8762ca-c6ce-493f-b14c-c90ff04e4cfb) |

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.