### PR TITLE
Ignore unknown video size

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -298,6 +298,7 @@ fun Player.getAspectRatioAsFlow(defaultAspectRatio: Float): Flow<Float> =
         .map {
             it.computeAspectRatio(defaultAspectRatio)
         }
+        .onEmpty { emit(defaultAspectRatio) }
 
 /**
  * Get track selection parameters as flow [Player.getTrackSelectionParameters]

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEmpty
 import kotlinx.coroutines.flow.transformLatest
 import kotlinx.coroutines.isActive
 import kotlin.time.Duration

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNot
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.merge
@@ -291,9 +292,12 @@ fun Player.videoSizeAsFlow(): Flow<VideoSize> = callbackFlow {
  *
  * @param defaultAspectRatio Aspect ratio when [Player.getVideoSize] is unknown or audio.
  */
-fun Player.getAspectRatioAsFlow(defaultAspectRatio: Float): Flow<Float> = videoSizeAsFlow().map {
-    it.computeAspectRatio(defaultAspectRatio)
-}
+fun Player.getAspectRatioAsFlow(defaultAspectRatio: Float): Flow<Float> =
+    videoSizeAsFlow()
+        .filterNot { it == VideoSize.UNKNOWN }
+        .map {
+            it.computeAspectRatio(defaultAspectRatio)
+        }
 
 /**
  * Get track selection parameters as flow [Player.getTrackSelectionParameters]


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to not reset the video aspect ratio when media transition to another. When loading video size is briefly set to unknown.

## Changes made

- `Player.getAspectRatioAsFlow` ignore unknown video size.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
