### PR TITLE
Visual improvements for the TV demo app

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
@@ -2,7 +2,7 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-@file:Suppress("MaximumLineLength", "MaxLineLength")
+@file:Suppress("MaximumLineLength", "MaxLineLength", "StringLiteralDuplication")
 
 package ch.srgssr.pillarbox.demo.shared.data
 
@@ -47,12 +47,14 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "Switzerland says sorry! The fondue invasion",
                     uri = "https://swi-vod.akamaized.net/videoJson/47603186/master.m3u8",
-                    description = "VOD - HLS"
+                    description = "VOD - HLS",
+                    imageUrl = "https://www.swissinfo.ch/srgscalableimage/47603560/16x9"
                 ),
                 DemoItem(
                     title = "Des violents orages ont touché Ajaccio, chef-lieu de la Corse, jeudi",
                     uri = "https://rts-vod-amd.akamaized.net/ww/13317145/f1d49f18-f302-37ce-866c-1c1c9b76a824/master.m3u8",
-                    description = "VOD - HLS (short)"
+                    description = "VOD - HLS (short)",
+                    imageUrl = "https://www.rts.ch/2022/08/18/12/38/13317144.image/16x9"
                 ),
                 DemoItem(
                     title = "The dig",
@@ -62,15 +64,17 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "Couleur 3 en vidéo (live)",
                     uri = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
-                    description = "Video livestream - HLS"
+                    description = "Video livestream - HLS",
+                    imageUrl = "https://www.rts.ch/2023/11/16/13/27/14474730.image/16x9"
                 ),
                 DemoItem(
                     title = "Couleur 3 en vidéo (DVR)",
                     uri = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8",
-                    description = "Video livestream with DVR - HLS"
+                    description = "Video livestream with DVR - HLS",
+                    imageUrl = "https://www.rts.ch/2023/11/16/13/27/14474730.image/16x9"
                 ),
                 DemoItem(
-                    title = "Tageschau",
+                    title = "Tagesschau",
                     uri = "https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8",
                     description = "Video livestream with DVR and timestamps - HLS"
                 ),
@@ -82,12 +86,14 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "Couleur 3 (live)",
                     uri = "https://stream.srg-ssr.ch/m/couleur3/mp3_128",
-                    description = "Audio livestream - MP3"
+                    description = "Audio livestream - MP3",
+                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
                 ),
                 DemoItem(
                     title = "Couleur 3 (DVR)",
                     uri = "https://lsaplus.swisstxt.ch/audio/couleur3_96.stream/playlist.m3u8",
-                    description = "Audio livestream - HLS"
+                    description = "Audio livestream - HLS",
+                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
                 )
             )
         )
@@ -97,27 +103,32 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "RSI 1",
                     uri = "urn:rsi:video:livestream_La1",
