### PR TITLE
Run GitHub Workflows on macOS 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,6 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
-          arch: x86_64
           script: >
             ./gradlew
             :pillarbox-analytics:connectedDebugAndroidTest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
   android-lint:
     name: Android Lint
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,7 +58,7 @@ jobs:
 
   detekt:
     name: Detekt
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +83,7 @@ jobs:
 
   dependency-analysis:
     name: Dependency Analysis
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -109,7 +109,7 @@ jobs:
 
   unit-test:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     permissions:
       pull-requests: write
     env:
@@ -148,7 +148,7 @@ jobs:
 
   android-tests:
     name: Android Tests
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -156,12 +156,6 @@ jobs:
       matrix:
         api-level: [ 26 ]
     steps:
-      - name: Enable KVM
-        # https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
       - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   check_date:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     name: Check latest commit
     outputs:
       should_run: ${{ steps.should_run.outputs.should_run }}
@@ -37,7 +37,7 @@ jobs:
   Build-nightly:
     needs: check_date
     if: ${{ needs.check_date.outputs.should_run != 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       DEMO_KEY_PASSWORD: ${{ secrets.DEMO_KEY_PASSWORD }}
       USERNAME: ${{ github.actor }}


### PR DESCRIPTION
# Pull request

## Description

Update the `build.yml` and `nightly.yml` GitHub Workflows to run on `macos-14` instead of `ubuntu-latest` to compare the performance.
A comparison of the various GitHub hosted runners is available [here](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories).

## Changes made

- Self-explanatory

> [!NOTE]
> In draft until we decide if it is interesting to merge or not.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.