### PR TITLE
Fix `PlayerTimeSlider` not being draggable

### DIFF
--- a/pillarbox-analytics/build.gradle.kts
+++ b/pillarbox-analytics/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
@@ -56,6 +58,10 @@ android {
             isIncludeAndroidResources = true
         }
     }
+}
+
+tasks.withType<Test>().configureEach {
+    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {

--- a/pillarbox-core-business/build.gradle.kts
+++ b/pillarbox-core-business/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
@@ -51,6 +53,10 @@ android {
             isIncludeAndroidResources = true
         }
     }
+}
+
+tasks.withType<Test>().configureEach {
+    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
@@ -63,6 +65,10 @@ android {
             isIncludeAndroidResources = true
         }
     }
+}
+
+tasks.withType<Test>().configureEach {
+    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
@@ -566,15 +566,18 @@ class MediaItemTrackerTest {
             )
             prepare()
             play()
+            seekTo(FakeMediaItemSource.NEAR_END_POSITION_MS)
         }
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
         TestPlayerRunHelper.runUntilTimelineChanged(player)
 
+        fakeClock.advanceTime(FakeMediaItemSource.NEAR_END_POSITION_MS)
+
         verifyOrder {
-            fakeMediaItemTracker.start(any(), FakeMediaItemTracker.Data(firstMediaId))
-            fakeMediaItemTracker.stop(any(), MediaItemTracker.StopReason.EoF, any())
-            fakeMediaItemTracker.start(any(), FakeMediaItemTracker.Data(secondMediaId))
+            fakeMediaItemTracker.start(player, FakeMediaItemTracker.Data(firstMediaId))
+            fakeMediaItemTracker.stop(player, MediaItemTracker.StopReason.EoF, any())
+            fakeMediaItemTracker.start(player, FakeMediaItemTracker.Data(secondMediaId))
         }
         confirmVerified(fakeMediaItemTracker)
     }

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
@@ -48,6 +50,10 @@ android {
             withJavadocJar()
         }
     }
+}
+
+tasks.withType<Test>().configureEach {
+    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ProgressTrackerState.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/ProgressTrackerState.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.ui
 
+import androidx.compose.runtime.Stable
 import androidx.media3.common.Player
 import kotlinx.coroutines.flow.StateFlow
 import kotlin.time.Duration
@@ -11,6 +12,7 @@ import kotlin.time.Duration
 /**
  * Interface used to subscribe to and update the [Player] progression.
  */
+@Stable
 interface ProgressTrackerState {
     /**
      * Emits the current progress, which can be either the value being manually set, or the actual [Player] progress.


### PR DESCRIPTION
# Pull request

## Description

Since Compose Material3 1.2.0 (introduced in https://github.com/SRGSSR/pillarbox-android/pull/421), the `onValueChangeFinished` callback is remembered in the `SliderState`. This prevents the `Slider` thumb from being dragged. By making the `ProgressTrackerState` stable, we can work around that, and having the `Slider` behave as we expect it to.

## Changes made

- Fix the `Slider` as explained above
- Fix flaky test in `MediaItemTrackerTest` and enable full test stacktrace in every module

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.