-                    description = "Live video"
+                    description = "Live video",
+                    imageUrl = "https://ws.srf.ch/asset/image/audio/6b100f6e-440c-4bfb-8372-89a0688c533a/EPISODE_IMAGE"
                 ),
                 DemoItem(
                     title = "RTS 1",
                     uri = "urn:rts:video:3608506",
-                    description = "DVR video livestream"
+                    description = "DVR video livestream",
+                    imageUrl = "https://www.rts.ch/2023/09/06/14/43/14253742.image/16x9"
                 ),
                 DemoItem(
                     title = "Couleur 3 (DVR)",
                     uri = "urn:rts:audio:3262363",
-                    description = "DVR audio livestream"
+                    description = "DVR audio livestream",
+                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
                 ),
                 DemoItem(
                     title = "Telegiornale flash",
                     uri = "urn:rsi:video:15916771",
-                    description = "Superfluously token-protected video"
+                    description = "Superfluously token-protected video",
+                    imageUrl = "https://il.rsi.ch/rsi-api/resize/image/v2/WEBVISUAL/256699/"
                 ),
                 DemoItem(
                     title = "SRF 1",
                     uri = "urn:srf:video:c4927fcf-e1a0-0001-7edd-1ef01d441651",
-                    description = "Live video"
+                    description = "Live video",
+                    imageUrl = "https://ws.srf.ch/asset/image/audio/d91bbe14-55dd-458c-bc88-963462972687/EPISODE_IMAGE"
                 ),
                 DemoItem(
                     title = "Il lavoro di TerraProject per una fotografia documentaria",
@@ -131,20 +142,24 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
             items = listOf(
                 DemoItem(
                     title = "VoD - Dash (H264)",
-                    uri = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd"
+                    uri = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "VoD - Dash Widewine cenc (H264)",
                     uri = "https://storage.googleapis.com/wvmedia/cenc/h264/tears/tears.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg",
                     licenseUrl = "https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test"
                 ),
                 DemoItem(
                     title = "VoD - Dash (H265)",
-                    uri = "https://storage.googleapis.com/wvmedia/clear/hevc/tears/tears.mpd"
+                    uri = "https://storage.googleapis.com/wvmedia/clear/hevc/tears/tears.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "VoD - Dash widewine cenc (H265)",
                     uri = "https://storage.googleapis.com/wvmedia/cenc/hevc/tears/tears.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg",
                     licenseUrl = "https://proxy.uat.widevine.com/proxy?video_id=2015_tears&provider=widevine_test"
                 )
             )
@@ -179,19 +194,23 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 ),
                 DemoItem(
                     title = "Apple WWDC Keynote 2023",
-                    uri = "https://events-delivery.apple.com/0105cftwpxxsfrpdwklppzjhjocakrsk/m3u8/vod_index-PQsoJoECcKHTYzphNkXohHsQWACugmET.m3u8"
+                    uri = "https://events-delivery.apple.com/0105cftwpxxsfrpdwklppzjhjocakrsk/m3u8/vod_index-PQsoJoECcKHTYzphNkXohHsQWACugmET.m3u8",
+                    imageUrl = "https://www.apple.com/v/apple-events/home/ac/images/overview/recent-events/gallery/jun-2023__cjqmmqlyd21y_large_2x.jpg"
                 ),
                 DemoItem(
                     title = "Apple Dolby Atmos",
-                    uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8"
+                    uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/adv_dv_atmos/main.m3u8",
+                    imageUrl = "https://is1-ssl.mzstatic.com/image/thumb/-6farfCY0YClFd7-z_qZbA/1000x563.webp"
                 ),
                 DemoItem(
                     title = "The Morning Show - My Way: Season 1",
-                    uri = "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1522121579&isExternal=true&brandId=tvs.sbd.4000&id=518077009&l=en-GB&aec=UHD"
+                    uri = "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1522121579&isExternal=true&brandId=tvs.sbd.4000&id=518077009&l=en-GB&aec=UHD",
+                    imageUrl = "https://is1-ssl.mzstatic.com/image/thumb/cZUkXfqYmSy57DBI5TiTMg/1000x563.webp"
                 ),
                 DemoItem(
                     title = "The Morning Show - Change: Season 2",
-                    uri = "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1568297173&isExternal=true&brandId=tvs.sbd.4000&id=518034010&l=en-GB&aec=UHD"
+                    uri = "https://play-edge.itunes.apple.com/WebObjects/MZPlayLocal.woa/hls/subscription/playlist.m3u8?cc=CH&svcId=tvs.vds.4021&a=1568297173&isExternal=true&brandId=tvs.sbd.4000&id=518034010&l=en-GB&aec=UHD",
+                    imageUrl = "https://is1-ssl.mzstatic.com/image/thumb/IxmmS1rQ7ouO-pKoJsVpGw/1000x563.webp"
                 )
             )
         )
@@ -201,7 +220,8 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "Brain Farm Skate Phantom Flex",
                     uri = "https://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8",
-                    description = "4K video"
+                    description = "4K video",
+                    imageUrl = "https://www.skateboarding.com/.image/c_limit%2Ccs_srgb%2Cq_auto:eco%2Cw_596/MTk2NDExNjYzMzU5OTQzODMw/screen-shot-2013-10-03-at-115714-am.webp"
                 )
             )
         )
