### PR TITLE
Display a loading indicator when fetching the next page

### DIFF
--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -63,6 +63,7 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import androidx.tv.foundation.lazy.grid.TvGridCells
+import androidx.tv.foundation.lazy.grid.TvGridItemSpan
 import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
 import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.foundation.lazy.grid.rememberTvLazyGridState
@@ -503,6 +504,19 @@ private fun <T : Content> ListsSectionContent(
                             }
                         )
                     }
+                }
+            }
+
+            if (items.loadState.append is LoadState.Loading) {
+                item(
+                    contentType = "LoadingView",
+                    span = { TvGridItemSpan(columnCount) }
+                ) {
+                    ListsSectionLoading(
+                        modifier = modifier
+                            .fillMaxSize()
+                            .padding(MaterialTheme.paddings.baseline)
+                    )
                 }
             }
         }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/ContentListView.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.demo.ui.integrationLayer
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -114,6 +115,16 @@ fun ContentListView(
                         if (index < items.itemCount - 1) {
                             Divider()
                         }
+                    }
+                }
+
+                if (items.loadState.append is LoadState.Loading) {
+                    item(contentType = "LoadingView") {
+                        LoadingView(
+                            modifier = modifier
+                                .fillMaxSize()
+                                .padding(top = MaterialTheme.paddings.baseline)
+                        )
                     }
                 }
             }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/integrationLayer/SearchView.kt
@@ -168,6 +168,16 @@ private fun SearchResultList(
                             }
                         }
                     }
+
+                    if (items.loadState.append is LoadState.Loading) {
+                        item(contentType = "LoadingView") {
+                            LoadingView(
+                                modifier = modifier
+                                    .fillMaxSize()
+                                    .padding(MaterialTheme.paddings.baseline)
+                            )
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Pull request

## Description

Currently, when fetching the next page using Paging, there is no loading indicator to tell the user that something is happening.
Now, there is an indicator shows while the page is being loaded.

The impacted screens are in "Lists" and "Search", both on the mobile and TV demo aps.

## Changes made

As explained above.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
