### PR TITLE
Add position and duration label

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/DurationFormatter.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/DurationFormatter.kt
@@ -7,7 +7,7 @@ package ch.srgssr.pillarbox.demo.shared.ui
 import kotlin.time.Duration
 
 /**
- * @return a formatter function for displaying the duration based on its length.
+ * @return a formatter function to display the duration based on its length.
  */
 fun Duration.getFormatter(): (Duration) -> String {
     return if (inWholeHours <= 0) DurationFormatter::formatMinutesSeconds else DurationFormatter::formatHourMinutesSeconds
@@ -16,13 +16,13 @@ fun Duration.getFormatter(): (Duration) -> String {
 /**
  * Duration formatter
  */
-object DurationFormatter {
+private object DurationFormatter {
     private const val FORMAT_HOURS_MINUTES_SECONDS = "%02d:%02d:%02d"
     private const val FORMAT_MINUTES_SECONDS = "%02d:%02d"
 
     /**
      * @param duration The duration to format.
-     * @return Format hour minutes seconds
+     * @return The duration formatted as "hh:mm:ss"
      */
     fun formatHourMinutesSeconds(duration: Duration): String {
         return duration.toComponents { hours, minutes, seconds, _ ->
@@ -32,10 +32,10 @@ object DurationFormatter {
 
     /**
      * @param duration The duration to format.
-     * @return Format minutes seconds
+     * @return The duration formatted as "mm:ss"
      */
     fun formatMinutesSeconds(duration: Duration): String {
-        return duration.toComponents { _, minutes, seconds, _ ->
+        return duration.toComponents { minutes, seconds, _ ->
             FORMAT_MINUTES_SECONDS.format(minutes, seconds)
         }
     }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/DurationFormatter.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/DurationFormatter.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.shared.ui
+
+import kotlin.time.Duration
+
+/**
+ * @return a formatter function for displaying the duration based on its length.
+ */
+fun Duration.getFormatter(): (Duration) -> String {
+    return if (inWholeHours <= 0) DurationFormatter::formatMinutesSeconds else DurationFormatter::formatHourMinutesSeconds
+}
+
+/**
+ * Duration formatter
+ */
+object DurationFormatter {
+    private const val FORMAT_HOURS_MINUTES_SECONDS = "%02d:%02d:%02d"
+    private const val FORMAT_MINUTES_SECONDS = "%02d:%02d"
+
+    /**
+     * @param duration The duration to format.
+     * @return Format hour minutes seconds
+     */
+    fun formatHourMinutesSeconds(duration: Duration): String {
+        return duration.toComponents { hours, minutes, seconds, _ ->
+            FORMAT_HOURS_MINUTES_SECONDS.format(hours, minutes, seconds)
+        }
+    }
+
+    /**
+     * @param duration The duration to format.
+     * @return Format minutes seconds
+     */
+    fun formatMinutesSeconds(duration: Duration): String {
+        return duration.toComponents { _, minutes, seconds, _ ->
+            FORMAT_MINUTES_SECONDS.format(minutes, seconds)
+        }
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerTimeSlider.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerTimeSlider.kt
@@ -6,17 +6,21 @@ package ch.srgssr.pillarbox.demo.ui.player.controls
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.media3.common.Player
+import ch.srgssr.pillarbox.demo.shared.ui.getFormatter
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.extension.canSeek
 import ch.srgssr.pillarbox.ui.ProgressTrackerState
@@ -24,6 +28,7 @@ import ch.srgssr.pillarbox.ui.SimpleProgressTrackerState
 import ch.srgssr.pillarbox.ui.SmoothProgressTrackerState
 import ch.srgssr.pillarbox.ui.extension.availableCommandsAsState
 import ch.srgssr.pillarbox.ui.extension.currentBufferedPercentageAsState
+import ch.srgssr.pillarbox.ui.extension.durationAsState
 import kotlinx.coroutines.CoroutineScope
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -65,28 +70,34 @@ fun PlayerTimeSlider(
     progressTracker: ProgressTrackerState = rememberProgressTrackerState(player = player, smoothTracker = true),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
 ) {
+    val duration by player.durationAsState()
     val currentProgress by progressTracker.progress.collectAsState()
     val currentProgressPercent = currentProgress.inWholeMilliseconds / player.duration.coerceAtLeast(1).toFloat()
     val bufferPercentage by player.currentBufferedPercentageAsState()
     val availableCommands by player.availableCommandsAsState()
-    Box(modifier = modifier) {
-        Slider(
-            value = bufferPercentage,
-            onValueChange = {},
-            enabled = false,
-            colors = playerSecondaryColors(),
-        )
+    val formatter = duration.milliseconds.getFormatter()
+    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+        Text(text = formatter(currentProgress))
+        Box(modifier = Modifier.weight(1f)) {
+            Slider(
+                value = bufferPercentage,
+                onValueChange = {},
+                enabled = false,
+                colors = playerSecondaryColors(),
+            )
 
-        Slider(
-            value = currentProgressPercent,
-            onValueChange = { percent ->
-                progressTracker.onChanged((percent * player.duration).toLong().milliseconds)
-            },
-            onValueChangeFinished = progressTracker::onFinished,
-            enabled = availableCommands.canSeek(),
-            colors = playerPrimaryColors(),
-            interactionSource = interactionSource,
-        )
+            Slider(
+                value = currentProgressPercent,
+                onValueChange = { percent ->
+                    progressTracker.onChanged((percent * player.duration).toLong().milliseconds)
+                },
+                onValueChangeFinished = progressTracker::onFinished,
+                enabled = availableCommands.canSeek(),
+                colors = playerPrimaryColors(),
+                interactionSource = interactionSource,
+            )
+        }
+        Text(text = formatter(duration.milliseconds))
     }
 }
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerTimeSlider.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerTimeSlider.kt
@@ -5,8 +5,10 @@
 package ch.srgssr.pillarbox.demo.ui.player.controls
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.SliderColors
 import androidx.compose.material3.SliderDefaults
@@ -21,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.shared.ui.getFormatter
+import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.extension.canSeek
 import ch.srgssr.pillarbox.ui.ProgressTrackerState
@@ -76,7 +79,11 @@ fun PlayerTimeSlider(
     val bufferPercentage by player.currentBufferedPercentageAsState()
     val availableCommands by player.availableCommandsAsState()
     val formatter = duration.milliseconds.getFormatter()
-    Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.mini)
+    ) {
         Text(text = formatter(currentProgress))
         Box(modifier = Modifier.weight(1f)) {
             Slider(


### PR DESCRIPTION
# Pull request

## Description

This PR add two labels to the Player demo user interface, one displaying the current position and the other the duration of the playing content.

![vod](https://github.com/SRGSSR/pillarbox-android/assets/30228000/52093380-6bfd-463b-8745-665206909e9f)

![live_dvr](https://github.com/SRGSSR/pillarbox-android/assets/30228000/4416eba9-b5b8-41fa-8942-dc9cdaea3212)


## Changes made

- Add current position label to the left of the slider.
- Add duration label to the right of the slider.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