@@ -210,23 +230,28 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
             items = listOf(
                 DemoItem(
                     title = "Multiple subtitles and audio tracks",
-                    uri = "https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+                    uri = "https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8",
+                    imageUrl = "https://durian.blender.org/wp-content/uploads/2010/06/05.8b_comp_000272.jpg"
                 ),
                 DemoItem(
                     title = "4K, HEVC",
-                    uri = "https://cdn.bitmovin.com/content/encoding_test_dash_hls/4k/hls/4k_profile/master.m3u8"
+                    uri = "https://cdn.bitmovin.com/content/encoding_test_dash_hls/4k/hls/4k_profile/master.m3u8",
+                    imageUrl = "https://peach.blender.org/wp-content/uploads/bbb-splash.png"
                 ),
                 DemoItem(
                     title = "VoD, single audio track",
-                    uri = "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8"
+                    uri = "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/m3u8s/f08e80da-bf1d-4e3d-8899-f0f6155f6efa.m3u8",
+                    imageUrl = "https://img.redbull.com/images/c_crop,w_3840,h_1920,x_0,y_0,f_auto,q_auto/c_scale,w_1200/redbullcom/tv/FO-1MR39KNMH2111/fo-1mr39knmh2111-featuremedia"
                 ),
                 DemoItem(
                     title = "AES-128",
-                    uri = "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8"
+                    uri = "https://bitmovin-a.akamaihd.net/content/art-of-motion_drm/m3u8s/11331.m3u8",
+                    imageUrl = "https://img.redbull.com/images/c_crop,w_3840,h_1920,x_0,y_0,f_auto,q_auto/c_scale,w_1200/redbullcom/tv/FO-1MR39KNMH2111/fo-1mr39knmh2111-featuremedia"
                 ),
                 DemoItem(
                     title = "AVC Progressive",
-                    uri = "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4"
+                    uri = "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4",
+                    imageUrl = "https://img.redbull.com/images/c_crop,w_3840,h_1920,x_0,y_0,f_auto,q_auto/c_scale,w_1200/redbullcom/tv/FO-1MR39KNMH2111/fo-1mr39knmh2111-featuremedia"
                 )
             )
         )
@@ -235,7 +260,8 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
             items = listOf(
                 DemoItem(
                     title = "Fragmented MP4",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Key Rotation",
@@ -243,23 +269,28 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 ),
                 DemoItem(
                     title = "Alternate audio language",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.m3u8",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Audio only",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.m3u8?filter=(type!=%22video%22)"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.m3u8?filter=(type!=%22video%22)",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Trickplay",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/no-handler-origin/tears-of-steel/tears-of-steel-trickplay.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/no-handler-origin/tears-of-steel/tears-of-steel-trickplay.m3u8",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Limiting bandwidth use",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8?max_bitrate=800000"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8?max_bitrate=800000",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Dynamic Track Selection",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8?filter=%28type%3D%3D%22audio%22%26%26systemBitrate%3C100000%29%7C%7C%28type%3D%3D%22video%22%26%26systemBitrate%3C1024000%29"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.m3u8?filter=%28type%3D%3D%22audio%22%26%26systemBitrate%3C100000%29%7C%7C%28type%3D%3D%22video%22%26%26systemBitrate%3C1024000%29",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Pure live",
@@ -279,11 +310,13 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 ),
                 DemoItem(
                     title = "fMP4, clear",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-fmp4.ism/.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-fmp4.ism/.m3u8",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "fMP4, HEVC 4K",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hevc.ism/.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hevc.ism/.m3u8",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 )
             )
         )
@@ -292,35 +325,43 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
             items = listOf(
                 DemoItem(
                     title = "MP4",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.mp4/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.mp4/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Fragmented MP4",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Trickplay",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/no-handler-origin/tears-of-steel/tears-of-steel-trickplay.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/no-handler-origin/tears-of-steel/tears-of-steel-trickplay.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Tiled thumbnails (live/timeline)",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-tiled-thumbnails-timeline.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-tiled-thumbnails-timeline.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Single - fragmented TTML",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-en.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-en.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Multiple - fragmented TTML",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-ttml.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-ttml.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Multiple - RFC 5646 language tags",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-rfc5646.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-rfc5646.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Accessibility - hard of hearing",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hoh-subs.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-hoh-subs.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Pure live",
@@ -336,19 +377,23 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 ),
                 DemoItem(
                     title = "Audio only",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.mpd?filter=(type!=%22video%22)"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.mpd?filter=(type!=%22video%22)",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Alternate audio language",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-lang.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Multiple audio codecs",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-codec.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-multi-codec.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 ),
                 DemoItem(
                     title = "Accessibility - audio description",
-                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-desc-aud.ism/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel-desc-aud.ism/.mpd",
+                    imageUrl = "https://mango.blender.org/wp-content/gallery/4k-renders/01_thom_celia_bridge.jpg"
                 )
             )
         )
@@ -357,15 +402,18 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
             items = listOf(
                 DemoItem(
                     title = "Horizontal video",
-                    uri = "urn:rts:video:6820736"
+                    uri = "urn:rts:video:6820736",
+                    imageUrl = "https://www.rts.ch/2015/05/28/20/19/6820735.image/16x9"
                 ),
                 DemoItem(
                     title = "Square video",
-                    uri = "urn:rts:video:8393241"
+                    uri = "urn:rts:video:8393241",
+                    imageUrl = "https://www.rts.ch/2017/02/16/07/08/8393235.image/16x9"
                 ),
                 DemoItem(
                     title = "Vertical video",
-                    uri = "urn:rts:video:13444390"
+                    uri = "urn:rts:video:13444390",
+                    imageUrl = "https://www.rts.ch/2022/10/06/17/32/13444380.image/4x5"
                 )
             )
         )
