### PR TITLE
Fix crash when decode bitmap throw an exception

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
@@ -86,8 +86,10 @@ class PillarboxMediaDescriptionAdapter(
             outHeight = imageMaxHeight
         }
         runBlocking(Dispatchers.IO) {
-            val bitmap = BitmapFactory.decodeStream(imageUrl.openStream(), null, opts)
-            bitmap?.let {
+            val result = runCatching {
+                BitmapFactory.decodeStream(imageUrl.openStream(), null, opts)
+            }
+            result.getOrNull()?.let {
                 bitmapCache.put(imageUri, it)
                 callback.onBitmap(it)
             }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapter.kt
@@ -87,7 +87,9 @@ class PillarboxMediaDescriptionAdapter(
         }
         runBlocking(Dispatchers.IO) {
             val result = runCatching {
-                BitmapFactory.decodeStream(imageUrl.openStream(), null, opts)
+                imageUrl.openStream().use {
+                    BitmapFactory.decodeStream(it, null, opts)
+                }
             }
             result.getOrNull()?.let {
                 bitmapCache.put(imageUri, it)


### PR DESCRIPTION
# Pull request

## Description

This PR fixe a crash when open the player from the Demo on mobile while no internet.

## Changes made

- Handle correctly Bitmap decoding error in `PillarboxMediaDescriptionAdapter`

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
