### PR TITLE
Add back arrow on sub screens in the mobile demo app

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/MainNavigation.kt
@@ -18,9 +18,10 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -52,6 +53,9 @@ import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.showcases.showCasesNavGraph
 import androidx.appcompat.R as appcompatR
 
+private val bottomNavItems = listOf(HomeDestination.Examples, HomeDestination.ShowCases, HomeDestination.Lists, HomeDestination.Search)
+private const val StartDestinationIndex = 0
+
 /**
  * Main view with all the navigation
  */
@@ -59,14 +63,12 @@ import androidx.appcompat.R as appcompatR
 @Suppress("StringLiteralDuplication")
 @Composable
 fun MainNavigation() {
-    val navController = rememberNavController()
-    val bottomNavItems = remember {
-        mutableStateListOf(HomeDestination.Examples, HomeDestination.ShowCases, HomeDestination.Lists, HomeDestination.Search)
-    }
-    val startDestination by remember(bottomNavItems) { mutableStateOf(bottomNavItems[0]) }
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    var activeBottomItemIndex by rememberSaveable { mutableIntStateOf(StartDestinationIndex) }
 
-    var activeBottomItem by remember(startDestination) { mutableStateOf(startDestination) }
+    val navController = rememberNavController()
+    val startDestination = bottomNavItems[StartDestinationIndex]
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val activeBottomItem by remember(activeBottomItemIndex) { mutableStateOf(bottomNavItems[activeBottomItemIndex]) }
 
     Scaffold(
         topBar = {
@@ -92,7 +94,7 @@ fun MainNavigation() {
                 items = bottomNavItems,
                 activeItem = activeBottomItem,
                 onItemClick = { item ->
-                    activeBottomItem = item
+                    activeBottomItemIndex = bottomNavItems.indexOf(item)
 
                     navController.navigate(item.route) {
                         // Pop up to the start destination of the graph to

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListsView.kt
@@ -70,7 +70,7 @@ fun NavGraphBuilder.listNavGraph(navController: NavController, ilRepository: ILR
         }
     }
 
-    composable(route = NavigationRoutes.contentLists, DemoPageView("home", defaultListsLevels)) {
+    composable(route = NavigationRoutes.homeLists, DemoPageView("home", defaultListsLevels)) {
         ContentListsView { contentList ->
             navController.navigate(route = contentList.destinationRoute)
         }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseNavigation.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowCaseNavigation.kt
@@ -18,7 +18,7 @@ import ch.srgssr.pillarbox.demo.ui.showcases.tracking.TrackingToggleSample
  * Inject Showcases Navigation
  */
 fun NavGraphBuilder.showCasesNavGraph(navController: NavController) {
-    composable(NavigationRoutes.showcaseList, DemoPageView("home", Levels)) {
+    composable(NavigationRoutes.homeShowcases, DemoPageView("home", Levels)) {
         ShowCaseList(navController = navController)
     }
     composable(NavigationRoutes.story, DemoPageView("story", Levels)) {


### PR DESCRIPTION
# Pull request

## Description

When navigating deeper in the "Lists" section, the only way to go back to previous screens is by using the system back button/gesture.
This PR adds a back arrow in the toolbar when needed.

## Changes made

As explained above.

## Screenshots

| Description | Light mode | Dark mode |
|-----|-----|-----|
| "Lists" root (no change) | ![Screenshot_20231127_133610](https://github.com/SRGSSR/pillarbox-android/assets/1009664/1fe8a639-181f-438d-8bdf-bdf090d53b4d) | ![Screenshot_20231127_133406](https://github.com/SRGSSR/pillarbox-android/assets/1009664/72177a53-9965-4ca3-9c69-bce5ec0c51d1) |
| "Lists" sub-section | ![Screenshot_20231127_133618](https://github.com/SRGSSR/pillarbox-android/assets/1009664/d3c2db4d-5c06-4ef8-83ff-ebb69520fd3d) | ![Screenshot_20231127_133412](https://github.com/SRGSSR/pillarbox-android/assets/1009664/856c6224-0913-44c3-a315-b146fbb1f19a) |

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.