@@ -375,12 +423,14 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "Couleur 3 en direct",
                     uri = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
-                    description = "Live video (unbuffered)"
+                    description = "Live video (unbuffered)",
+                    imageUrl = "https://www.rts.ch/2023/11/16/13/27/14474730.image/16x9"
                 ),
                 DemoItem(
                     title = "Couleur 3 en direct",
                     uri = "http://stream.srg-ssr.ch/m/couleur3/mp3_128",
-                    description = "Audio livestream (unbuffered)"
+                    description = "Audio livestream (unbuffered)",
+                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
                 )
             )
         )
@@ -390,7 +440,8 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "Expired URN",
                     uri = "urn:rts:video:13382911",
-                    description = "Content that is not available anymore"
+                    description = "Content that is not available anymore",
+                    imageUrl = "https://www.rts.ch/2022/09/20/09/57/13365589.image/16x9"
                 ),
                 DemoItem(
                     title = "Unknown URN",

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
@@ -59,41 +59,44 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "The dig",
                     uri = "https://media.swissinfo.ch/media/video/dddaff93-c2cd-4b6e-bdad-55f75a519480/rendition/154a844b-de1d-4854-93c1-5c61cd07e98c.mp4",
-                    description = "VOD - MP4"
+                    description = "VOD - MP4",
+                    imageUrl = "https://www.swissinfo.ch/resource/image/47686506/landscape_ratio3x2/280/187/347ee14103b1b86184659b2fd04c69ba/8C028539EC620EFACC0BF2F61591E2F8/img_8527.jpg"
                 ),
                 DemoItem(
                     title = "Couleur 3 en vidéo (live)",
                     uri = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
                     description = "Video livestream - HLS",
-                    imageUrl = "https://www.rts.ch/2023/11/16/13/27/14474730.image/16x9"
+                    imageUrl = "https://img.rts.ch/audio/2010/image/924h3y-25865853.image?w=640&h=640"
                 ),
                 DemoItem(
                     title = "Couleur 3 en vidéo (DVR)",
                     uri = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8",
                     description = "Video livestream with DVR - HLS",
-                    imageUrl = "https://www.rts.ch/2023/11/16/13/27/14474730.image/16x9"
+                    imageUrl = "https://il.srgssr.ch/images/?imageUrl=https%3A%2F%2Fwww.rts.ch%2F2020%2F05%2F18%2F14%2F20%2F11333286.image%2F16x9&format=jpg&width=960"
                 ),
                 DemoItem(
                     title = "Tagesschau",
                     uri = "https://tagesschau.akamaized.net/hls/live/2020115/tagesschau/tagesschau_1/master.m3u8",
-                    description = "Video livestream with DVR and timestamps - HLS"
+                    description = "Video livestream with DVR and timestamps - HLS",
+                    imageUrl = "https://images.tagesschau.de/image/89045d82-5cd5-46ad-8f91-73911add30ee/AAABh3YLLz0/AAABibBx2rU/20x9-1280/tagesschau-logo-100.jpg"
                 ),
                 DemoItem(
                     title = "On en parle",
                     uri = "https://rts-aod-dd.akamaized.net/ww/13306839/63cc2653-8305-3894-a448-108810b553ef.mp3",
-                    description = "AOD - MP3"
+                    description = "AOD - MP3",
+                    imageUrl = "https://www.rts.ch/2023/09/28/17/49/11872957.image?w=624&h=351"
                 ),
                 DemoItem(
                     title = "Couleur 3 (live)",
                     uri = "https://stream.srg-ssr.ch/m/couleur3/mp3_128",
                     description = "Audio livestream - MP3",
-                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
+                    imageUrl = "https://img.rts.ch/articles/2017/image/cxsqgp-25867841.image?w=640&h=640"
                 ),
                 DemoItem(
                     title = "Couleur 3 (DVR)",
                     uri = "https://lsaplus.swisstxt.ch/audio/couleur3_96.stream/playlist.m3u8",
                     description = "Audio livestream - HLS",
-                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
+                    imageUrl = "https://img.rts.ch/articles/2017/image/cxsqgp-25867841.image?w=640&h=640"
                 )
             )
         )
