### PR TITLE
Fix error in nightly workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
   detekt:
     name: Detekt
     runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -75,6 +78,9 @@ jobs:
   dependency-analysis:
     name: Dependency Analysis
     runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -88,6 +94,7 @@ jobs:
         run: ./gradlew buildHealth
       - name: Archive analysis report
         uses: actions/upload-artifact@v3
+        if: failure()
         with:
           name: dependency-analysis-report
           path: build/reports/dependency-analysis/build-health-report.txt

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -6,11 +6,11 @@ on:
   workflow_dispatch:
     inputs:
       version_name:
-        description: 'version name as xx.yy.zz-Optional'
+        description: 'Version name as x.y.z-optional'
         required: true
         type: string
   schedule:
-    - cron:  '0 0 * * 1,5'
+    - cron:  '0 0 * * *'
 
 jobs:
   check_date:
@@ -20,14 +20,13 @@ jobs:
       should_run: ${{ steps.should_run.outputs.should_run }}
 
     steps:
-      - uses: actions/checkout@v3
-      - name: print latest_commit
+      - uses: actions/checkout@v4
+      - name: Print the last commit sha
         run: echo ${{ github.sha }}
       - id: should_run
-        continue-on-error: true
-        name: check latest commit is less than a day
+        name: Check that the last commit was made in the last 24h
         if: ${{ github.event_name == 'schedule' }}
-        run: test -z $(git rev-list  --after="24 hours"  ${{ github.sha }}) &amp;&amp; echo "should_run=false" >> "$GITHUB_OUTPUT"
+        run: test -z $(git rev-list --after="24 hours" ${{ github.sha }}) && echo "should_run=false" >> "$GITHUB_OUTPUT"
 
   Build-nightly:
     needs: check_date
@@ -39,45 +38,41 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
-      - name: VERSION_NAME from inputs
+      - name: Setup VERSION_NAME from inputs
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          echo "VERSION_NAME=${{ inputs.version_name }}" >> "$GITHUB_ENV"
-      - name: Find latest tag
+        run: echo "VERSION_NAME=${{ inputs.version_name }}" >> "$GITHUB_ENV"
+      - name: Find the latest tag
         if: ${{ github.event_name != 'workflow_dispatch' }}
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
         with:
           fallback: 0.0.1-alpha01 # Optional fallback tag to use when no tag can be found
-      - name: Setup VERSION_NAME from latest git tag
+      - name: Setup VERSION_NAME from the latest tag
         if: ${{ github.event_name != 'workflow_dispatch' }}
-        run: |
-          echo "VERSION_NAME=${{ steps.previoustag.outputs.tag }}" >> "$GITHUB_ENV"
+        run: echo "VERSION_NAME=${{ steps.previoustag.outputs.tag }}" >> "$GITHUB_ENV"
       - name: Print VersionName
         run: |
           echo "Version name is ${{ env.VERSION_NAME }}"
-          echo "ref ${GITHUB_REF}"
-          echo "refname ${GITHUB_REF_NAME}"
-          echo "refname ${GITHUB_REF_TYPE}"
+          echo "GitHub ref ${GITHUB_REF}"
+          echo "GitHub ref name ${GITHUB_REF_NAME}"
+          echo "GitHub ref type ${GITHUB_REF_TYPE}"
           echo "CI ${{ env.CI }}"
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
-          cache: 'gradle'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2.8.0
-        with:
-          arguments: assembleNightlyRelease
-      - name: upload artifact to Firebase App Distribution
+      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/gradle-build-action@v2
+      - name: Assemble nightly release
+        run: ./gradlew assembleNightlyRelease
+      - name: Upload artifact to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.NIGHTLY_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_CREDENTIAL_FILE_CONTENT }}
           groups: ${{ secrets.NIGHTLY_GROUPS }}
           file: pillarbox-demo/build/outputs/apk/nightly/release/pillarbox-demo-nightly-release.apk
-


### PR DESCRIPTION
# Pull request

## Description

The nightly workflow keeps reporting an error and deploying the same artefact. This PR should fix that. The error reported is:
```bash
Run test -z $(git rev-list  --after="24 hours"  5c812aafa3c064d2501c85ce2c7d825473370948) &amp;&amp; echo "should_run=false" >> "$GITHUB_OUTPUT"
/home/runner/work/_temp/d83f63c5-3826-409c-b4f3-a437ff831d3d.sh: line 1: syntax error near unexpected token `;&'
Error: Process completed with exit code 2.
```

## Changes made

- Fix the error reported every time the nightly workflow run
- Make the nightly workflow run everyday
- Update GitHub Actions to the latest versions
- Properly use `gradle/gradle-build-action` to improve cache management

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
