### PR TITLE
Improve publishing configuration 

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -7,5 +7,10 @@ plugins {
 }
 
 repositories {
+    google()
     mavenCentral()
+}
+
+dependencies {
+    api("com.android.tools.build:gradle-api:8.3.0")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,11 +6,6 @@ plugins {
     `kotlin-dsl`
 }
 
-repositories {
-    google()
-    mavenCentral()
-}
-
 dependencies {
-    api("com.android.tools.build:gradle-api:8.3.0")
+    api(libs.android.gradle.api)
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+
+dependencyResolutionManagement {
+    repositoriesMode = RepositoriesMode.FAIL_ON_PROJECT_REPOS
+
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/java/VersionConfig.kt
+++ b/buildSrc/src/main/java/VersionConfig.kt
@@ -22,11 +22,6 @@ object VersionConfig {
     private val versionOnlyRegex = "[0-9]+.[0-9].[0-9]".toRegex()
 
     /**
-     * Maven artifact group
-     */
-    const val GROUP = "ch.srgssr.pillarbox"
-
-    /**
      * Version name
      *
      * @return "Local" if [ENV_VERSION_NAME] no set.

--- a/buildSrc/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxPublishingPlugin.kt
+++ b/buildSrc/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxPublishingPlugin.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.gradle
+
+import com.android.build.api.dsl.LibraryExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Custom Gradle plugin to manage publication of a Pillarbox's library modules.
+ */
+class PillarboxPublishingPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("com.android.library")
+        pluginManager.apply("org.gradle.maven-publish")
+
+        extensions.configure<LibraryExtension> {
+            publishing {
+                singleVariant("release") {
+                    withSourcesJar()
+                    withJavadocJar()
+                }
+            }
+        }
+
+        extensions.configure<PublishingExtension> {
+            publications {
+                register<MavenPublication>("gpr") {
+                    afterEvaluate {
+                        from(components["release"])
+                    }
+                }
+            }
+
+            repositories {
+                maven {
+                    name = "GitHubPackages"
+                    url = uri("https://maven.pkg.github.com/SRGSSR/pillarbox-android")
+                    credentials {
+                        username = findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
+                        password = findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxPublishingPlugin.kt
+++ b/buildSrc/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxPublishingPlugin.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.gradle
 
+import VersionConfig
 import com.android.build.api.dsl.LibraryExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -22,6 +23,11 @@ class PillarboxPublishingPlugin : Plugin<Project> {
         pluginManager.apply("org.gradle.maven-publish")
 
         extensions.configure<LibraryExtension> {
+            defaultConfig {
+                group = "ch.srgssr.pillarbox"
+                version = VersionConfig.versionName()
+            }
+
             publishing {
                 singleVariant("release") {
                     withSourcesJar()

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/ch.srgssr.pillarbox.gradle.publishing.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/ch.srgssr.pillarbox.gradle.publishing.properties
@@ -1,0 +1,1 @@
+implementation-class=ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ turbine = "1.0.0"
 
 [libraries]
 accompanist-navigation-material = { module = "com.google.accompanist:accompanist-navigation-material", version.ref = "accompanist" }
+android-gradle-api = { module = "com.android.tools.build:gradle-api", version.ref = "android-gradle-plugin" }
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidx-activity" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidx-activity" }

--- a/pillarbox-analytics/build.gradle.kts
+++ b/pillarbox-analytics/build.gradle.kts
@@ -20,8 +20,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        version = VersionConfig.versionName()
-        group = VersionConfig.GROUP
 
         buildConfigField("String", "BUILD_DATE", "\"${AppConfig.getBuildDate()}\"")
         buildConfigField("String", "VERSION_NAME", "\"${version}\"")

--- a/pillarbox-analytics/build.gradle.kts
+++ b/pillarbox-analytics/build.gradle.kts
@@ -1,15 +1,18 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
+
+import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlinx.kover)
-    `maven-publish`
 }
+
+apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.analytics"
@@ -47,12 +50,6 @@ android {
         buildConfig = true
         resValues = false
     }
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
@@ -87,28 +84,6 @@ koverReport {
     androidReports("debug") {
         xml {
             title.set(project.path)
-        }
-    }
-}
-
-publishing {
-
-    publications {
-        register<MavenPublication>("gpr") {
-            afterEvaluate {
-                from(components["release"])
-            }
-        }
-    }
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/SRGSSR/pillarbox-android")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                password =
-                    project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
         }
     }
 }

--- a/pillarbox-core-business/build.gradle.kts
+++ b/pillarbox-core-business/build.gradle.kts
@@ -21,8 +21,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        version = VersionConfig.versionName()
-        group = VersionConfig.GROUP
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/pillarbox-core-business/build.gradle.kts
+++ b/pillarbox-core-business/build.gradle.kts
@@ -1,16 +1,19 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
+
+import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlinx.kover)
-    `maven-publish`
 }
+
+apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.core.business"
@@ -41,12 +44,6 @@ android {
     buildFeatures {
         buildConfig = true
         resValues = false
-    }
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
     }
     testOptions {
         unitTests {
@@ -105,27 +102,6 @@ koverReport {
     androidReports("debug") {
         xml {
             title.set(project.path)
-        }
-    }
-}
-
-publishing {
-    publications {
-        register<MavenPublication>("gpr") {
-            afterEvaluate {
-                from(components["release"])
-            }
-        }
-    }
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/SRGSSR/pillarbox-android")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                password =
-                    project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
         }
     }
 }

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -1,15 +1,18 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
+
+import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlinx.kover)
-    `maven-publish`
 }
+
+apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.player"
@@ -43,12 +46,6 @@ android {
     buildFeatures {
         buildConfig = true
         resValues = false
-    }
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
     }
 
     // Mockk includes some licenses information, which may conflict with other license files. This block merges all licenses together.
@@ -115,27 +112,6 @@ koverReport {
     androidReports("debug") {
         xml {
             title.set(project.path)
-        }
-    }
-}
-
-publishing {
-    publications {
-        register<MavenPublication>("gpr") {
-            afterEvaluate {
-                from(components["release"])
-            }
-        }
-    }
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/SRGSSR/pillarbox-android")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                password =
-                    project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
         }
     }
 }

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -20,8 +20,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        version = VersionConfig.versionName()
-        group = VersionConfig.GROUP
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFile("consumer-rules.pro")

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -1,15 +1,18 @@
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 /*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
+
+import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlinx.kover)
-    `maven-publish`
 }
+
+apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.ui"
@@ -43,12 +46,6 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.androidx.compose.compiler.get()
-    }
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
     }
 }
 
@@ -87,27 +84,6 @@ koverReport {
     androidReports("debug") {
         xml {
             title.set(project.path)
-        }
-    }
-}
-
-publishing {
-    publications {
-        register<MavenPublication>("gpr") {
-            afterEvaluate {
-                from(components["release"])
-            }
-        }
-    }
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/SRGSSR/pillarbox-android")
-            credentials {
-                username = project.findProperty("gpr.user") as String? ?: System.getenv("USERNAME")
-                password =
-                    project.findProperty("gpr.key") as String? ?: System.getenv("GITHUB_TOKEN")
-            }
         }
     }
 }

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -20,8 +20,6 @@ android {
 
     defaultConfig {
         minSdk = AppConfig.minSdk
-        version = VersionConfig.versionName()
-        group = VersionConfig.GROUP
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFile("consumer-rules.pro")


### PR DESCRIPTION
# Pull request

## Description

This PR creates a custom Gradle plugin to handle the publishing logic of our library modules: `pillarbox-analytics`, `pillarbox-core-business`, `pillarbox-player`, and `pillarbox-ui`.
By doing this, we can have the publishing logic in one place, so it is easier to maintain in the future, if the Gradle API changes, the Maven URL changes, ...

> [!NOTE]
> To test this, I've published each module to Maven local, by running `./gradlew :<module>:publishToMavenLocal`, but I didn't try an actual publication. Since we're doing a new release soon, it will be a good opportunity to test this.

## Changes made

- Self-explanatory

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.