### PR TITLE
Introduce a `build` step to the `build` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,32 @@ on:
     types: [ synchronize, opened, reopened, ready_for_review ]
 
 concurrency:
-  group: build-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v3
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle; cp .github/gradle-ci.properties ~/.gradle/gradle.properties
+      - name: Build modules
+        run: ./gradlew :pillarbox-demo:assembleProdDebug :pillarbox-demo-tv:assembleDebug :pillarbox-player-testutils:assembleDebug
+
   android-lint:
     name: Android Lint
     runs-on: ubuntu-latest
+    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -42,6 +61,7 @@ jobs:
   detekt:
     name: Detekt
     runs-on: ubuntu-latest
+    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,6 +88,7 @@ jobs:
   dependency-analysis:
     name: Dependency Analysis
     runs-on: ubuntu-latest
+    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -96,6 +117,7 @@ jobs:
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       pull-requests: write
     env:
@@ -136,6 +158,7 @@ jobs:
   android-tests:
     name: Android Tests
     runs-on: ubuntu-latest
+    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 concurrency:
-  group: build-on-windows-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/dependency_graph.yml
+++ b/.github/workflows/dependency_graph.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   submit-dependency-graph:
     name: Submit dependency graph

--- a/.github/workflows/gradle_wrapper_validation.yml
+++ b/.github/workflows/gradle_wrapper_validation.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
 
 concurrency:
-  group: gradle-wrapper-validation-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Pull request

## Description
This PR introduces a `build` step in the `build` workflow. All the existing tasks are now waiting for the `build` step to complete, before starting.
This may improve the time needed for the CI checks to complete, as the build is now only done once, and then shared amongst all the steps.

> [!NOTE]
> As caches are only written when running on `main`, the impact of the PR won't be visible until it has been merged.

## Changes made

- Self-explanatory

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.