### PR TITLE
Create a custom Gradle plugin to configure testing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,6 @@ plugins {
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.detekt)
     alias(libs.plugins.dependency.analysis.gradle.plugin)
-    alias(libs.plugins.kotlinx.kover)
 }
 
 apply(plugin = "android-reporting")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,4 +8,5 @@ plugins {
 
 dependencies {
     api(libs.android.gradle.api)
+    api(libs.kotlinx.kover.gradle)
 }

--- a/buildSrc/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxTestedModulePlugin.kt
+++ b/buildSrc/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxTestedModulePlugin.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.gradle
+
+import com.android.build.api.dsl.LibraryExtension
+import kotlinx.kover.gradle.plugin.dsl.KoverReportExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.withType
+
+/**
+ * Custom Gradle plugin to configure a Pillarbox module for testing.
+ */
+class PillarboxTestedModulePlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        pluginManager.apply("com.android.library")
+        pluginManager.apply("org.jetbrains.kotlinx.kover")
+
+        extensions.configure<LibraryExtension> {
+            defaultConfig {
+                testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+            }
+
+            @Suppress("UnstableApiUsage")
+            testOptions {
+                unitTests {
+                    isIncludeAndroidResources = true
+                }
+            }
+        }
+
+        extensions.configure<KoverReportExtension> {
+            androidReports("debug") {
+                xml {
+                    title.set(project.path)
+                }
+            }
+        }
+
+        tasks.withType<Test>().configureEach {
+            testLogging.exceptionFormat = TestExceptionFormat.FULL
+        }
+    }
+}

--- a/buildSrc/src/main/resources/META-INF/gradle-plugins/ch.srgssr.pillarbox.gradle.tested_module.properties
+++ b/buildSrc/src/main/resources/META-INF/gradle-plugins/ch.srgssr.pillarbox.gradle.tested_module.properties
@@ -1,0 +1,1 @@
+implementation-class=ch.srgssr.pillarbox.gradle.PillarboxTestedModulePlugin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,7 @@ coil-base = { module = "io.coil-kt:coil-compose-base", version.ref = "coil" }
 json = { module = "org.json:json", version.ref = "json" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlinx-kover-gradle = { module = "org.jetbrains.kotlinx:kover-gradle-plugin", version.ref = "kotlinx-kover" }
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
@@ -142,4 +143,3 @@ dependency-analysis-gradle-plugin = { id = "com.autonomousapps.dependency-analys
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kotlinx-kover" }

--- a/pillarbox-analytics/build.gradle.kts
+++ b/pillarbox-analytics/build.gradle.kts
@@ -3,16 +3,11 @@
  * License information is available from the LICENSE file.
  */
 
-import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 plugins {
-    alias(libs.plugins.android.library)
+    id("ch.srgssr.pillarbox.gradle.publishing")
+    id("ch.srgssr.pillarbox.gradle.tested_module")
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlinx.kover)
 }
-
-apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.analytics"
@@ -24,7 +19,6 @@ android {
         buildConfigField("String", "BUILD_DATE", "\"${AppConfig.getBuildDate()}\"")
         buildConfigField("String", "VERSION_NAME", "\"${version}\"")
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
 
@@ -48,15 +42,6 @@ android {
         buildConfig = true
         resValues = false
     }
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {
@@ -76,12 +61,4 @@ dependencies {
     testRuntimeOnly(libs.robolectric)
     testImplementation(libs.robolectric.annotations)
     testImplementation(libs.robolectric.shadows.framework)
-}
-
-koverReport {
-    androidReports("debug") {
-        xml {
-            title.set(project.path)
-        }
-    }
 }

--- a/pillarbox-core-business/build.gradle.kts
+++ b/pillarbox-core-business/build.gradle.kts
@@ -3,17 +3,12 @@
  * License information is available from the LICENSE file.
  */
 
-import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 plugins {
-    alias(libs.plugins.android.library)
+    id("ch.srgssr.pillarbox.gradle.publishing")
+    id("ch.srgssr.pillarbox.gradle.tested_module")
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
-    alias(libs.plugins.kotlinx.kover)
 }
-
-apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.core.business"
@@ -22,7 +17,6 @@ android {
     defaultConfig {
         minSdk = AppConfig.minSdk
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
     }
 
@@ -43,15 +37,6 @@ android {
         buildConfig = true
         resValues = false
     }
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {
@@ -94,12 +79,4 @@ dependencies {
     testRuntimeOnly(libs.robolectric)
     testImplementation(libs.robolectric.annotations)
     testImplementation(libs.robolectric.shadows.framework)
-}
-
-koverReport {
-    androidReports("debug") {
-        xml {
-            title.set(project.path)
-        }
-    }
 }

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -3,16 +3,11 @@
  * License information is available from the LICENSE file.
  */
 
-import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 plugins {
-    alias(libs.plugins.android.library)
+    id("ch.srgssr.pillarbox.gradle.publishing")
+    id("ch.srgssr.pillarbox.gradle.tested_module")
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlinx.kover)
 }
-
-apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.player"
@@ -21,7 +16,6 @@ android {
     defaultConfig {
         minSdk = AppConfig.minSdk
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFile("consumer-rules.pro")
     }
 
@@ -55,15 +49,6 @@ android {
             merges += "META-INF/LICENSE-notice.md"
         }
     }
-    testOptions {
-        unitTests {
-            isIncludeAndroidResources = true
-        }
-    }
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {
@@ -104,12 +89,4 @@ dependencies {
     androidTestRuntimeOnly(libs.kotlinx.coroutines.android)
     androidTestImplementation(libs.mockk)
     androidTestImplementation(libs.mockk.android)
-}
-
-koverReport {
-    androidReports("debug") {
-        xml {
-            title.set(project.path)
-        }
-    }
 }

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -3,16 +3,11 @@
  * License information is available from the LICENSE file.
  */
 
-import ch.srgssr.pillarbox.gradle.PillarboxPublishingPlugin
-import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-
 plugins {
-    alias(libs.plugins.android.library)
+    id("ch.srgssr.pillarbox.gradle.publishing")
+    id("ch.srgssr.pillarbox.gradle.tested_module")
     alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlinx.kover)
 }
-
-apply<PillarboxPublishingPlugin>()
 
 android {
     namespace = "ch.srgssr.pillarbox.ui"
@@ -21,7 +16,6 @@ android {
     defaultConfig {
         minSdk = AppConfig.minSdk
 
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFile("consumer-rules.pro")
     }
 
@@ -45,10 +39,6 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.androidx.compose.compiler.get()
     }
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging.exceptionFormat = TestExceptionFormat.FULL
 }
 
 dependencies {
@@ -76,12 +66,4 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
 
     debugImplementation(libs.androidx.compose.ui.tooling)
-}
-
-koverReport {
-    androidReports("debug") {
-        xml {
-            title.set(project.path)
-        }
-    }
 }


### PR DESCRIPTION
# Pull request

## Description

Following the same pattern introduced in #468, this PR creates a new Gradle plugin to configure testing in Android library modules. Specifically, it:
- sets the default test runner
- include Android resources in tests
- configure Kover
- enable stacktrace on failing tests

## Changes made

- Self-explanatory

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.