@@ -170,27 +173,32 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 DemoItem(
                     title = "Apple Basic 4:3",
                     uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8",
-                    description = "4x3 aspect ratio, H.264 @ 30Hz"
+                    description = "4x3 aspect ratio, H.264 @ 30Hz",
+                    imageUrl = "https://www.apple.com/newsroom/images/default/apple-logo-og.jpg?202312141200"
                 ),
                 DemoItem(
                     title = "Apple Basic 16:9",
                     uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8",
-                    description = "16x9 aspect ratio, H.264 @ 30Hz"
+                    description = "16x9 aspect ratio, H.264 @ 30Hz",
+                    imageUrl = "https://www.apple.com/newsroom/images/default/apple-logo-og.jpg?202312141200"
                 ),
                 DemoItem(
                     title = "Apple Advanced 16:9 (TS)",
                     uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_ts/master.m3u8",
-                    description = "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Transport stream"
+                    description = "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Transport stream",
+                    imageUrl = "https://www.apple.com/newsroom/images/default/apple-logo-og.jpg?202312141200"
                 ),
                 DemoItem(
                     title = "Apple Advanced 16:9 (fMP4)",
                     uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/img_bipbop_adv_example_fmp4/master.m3u8",
-                    description = "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Fragmented MP4"
+                    description = "16x9 aspect ratio, H.264 @ 30Hz and 60Hz, Fragmented MP4",
+                    imageUrl = "https://www.apple.com/newsroom/images/default/apple-logo-og.jpg?202312141200"
                 ),
                 DemoItem(
                     title = "Apple Advanced 16:9 (HEVC/H.264)",
                     uri = "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_adv_example_hevc/master.m3u8",
-                    description = "16x9 aspect ratio, H.264 and HEVC @ 30Hz and 60Hz"
+                    description = "16x9 aspect ratio, H.264 and HEVC @ 30Hz and 60Hz",
+                    imageUrl = "https://www.apple.com/newsroom/images/default/apple-logo-og.jpg?202312141200"
                 ),
                 DemoItem(
                     title = "Apple WWDC Keynote 2023",
@@ -221,7 +229,7 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                     title = "Brain Farm Skate Phantom Flex",
                     uri = "https://sample.vodobox.net/skate_phantom_flex_4k/skate_phantom_flex_4k.m3u8",
                     description = "4K video",
-                    imageUrl = "https://www.skateboarding.com/.image/c_limit%2Ccs_srgb%2Cq_auto:eco%2Cw_596/MTk2NDExNjYzMzU5OTQzODMw/screen-shot-2013-10-03-at-115714-am.webp"
+                    imageUrl = "https://i.ytimg.com/vi/d4_96ZWu3Vk/maxresdefault.jpg"
                 )
             )
         )
