### PR TITLE
428 add spherical surface support

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/NavigationRoutes.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/NavigationRoutes.kt
@@ -22,6 +22,7 @@ object NavigationRoutes {
     const val updatableSample = "updatable_sample"
     const val smoothSeeking = "smoothSeeking_sample"
     const val startAtGivenTime = "start_given_time_sample"
+    const val video360 = "video_360"
 
     const val homeLists = "home_lists"
     const val contentLists = "content_lists"

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
@@ -187,6 +187,8 @@ fun ShowcasesHome(navController: NavController) {
                 }
             )
 
+            Divider()
+
             DemoListItemView(
                 title = stringResource(R.string.video_360),
                 modifier = itemModifier,

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
@@ -186,6 +186,16 @@ fun ShowcasesHome(navController: NavController) {
                     )
                 }
             )
+
+            DemoListItemView(
+                title = stringResource(R.string.video_360),
+                modifier = itemModifier,
+                onClick = {
+                    navController.navigate(
+                        NavigationRoutes.video360
+                    )
+                }
+            )
         }
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesNavigation.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesNavigation.kt
@@ -15,6 +15,7 @@ import ch.srgssr.pillarbox.demo.ui.showcases.layouts.StoryLayoutShowcase
 import ch.srgssr.pillarbox.demo.ui.showcases.misc.MultiPlayerShowcase
 import ch.srgssr.pillarbox.demo.ui.showcases.misc.ResizablePlayerShowcase
 import ch.srgssr.pillarbox.demo.ui.showcases.misc.SmoothSeekingShowcase
+import ch.srgssr.pillarbox.demo.ui.showcases.misc.SphericalSurfaceShowcase
 import ch.srgssr.pillarbox.demo.ui.showcases.misc.StartAtGivenTimeShowcase
 import ch.srgssr.pillarbox.demo.ui.showcases.misc.TrackingToggleShowcase
 import ch.srgssr.pillarbox.demo.ui.showcases.misc.UpdatableMediaItemShowcase
@@ -52,6 +53,9 @@ fun NavGraphBuilder.showcasesNavGraph(navController: NavController) {
     }
     composable(NavigationRoutes.startAtGivenTime, DemoPageView("start at given time", Levels)) {
         StartAtGivenTimeShowcase()
+    }
+    composable(NavigationRoutes.video360, DemoPageView("Video 360°", Levels)) {
+        SphericalSurfaceShowcase()
     }
 }
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.ui.showcases.misc
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.LifecycleStartEffect
+import androidx.media3.common.Player
+import ch.srgssr.pillarbox.core.business.MediaItemUrn
+import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
+import ch.srgssr.pillarbox.ui.widget.player.SphericalSurface
+
+/**
+ * Showcase how to display a spherical surface to play 360° video.
+ *
+ */
+@Composable
+fun SphericalSurfaceShowcase() {
+    val context = LocalContext.current
+    val player = remember {
+        PlayerModule.provideDefaultPlayer(context = context).apply {
+            setMediaItem(MediaItemUrn("urn:rts:video:8414077"))
+            repeatMode = Player.REPEAT_MODE_ONE
+        }
+    }
+
+    LifecycleStartEffect(player) {
+        player.play()
+        onStopOrDispose {
+            player.pause()
+        }
+    }
+
+    DisposableEffect(player) {
+        player.prepare()
+        onDispose {
+            player.release()
+        }
+    }
+
+    SphericalSurface(player = player, modifier = Modifier.fillMaxSize())
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
@@ -18,7 +18,6 @@ import ch.srgssr.pillarbox.ui.widget.player.SphericalSurface
 
 /**
  * Showcase how to display a spherical surface to play 360° video.
- *
  */
 @Composable
 fun SphericalSurfaceShowcase() {

--- a/pillarbox-demo/src/main/res/values/strings.xml
+++ b/pillarbox-demo/src/main/res/values/strings.xml
@@ -27,4 +27,5 @@
     <string name="smooth_seeking_example">Smooth seeking</string>
     <string name="navigate_up">Navigate up</string>
     <string name="start_given_time_example">Start at given time (10min)</string>
+    <string name="video_360">360°</string>
 </resources>

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/SphericalSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/SphericalSurface.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.ui.widget.player
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
+import ch.srgssr.pillarbox.ui.extension.playerErrorAsState
+
+/**
+ * Render [player] content on a [SphericalGLSurfaceView]
+ *
+ * @param player The player to render.
+ * @param modifier The modifier to be applied to the layout.
+ */
+@Composable
+fun SphericalSurface(player: Player, modifier: Modifier = Modifier) {
+    val playerError by player.playerErrorAsState()
+    if (playerError != null) {
+        return
+    }
+    AndroidView(
+        modifier = modifier,
+        factory = { context ->
+            SphericalGLSurfaceView(context)
+        }, update = { view ->
+            player.setVideoSurfaceView(view)
+            view.onResume()
+        }, onRelease = { view ->
+            player.setVideoSurfaceView(null)
+            view.onPause()
+        }, onReset = {
+            // onRested is called before update when composable is reuse with different context.
+            player.setVideoSurface(null)
+        }
+    )
+}

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/SphericalSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/SphericalSurface.kt
@@ -13,7 +13,7 @@ import androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
 import ch.srgssr.pillarbox.ui.extension.playerErrorAsState
 
 /**
- * Render [player] content on a [SphericalGLSurfaceView]
+ * Render the [player] content on a [SphericalGLSurfaceView].
  *
  * @param player The player to render.
  * @param modifier The modifier to be applied to the layout.
@@ -35,7 +35,7 @@ fun SphericalSurface(player: Player, modifier: Modifier = Modifier) {
             player.setVideoSurfaceView(null)
             view.onPause()
         }, onReset = {
-            // onRested is called before update when composable is reuse with different context.
+            // onReset is called before `update`, when the composable is reused with a different context.
             player.setVideoSurface(null)
         }
     )


### PR DESCRIPTION
## Description

The goal of the PR is to showcase how to play a 360° video.

## Changes made

- Add Composable wrapper `SphericalSurface` for `SphericalGLSurfaceView`.
- Add related showcase.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
