### PR TITLE
Fix player controls in demo tv

### DIFF
--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/TvPlayerView.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/TvPlayerView.kt
@@ -4,13 +4,19 @@
  */
 package ch.srgssr.pillarbox.demo.tv.player.compose
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.media3.common.Player
-import ch.srgssr.pillarbox.ui.widget.ToggleableBox
+import ch.srgssr.pillarbox.ui.extension.handleDPadKeyEvents
+import ch.srgssr.pillarbox.ui.widget.maintainVisibleOnFocus
 import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 import ch.srgssr.pillarbox.ui.widget.rememberDelayedVisibilityState
 
@@ -26,19 +32,32 @@ fun TvPlayerView(
     modifier: Modifier = Modifier
 ) {
     val visibilityState = rememberDelayedVisibilityState(player = player, visible = true)
-    ToggleableBox(
-        modifier = modifier,
-        visibilityState = visibilityState,
-        toggleableContent = {
-            Box(modifier = Modifier, contentAlignment = Alignment.Center) {
+    Box(modifier = modifier) {
+        PlayerSurface(
+            player = player,
+            modifier = Modifier
+                .fillMaxSize()
+                .handleDPadKeyEvents(onEnter = {
+                    visibilityState.show()
+                })
+                .focusable(true)
+        )
+        AnimatedVisibility(
+            visible = visibilityState.isVisible,
+            enter = expandVertically { it },
+            exit = shrinkVertically { it }
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .maintainVisibleOnFocus(delayedVisibilityState = visibilityState),
+                contentAlignment = Alignment.Center
+            ) {
                 TvPlaybackRow(player = player, state = visibilityState)
             }
-        },
-        content = {
-            PlayerSurface(
-                player = player,
-                modifier = Modifier.fillMaxSize()
-            )
         }
-    )
+        BackHandler(enabled = visibilityState.isVisible) {
+            visibilityState.hide()
+        }
+    }
 }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to allow users of Pillarbox Demo TV to modify playback.

## Changes made

- Fix button from player view on TV to only toggle view and not do actions.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
