### PR TITLE
416 use legacy uniqueid after migration commanders act v4x to v5x

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,8 +30,8 @@ ktor = "2.3.7"
 mockk = "1.13.9"
 okhttp = "4.12.0"
 srg-data-provider = "0.8.0"
-tag-commander-core = "5.4.1"
-tag-commander-server-side = "5.5.1"
+tag-commander-core = "5.4.2"
+tag-commander-server-side = "5.5.2"
 
 [libraries]
 accompanist-navigation-material = { module = "com.google.accompanist:accompanist-navigation-material", version.ref = "accompanist" }

--- a/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestCommandersAct.kt
+++ b/pillarbox-analytics/src/androidTest/java/ch/srgssr/pillarbox/analytics/TestCommandersAct.kt
@@ -9,6 +9,9 @@ import ch.srgssr.pillarbox.analytics.commandersact.CommandersActEvent
 import ch.srgssr.pillarbox.analytics.commandersact.CommandersActLabels
 import ch.srgssr.pillarbox.analytics.commandersact.CommandersActPageView
 import ch.srgssr.pillarbox.analytics.commandersact.CommandersActSrg
+import com.tagcommander.lib.core.TCUser
+import com.tagcommander.lib.serverside.TCPredefinedVariables
+import com.tagcommander.lib.serverside.schemas.TCDevice
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -47,5 +50,12 @@ class TestCommandersAct {
         val expected = "service1,service2"
         commandersAct.setConsentServices(services)
         Assert.assertEquals(expected, commandersAct.getPermanentDataLabel(CommandersActLabels.CONSENT_SERVICES.label))
+    }
+
+    @Test
+    fun testLegacyUniqueId() {
+        val legacyUniqueId: String = TCPredefinedVariables.getInstance().uniqueIdentifier
+        Assert.assertEquals(legacyUniqueId, TCDevice.getInstance().sdkID)
+        Assert.assertEquals(legacyUniqueId, TCUser.getInstance().anonymous_id)
     }
 }


### PR DESCRIPTION
## Description

This PR uses the same unique identifier between v4 and v5, ensuring users are identified correctly between app updates to v5. The same change has been made for Apple at https://github.com/SRGSSR/pillarbox-apple/pull/752

## Changes made

* Override SDK identifier.
* Update to Commanders Act SDK 5.4.4 so that required APIs are available.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
