### PR TITLE
Fix initial aspect ratio

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -292,16 +292,11 @@ fun Player.videoSizeAsFlow(): Flow<VideoSize> = callbackFlow {
  *
  * @param defaultAspectRatio The aspect ratio when the video size is unknown, or for audio content.
  */
-fun Player.getAspectRatioAsFlow(defaultAspectRatio: Float) = callbackFlow {
-    val listener = object : Listener {
-        override fun onTracksChanged(tracks: Tracks) {
-            trySend(tracks.getVideoAspectRatioOrElse(defaultAspectRatio))
-        }
-    }
-
-    trySend(currentTracks.getVideoAspectRatioOrElse(defaultAspectRatio))
-    addPlayerListener(player = this@getAspectRatioAsFlow, listener)
-}.distinctUntilChanged()
+fun Player.getAspectRatioAsFlow(defaultAspectRatio: Float): Flow<Float> {
+    return getCurrentTracksAsFlow()
+        .map { it.getVideoAspectRatioOrElse(defaultAspectRatio) }
+        .distinctUntilChanged()
+}
 
 /**
  * Get track selection parameters as flow [Player.getTrackSelectionParameters]

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -293,16 +293,6 @@ fun Player.videoSizeAsFlow(): Flow<VideoSize> = callbackFlow {
  * @param defaultAspectRatio The aspect ratio when the video size is unknown, or for audio content.
  */
 fun Player.getAspectRatioAsFlow(defaultAspectRatio: Float) = callbackFlow {
-    fun Tracks.getVideoAspectRatioOrElse(defaultAspectRatio: Float): Float {
-        val format = video.find { it.isSelected }?.getTrackFormat(0)
-
-        return if (format == null || format.height <= 0 || format.width == Format.NO_VALUE) {
-            defaultAspectRatio
-        } else {
-            format.width * format.pixelWidthHeightRatio / format.height.toFloat()
-        }
-    }
-
     val listener = object : Listener {
         override fun onTracksChanged(tracks: Tracks) {
             trySend(tracks.getVideoAspectRatioOrElse(defaultAspectRatio))
@@ -357,6 +347,16 @@ private suspend fun <T> ProducerScope<T>.addPlayerListener(player: Player, liste
     player.addListener(listener)
     awaitClose {
         player.removeListener(listener)
+    }
+}
+
+private fun Tracks.getVideoAspectRatioOrElse(defaultAspectRatio: Float): Float {
+    val format = video.find { it.isSelected }?.getTrackFormat(0)
+
+    return if (format == null || format.height <= 0 || format.width == Format.NO_VALUE) {
+        defaultAspectRatio
+    } else {
+        format.width * format.pixelWidthHeightRatio / format.height.toFloat()
     }
 }
 

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
@@ -213,9 +213,9 @@ fun Player.videoSizeAsState(): State<VideoSize> {
 }
 
 /**
- * Get aspect ratio as state computed from [Player.getVideoSize]
+ * Get aspect ratio of the current video as [State].
  *
- * @param defaultAspectRatio The aspect ratio when video size is unknown or for audio content.
+ * @param defaultAspectRatio The aspect ratio when the video size is unknown, or for audio content.
  */
 @Composable
 fun Player.getAspectRatioAsState(defaultAspectRatio: Float): FloatState {

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
@@ -52,6 +52,7 @@ fun PlayerSurface(
 ) {
     val videoAspectRatio by player.getAspectRatioAsState(defaultAspectRatio = defaultAspectRatio ?: 0f)
     if (videoAspectRatio <= 0f) {
+        Box(modifier)
         return
     }
 


### PR DESCRIPTION
# Pull request

## Description

This PR fixes various issues related to video size, aspect ratio and media transition:
- The default aspect ratio for video is no longer 1:1, preventing the jump to the actual ratio once the video has started to load
- When transitioning from a video to an audio, the last frame of the video doesn't remain on the screen while the audio is playing
- The surface used to play the media is not created for audio content

## Changes made

- Use the current tracks to get the media aspect ratio, instead of the video size
- Set the default aspect ratio in `PlayerSurface` to 0, meaning that we don't display any surface
  - The integrator can still pass a default aspect ratio to override this
- The surface used to play media is no longer created for audio content

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.