### PR TITLE
Enable Detekt on every source set

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,6 @@ allprojects {
     // Tutorial : https://medium.com/@nagendran.p/integrating-detekt-in-the-android-studio-442128e971f8
     detekt {
         config.setFrom(files("../config/detekt/detekt.yml"))
-        source.setFrom(files("src/main/java", "src/main/kotlin"))
         // preconfigure defaults
         buildUponDefaultConfig = false
         ignoredBuildTypes = listOf("release")

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/MediaEventTypeTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/MediaEventTypeTest.kt
@@ -18,5 +18,4 @@ class MediaEventTypeTest {
         assertEquals("pos", MediaEventType.Pos.toString())
         assertEquals("uptime", MediaEventType.Uptime.toString())
     }
-
 }

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/ImageScalingServiceTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/ImageScalingServiceTest.kt
@@ -16,7 +16,6 @@ class ImageScalingServiceTest {
         val baseUrl = IlHost.PROD
         val imageUrl = "https://www.rts.ch/2020/05/18/14/20/11333286.image/16x9"
 
-
         val imageScalingService = ImageScalingService(baseUrl)
         val scaledImageUrl = imageScalingService.getScaledImageUrl(imageUrl)
         val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8)

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/ResourceSelectorTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/ResourceSelectorTest.kt
@@ -230,7 +230,9 @@ class ResourceSelectorTest {
 
         fun createSupportedDrmResource(): Resource {
             return Resource(
-                "", Resource.Type.DASH, drmList = listOf(
+                url = "",
+                type = Resource.Type.DASH,
+                drmList = listOf(
                     Drm(Drm.Type.WIDEVINE, "https://widevine.license.co"),
                     Drm(Drm.Type.PLAYREADY, "https://playready.license.co")
                 )

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
@@ -50,8 +50,18 @@ class TestJsonSerialization {
 
     @Test
     fun testMediaCompositionValidJson() {
-        val json =
-            "{\"chapterUrn\":\"urn:srf:video:12343\" ,\"chapterList\": [{\"urn\":\"urn:srf:video:12343\",\"title\":\"Chapter title\",\"imageUrl\":\"https://image.png\"}]}"
+        val json = """
+{
+  "chapterUrn": "urn:srf:video:12343",
+  "chapterList": [
+    {
+      "urn": "urn:srf:video:12343",
+      "title": "Chapter title",
+      "imageUrl": "https://image.png"
+    }
+  ]
+}
+"""
         val mediaComposition = jsonSerializer.decodeFromString<MediaComposition>(json)
         Assert.assertNotNull(mediaComposition)
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestCurrentMediaItemTracker.kt
@@ -6,7 +6,6 @@ package ch.srgssr.pillarbox.player
 
 import android.net.Uri
 import androidx.media3.common.MediaItem
-import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
 import ch.srgssr.pillarbox.player.test.utils.AnalyticsListenerCommander
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemTracker
@@ -34,13 +33,19 @@ class TestCurrentMediaItemTracker {
         every { analyticsCommander.currentMediaItem } returns null
         every { analyticsCommander.currentPosition } returns 1000L
         tracker = TestTracker()
-        currentItemTracker = CurrentMediaItemTracker(analyticsCommander, MediaItemTrackerRepository().apply {
-            registerFactory(TestTracker::class.java, object : MediaItemTracker.Factory {
-                override fun create(): MediaItemTracker {
-                    return tracker
-                }
-            })
-        })
+        currentItemTracker = CurrentMediaItemTracker(
+            player = analyticsCommander,
+            mediaItemTrackerProvider = MediaItemTrackerRepository().apply {
+                registerFactory(
+                    TestTracker::class.java,
+                    object : MediaItemTracker.Factory {
+                        override fun create(): MediaItemTracker {
+                            return tracker
+                        }
+                    }
+                )
+            }
+        )
     }
 
     @After
@@ -347,34 +352,5 @@ class TestCurrentMediaItemTracker {
                 else -> stateList.add(EventState.END)
             }
         }
-    }
-
-    private class DummyTimeline(private val mediaItem: MediaItem) : Timeline() {
-
-        override fun getWindowCount(): Int {
-            return 1
-        }
-
-        override fun getWindow(windowIndex: Int, window: Window, defaultPositionProjectionUs: Long): Window {
-            window.mediaItem = mediaItem
-            return window
-        }
-
-        override fun getPeriodCount(): Int {
-            return 0
-        }
-
-        override fun getPeriod(periodIndex: Int, period: Period, setIds: Boolean): Period {
-            return Period()
-        }
-
-        override fun getIndexOfPeriod(uid: Any): Int {
-            return 0
-        }
-
-        override fun getUidOfPeriod(periodIndex: Int): Any {
-            return Any()
-        }
-
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestFormatExtension.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestFormatExtension.kt
@@ -51,5 +51,4 @@ class TestFormatExtension {
         Assert.assertTrue(format.hasSelection(C.SELECTION_FLAG_AUTOSELECT or C.SELECTION_FLAG_DEFAULT))
         Assert.assertFalse(format.hasSelection(C.SELECTION_FLAG_FORCED))
     }
-
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestMediaItemTrackerRepository.kt
@@ -43,11 +43,11 @@ class TestMediaItemTrackerRepository {
         }
 
         override fun start(player: ExoPlayer, initialData: Any?) {
-
+            // Nothing
         }
 
         override fun stop(player: ExoPlayer, reason: MediaItemTracker.StopReason, positionMs: Long) {
-
+            // Nothing
         }
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestSeekIncrement.kt
@@ -51,7 +51,6 @@ class TestSeekIncrement {
         Assert.assertEquals(seekForward, increment.forward)
     }
 
-
     companion object {
         private val NegativeIncrement = (-10).seconds
         private val PositiveIncrement = 5.seconds

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestTracksExtension.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestTracksExtension.kt
@@ -94,7 +94,7 @@ class TestTracksExtension {
         ):
             Format {
             return Format.Builder()
-                .setId("id:${label}")
+                .setId("id:$label")
                 .setLabel(label)
                 .setLanguage("fr")
                 .setSelectionFlags(selectionFlags)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestUnsupportedTracks.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestUnsupportedTracks.kt
@@ -108,7 +108,7 @@ class TestUnsupportedTracks {
 
         private fun createSampleFormat(label: String): Format {
             return Format.Builder()
-                .setId("id:${label}")
+                .setId("id:$label")
                 .setLabel(label)
                 .setContainerMimeType(MimeTypes.AUDIO_MP4)
                 .build()
@@ -120,5 +120,4 @@ class TestUnsupportedTracks {
             }
         }
     }
-
 }


### PR DESCRIPTION
# Pull request

## Description

Now Detekt will analyse every Kotlin file in the project, not only production code (in `src/main`).
I've fixed the few reported issues following this change.

## Changes made

- Self-explanatory

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.