@@ -265,7 +273,8 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 ),
                 DemoItem(
                     title = "Key Rotation",
-                    uri = "https://demo.unified-streaming.com/k8s/keyrotation/stable/keyrotation/keyrotation.isml/.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/keyrotation/stable/keyrotation/keyrotation.isml/.m3u8",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "Alternate audio language",
@@ -294,19 +303,23 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 ),
                 DemoItem(
                     title = "Pure live",
-                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "Timeshift (5 minutes)",
-                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8?time_shift=300"
+                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8?time_shift=300",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "Live audio",
-                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8?filter=(type!=%22video%22)"
+                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.m3u8?filter=(type!=%22video%22)",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "Pure live (scte35)",
-                    uri = "https://demo.unified-streaming.com/k8s/live/stable/scte35.isml/.m3u8"
+                    uri = "https://demo.unified-streaming.com/k8s/live/stable/scte35.isml/.m3u8",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "fMP4, clear",
@@ -365,15 +378,18 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                 ),
                 DemoItem(
                     title = "Pure live",
-                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "Timeshift (5 minutes)",
-                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd?time_shift=300"
+                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live.isml/.mpd?time_shift=300",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "DVB DASH low latency",
-                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live-low-latency.isml/.mpd"
+                    uri = "https://demo.unified-streaming.com/k8s/live/stable/live-low-latency.isml/.mpd",
+                    imageUrl = "https://website-storage.unified-streaming.com/images/_1200x630_crop_center-center_none/default-facebook.png"
                 ),
                 DemoItem(
                     title = "Audio only",
@@ -424,13 +440,13 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                     title = "Couleur 3 en direct",
                     uri = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
                     description = "Live video (unbuffered)",
-                    imageUrl = "https://www.rts.ch/2023/11/16/13/27/14474730.image/16x9"
+                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
                 ),
                 DemoItem(
                     title = "Couleur 3 en direct",
                     uri = "http://stream.srg-ssr.ch/m/couleur3/mp3_128",
                     description = "Audio livestream (unbuffered)",
-                    imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
+                    imageUrl = "https://img.rts.ch/articles/2017/image/cxsqgp-25867841.image?w=320&h=320"
                 )
             )
         )

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/theme/Colors.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/theme/Colors.kt
@@ -8,9 +8,6 @@ package ch.srgssr.pillarbox.demo.shared.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val srg_branding_color = Color(0xFFAF001E)
-val srg_branding_onColor = Color(0xFFFFFFFF)
-
 val md_theme_light_primary = Color(0xFF3A52CA)
 val md_theme_light_onPrimary = Color(0xFFFFFFFF)
 val md_theme_light_primaryContainer = Color(0xFFDEE1FF)

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/theme/Colors.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/theme/Colors.kt
@@ -8,6 +8,9 @@ package ch.srgssr.pillarbox.demo.shared.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+val srg_branding_color = Color(0xFFAF001E)
+val srg_branding_onColor = Color(0xFFFFFFFF)
+
 val md_theme_light_primary = Color(0xFF3A52CA)
 val md_theme_light_onPrimary = Color(0xFFFFFFFF)
 val md_theme_light_primaryContainer = Color(0xFFDEE1FF)

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/examples/Examples.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/examples/Examples.kt
@@ -149,7 +149,7 @@ fun ExamplesHome(
                     ) {
                         Text(
                             text = item.title,
-                            color = if (item.imageUrl != null) Color.White else Color.Unspecified,
+                            color = Color.White,
                             overflow = TextOverflow.Ellipsis,
                             maxLines = 2,
                             style = MaterialTheme.typography.bodyMedium
@@ -160,7 +160,7 @@ fun ExamplesHome(
                             Text(
                                 text = description,
                                 modifier = Modifier.padding(top = MaterialTheme.paddings.small),
-                                color = if (item.imageUrl != null) Color.White else Color.Unspecified,
+                                color = Color.White,
                                 overflow = TextOverflow.Ellipsis,
                                 maxLines = 2,
                                 style = MaterialTheme.typography.bodySmall

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/examples/Examples.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/examples/Examples.kt
@@ -4,12 +4,13 @@
  */
 package ch.srgssr.pillarbox.demo.tv.examples
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -27,18 +28,20 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.onPreviewKeyEvent
 import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -58,6 +61,7 @@ import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.demo.shared.ui.NavigationRoutes
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 import ch.srgssr.pillarbox.demo.tv.ui.theme.paddings
+import coil.compose.AsyncImage
 import kotlinx.coroutines.launch
 
 /**
@@ -83,6 +87,7 @@ fun ExamplesHome(
     ) {
         composable(NavigationRoutes.homeSamples) {
             ExamplesSection(
+                columnCount = 4,
                 items = playlists,
                 focusFirstItem = false,
                 navController = navController,
@@ -116,6 +121,7 @@ fun ExamplesHome(
             val playlist = playlists[playlistIndex]
 
             ExamplesSection(
+                columnCount = 3,
                 title = playlist.title,
                 items = playlist.items,
                 focusFirstItem = true,
@@ -124,27 +130,42 @@ fun ExamplesHome(
                     onItemSelected(item)
                 }
             ) { item ->
-                Column(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(MaterialTheme.paddings.baseline),
-                    verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.small)
-                ) {
-                    Text(
-                        text = item.title,
-                        overflow = TextOverflow.Ellipsis,
-                        maxLines = 2,
-                        style = MaterialTheme.typography.bodyMedium
-                            .copy(fontWeight = FontWeight.Bold)
-                    )
+                Box {
+                    if (item.imageUrl != null) {
+                        AsyncImage(
+                            model = item.imageUrl,
+                            contentDescription = item.title,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop
+                        )
+                    }
 
-                    item.description?.let { description ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Brush.verticalGradient(listOf(Color.Transparent, Color.Black)))
+                            .padding(MaterialTheme.paddings.small),
+                        verticalArrangement = Arrangement.Bottom
+                    ) {
                         Text(
-                            text = description,
+                            text = item.title,
+                            color = if (item.imageUrl != null) Color.White else Color.Unspecified,
                             overflow = TextOverflow.Ellipsis,
                             maxLines = 2,
-                            style = MaterialTheme.typography.bodySmall
+                            style = MaterialTheme.typography.bodyMedium
+                                .copy(fontWeight = FontWeight.Bold)
                         )
+
+                        item.description?.let { description ->
+                            Text(
+                                text = description,
+                                modifier = Modifier.padding(top = MaterialTheme.paddings.small),
+                                color = if (item.imageUrl != null) Color.White else Color.Unspecified,
+                                overflow = TextOverflow.Ellipsis,
+                                maxLines = 2,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
                     }
                 }
             }
@@ -155,6 +176,7 @@ fun ExamplesHome(
 @Composable
 @OptIn(ExperimentalComposeUiApi::class, ExperimentalTvMaterial3Api::class)
 private fun <T> ExamplesSection(
+    columnCount: Int,
     modifier: Modifier = Modifier,
     title: String? = null,
     items: List<T>,
@@ -167,7 +189,6 @@ private fun <T> ExamplesSection(
         mutableIntStateOf(if (focusFirstItem) 0 else -1)
     }
 
-    val columnCount = 4
     val focusManager = LocalFocusManager.current
     val isOnFirstRow by remember {
         derivedStateOf { (focusedIndex / columnCount) <= 0 }
@@ -226,7 +247,7 @@ private fun <T> ExamplesSection(
                 Card(
                     onClick = { onItemClick(index, item) },
                     modifier = Modifier
-                        .height(104.dp)
+                        .aspectRatio(16f / 9)
                         .focusRequester(focusRequester)
                         .onGloballyPositioned {
                             if (index == focusedIndex) {

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/PlayerSettingDrawer.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/player/compose/PlayerSettingDrawer.kt
@@ -8,6 +8,7 @@ import android.app.Application
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -239,7 +240,8 @@ private fun <T> NavigationDrawerScope.GenericSetting(
         )
 
         TvLazyColumn(
-            contentPadding = PaddingValues(vertical = MaterialTheme.paddings.baseline)
+            contentPadding = PaddingValues(vertical = MaterialTheme.paddings.baseline),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.baseline)
         ) {
             items(items) { item ->
                 NavigationDrawerItem(
@@ -274,7 +276,8 @@ private fun NavigationDrawerScope.TracksSetting(
         )
 
         TvLazyColumn(
-            contentPadding = PaddingValues(vertical = MaterialTheme.paddings.baseline)
+            contentPadding = PaddingValues(vertical = MaterialTheme.paddings.baseline),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.baseline)
         ) {
             item {
                 NavigationDrawerItem(

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/TVDemoTopBar.kt
@@ -18,6 +18,11 @@ import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.focusRestorer
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -31,7 +36,6 @@ import androidx.tv.material3.Text
 import ch.srgssr.pillarbox.demo.shared.ui.HomeDestination
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 import ch.srgssr.pillarbox.demo.tv.ui.theme.paddings
-import ch.srgssr.pillarbox.ui.extension.handleDPadKeyEvents
 
 /**
  * Top bar displayed in the demo app on TV.
@@ -64,13 +68,16 @@ fun TVDemoTopBar(
         selectedTabIndex = focusedTabIndex,
         modifier = modifier
             .focusRestorer()
-            .handleDPadKeyEvents(
-                onRight = {
+            .onPreviewKeyEvent {
+                if (it.key == Key.DirectionRight && it.type == KeyEventType.KeyDown) {
                     if (focusedTabIndex < destinations.lastIndex) {
                         focusManager.moveFocus(FocusDirection.Right)
                     }
+                    true
+                } else {
+                    false
                 }
-            )
+            }
     ) {
         destinations.forEachIndexed { index, destination ->
             key(index) {

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -68,6 +68,8 @@ import androidx.tv.foundation.lazy.grid.TvLazyVerticalGrid
 import androidx.tv.foundation.lazy.grid.itemsIndexed
 import androidx.tv.foundation.lazy.grid.rememberTvLazyGridState
 import androidx.tv.material3.Card
+import androidx.tv.material3.CardColors
+import androidx.tv.material3.CardDefaults
 import androidx.tv.material3.ExperimentalTvMaterial3Api
 import androidx.tv.material3.Icon
 import androidx.tv.material3.MaterialTheme
@@ -91,6 +93,8 @@ import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ContentListSection
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListFactories
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
+import ch.srgssr.pillarbox.demo.shared.ui.theme.srg_branding_color
+import ch.srgssr.pillarbox.demo.shared.ui.theme.srg_branding_onColor
 import ch.srgssr.pillarbox.demo.tv.R
 import ch.srgssr.pillarbox.demo.tv.player.PlayerActivity
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
@@ -151,6 +155,12 @@ fun ListsHome(
                 itemToString = { item ->
                     item.destinationTitle
                 },
+                cardColors = CardDefaults.colors(
+                    containerColor = srg_branding_color,
+                    contentColor = srg_branding_onColor,
+                    focusedContentColor = srg_branding_onColor,
+                    pressedContentColor = srg_branding_onColor
+                ),
                 navController = navController,
                 onItemClick = { _, contentList ->
                     navController.navigate(contentList.destinationRoute)
@@ -247,6 +257,7 @@ private fun <T> ListsSection(
     focusFirstItem: Boolean,
     navController: NavHostController,
     itemToString: (item: T) -> String,
+    cardColors: CardColors = CardDefaults.colors(),
     onItemClick: (index: Int, item: T) -> Unit
 ) {
     var focusedIndex by rememberSaveable(items, focusFirstItem) {
@@ -326,7 +337,8 @@ private fun <T> ListsSection(
                             if (it.hasFocus) {
                                 focusedIndex = index
                             }
-                        }
+                        },
+                    colors = cardColors
                 ) {
                     Box(
                         modifier = Modifier.fillMaxSize(),

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -92,8 +92,6 @@ import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.Content
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ContentListSection
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListFactories
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.contentListSections
-import ch.srgssr.pillarbox.demo.shared.ui.theme.srg_branding_color
-import ch.srgssr.pillarbox.demo.shared.ui.theme.srg_branding_onColor
 import ch.srgssr.pillarbox.demo.tv.R
 import ch.srgssr.pillarbox.demo.tv.player.PlayerActivity
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
@@ -155,10 +153,10 @@ fun ListsHome(
                     item.destinationTitle
                 },
                 cardColors = CardDefaults.colors(
-                    containerColor = srg_branding_color,
-                    contentColor = srg_branding_onColor,
-                    focusedContentColor = srg_branding_onColor,
-                    pressedContentColor = srg_branding_onColor
+                    containerColor = Color(0xFFAF001E),
+                    contentColor = Color.White,
+                    focusedContentColor = Color.White,
+                    pressedContentColor = Color.White
                 ),
                 navController = navController,
                 onItemClick = { _, contentList ->

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/integrationLayer/ListsHome.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Headset
@@ -49,7 +49,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
@@ -326,7 +325,7 @@ private fun <T> ListsSection(
                 Card(
                     onClick = { onItemClick(index, item) },
                     modifier = Modifier
-                        .height(104.dp)
+                        .aspectRatio(16f / 9)
                         .focusRequester(focusRequester)
                         .onGloballyPositioned {
                             if (index == focusedIndex) {
@@ -446,7 +445,6 @@ private fun <T : Content> ListsSectionContent(
         val isOnFirstRow by remember {
             derivedStateOf { (focusedIndex / columnCount) <= 0 }
         }
-        val itemHeight = if (hasMedia) 160.dp else 104.dp
 
         val coroutineScope = rememberCoroutineScope()
         val scrollState = rememberTvLazyGridState()
@@ -494,7 +492,7 @@ private fun <T : Content> ListsSectionContent(
                     Card(
                         onClick = { onItemClick(item) },
                         modifier = Modifier
-                            .height(itemHeight)
+                            .aspectRatio(16f / 9)
                             .focusRequester(focusRequester)
                             .onGloballyPositioned {
                                 if (index == focusedIndex) {


### PR DESCRIPTION
# Pull request

## Description

This PR visually improves the TV demo app in various ways, as described below.

## Changes made

- Increase padding between items in the settings drawer
- Use SRG branding colour for BU selector in "Lists"
- Add images in "Examples"
- Instead of an hardcoded height for cards, we use a 16/9 aspect ratio
- Fix top navigation

> [!NOTE]
> The following examples don't have images (yet?):
> - SRG SSR streams (URNs)
>   - Il lavoro di TerraProject per una fotografia documentaria
> - Corner cases
>   - Unknown URN

## Screenshots

| Description | Screenshot |
|-----|-----|
| Padding in settings | ![Screenshot_20231219_145358](https://github.com/SRGSSR/pillarbox-android/assets/1009664/b0cf1e9d-1c4b-406f-9bf3-f1a444a4ca42) |
| BU selector | ![Screenshot_20231219_145417](https://github.com/SRGSSR/pillarbox-android/assets/1009664/1a7aac67-fe16-4a14-a661-b4d51c660b46) |
| Images in "Examples" | ![Screenshot_20231219_145508](https://github.com/SRGSSR/pillarbox-android/assets/1009664/460d09ea-cd3f-48ad-a349-787459fe3db6) |

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.