### PR TITLE
464 fix analytics event skip next or previous media item

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -168,7 +168,7 @@ class CommandersActTrackerIntegrationTest {
     }
 
     @Test
-    fun `audio URN don't send any analytics`() {
+    fun `audio URN send any analytics`() {
         val tcMediaEventSlot = slot<TCMediaEvent>()
 
         player.setMediaItem(MediaItemUrn(URN_AUDIO))


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to fix an issue with `CurrentItemTracker` that doesn't stop trackers when it receive a position discontinuity changed with different media item index.

## Changes made

- Self explanatory

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
