### PR TITLE
Fix broken image URL in TV demo

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
@@ -48,7 +48,7 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                     title = "Switzerland says sorry! The fondue invasion",
                     uri = "https://swi-vod.akamaized.net/videoJson/47603186/master.m3u8",
                     description = "VOD - HLS",
-                    imageUrl = "https://www.swissinfo.ch/srgscalableimage/47603560/16x9"
+                    imageUrl = "https://cdn.prod.swi-services.ch/video-delivery/images/14e4562f-725d-4e41-a200-7fcaa77df2fe/5rwf1Bq_m3GC5secOZcIcgbbrbZPf4nI/16x9"
                 ),
                 DemoItem(
                     title = "Des violents orages ont touché Ajaccio, chef-lieu de la Corse, jeudi",


### PR DESCRIPTION
# Pull request

## Description

One of the image URL was broken in the TV demo app. This PR updates the URL to use the correct one.
Fix coming from https://github.com/SRGSSR/pillarbox-apple/pull/771 by @waliid 

## Changes made

- Self-explanatory

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.