### PR TITLE
Improve the multi player showcase

### DIFF
--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -75,6 +75,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
+    implementation(libs.androidx.media)
     implementation(libs.androidx.media3.common)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -2,8 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
+
     <application
         android:name=".DemoApplication"
         android:allowBackup="true"
@@ -26,8 +28,8 @@
 
         <activity
             android:name=".MainActivity"
-            android:theme="@style/Theme.PillarboxDemo"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/Theme.PillarboxDemo">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
@@ -20,13 +20,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.ui.extension.currentMediaMetadataAsState
 
-private val controlsBackgroundColor = Color.Black.copy(0.5f)
-
 /**
  * Player controls
  *
  * @param player The [Player] to interact with.
  * @param modifier The modifier to be applied to the layout.
+ * @param backgroundColor The background color to apply behind the controls.
  * @param interactionSource The interaction source of the slider.
  * @param content The content to display under the slider.
  * @receiver
@@ -35,14 +34,13 @@ private val controlsBackgroundColor = Color.Black.copy(0.5f)
 fun PlayerControls(
     player: Player,
     modifier: Modifier = Modifier,
+    backgroundColor: Color = Color.Black.copy(0.5f),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: @Composable ColumnScope.() -> Unit,
 ) {
     val mediaMetadata by player.currentMediaMetadataAsState()
     Box(
-        modifier = modifier.then(
-            Modifier.background(color = controlsBackgroundColor)
-        ),
+        modifier = modifier.background(color = backgroundColor),
         contentAlignment = Alignment.Center
     ) {
         Text(

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerShowcase.kt
@@ -5,88 +5,65 @@
 package ch.srgssr.pillarbox.demo.ui.showcases.misc
 
 import android.content.res.Configuration
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.movableContentOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.LifecycleResumeEffect
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.media3.common.Player
-import ch.srgssr.pillarbox.demo.shared.data.DemoItem
-import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
-import ch.srgssr.pillarbox.demo.ui.player.PlayerView
+import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerControls
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
+import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 
 /**
  * Demo of 2 player swapping view
  */
 @Composable
 fun MultiPlayerShowcase() {
-    var swapLeftRight by remember {
-        mutableStateOf(false)
-    }
-    val context = LocalContext.current
-    val playerOne = remember {
-        PlayerModule.provideDefaultPlayer(context).apply {
-            repeatMode = Player.REPEAT_MODE_ONE
-            setMediaItem(DemoItem.LiveVideo.toMediaItem())
-            prepare()
-        }
-    }
-    val playerTwo = remember {
-        PlayerModule.provideDefaultPlayer(context).apply {
-            repeatMode = Player.REPEAT_MODE_ONE
-            setMediaItem(DemoItem.DvrVideo.toMediaItem())
-            prepare()
-        }
-    }
-    DisposableEffect(Unit) {
-        onDispose {
-            playerOne.release()
-            playerTwo.release()
-        }
-    }
-    LifecycleResumeEffect(Unit) {
-        playerOne.play()
-        playerTwo.play()
-        onPauseOrDispose {
-            playerOne.pause()
-            playerTwo.pause()
-        }
-    }
+    val multiPlayerViewModel = viewModel<MultiPlayerViewModel>()
+    val activePlayer by multiPlayerViewModel.activePlayer.collectAsState()
+    val playerOne by multiPlayerViewModel.playerOne.collectAsState()
+    val playerTwo by multiPlayerViewModel.playerTwo.collectAsState()
+
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
-        Button(onClick = { swapLeftRight = !swapLeftRight }) {
+        Button(onClick = multiPlayerViewModel::swapPlayers) {
             Text(text = "Swap players")
         }
+
         val players = remember {
             movableContentOf {
-                PlayerView(
-                    modifier = Modifier
-                        .weight(1.0f)
-                        .padding(MaterialTheme.paddings.mini),
-                    player = if (swapLeftRight) playerTwo else playerOne,
+                ActivablePlayer(
+                    player = playerOne,
+                    isActive = activePlayer == playerOne,
+                    modifier = Modifier.weight(1f),
+                    onClick = multiPlayerViewModel::activateOtherPlayer,
                 )
-                PlayerView(
-                    modifier = Modifier
-                        .weight(1.0f)
-                        .padding(MaterialTheme.paddings.mini),
-                    player = if (swapLeftRight) playerOne else playerTwo,
+
+                ActivablePlayer(
+                    player = playerTwo,
+                    isActive = activePlayer == playerTwo,
+                    modifier = Modifier.weight(1f),
+                    onClick = multiPlayerViewModel::activateOtherPlayer,
                 )
             }
         }
+
         if (LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE) {
             Row(modifier = Modifier.fillMaxWidth()) {
                 players()
@@ -96,5 +73,39 @@ fun MultiPlayerShowcase() {
                 players()
             }
         }
+    }
+}
+
+@Composable
+private fun ActivablePlayer(
+    player: Player,
+    isActive: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    PlayerSurface(
+        modifier = modifier
+            .padding(MaterialTheme.paddings.mini)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                enabled = !isActive,
+                onClick = onClick,
+            ),
+        player = player,
+    ) {
+        val inactivePlayerOverlay = Modifier.drawWithContent {
+            drawContent()
+            drawRect(Color.LightGray.copy(alpha = 0.7f))
+        }
+
+        PlayerControls(
+            player = player,
+            modifier = Modifier
+                .fillMaxSize()
+                .then(if (isActive) Modifier else inactivePlayerOverlay),
+            backgroundColor = Color.Unspecified,
+            content = {},
+        )
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerShowcase.kt
@@ -32,7 +32,8 @@ import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 
 /**
- * Demo of 2 player swapping view
+ * Demo displaying two players, that can be swapped.
+ * At any given moment, there's always only one player with sound active.
  */
 @Composable
 fun MultiPlayerShowcase() {
@@ -52,14 +53,14 @@ fun MultiPlayerShowcase() {
                     player = playerOne,
                     isActive = activePlayer == playerOne,
                     modifier = Modifier.weight(1f),
-                    onClick = multiPlayerViewModel::activateOtherPlayer,
+                    onClick = { multiPlayerViewModel.setActivePlayer(playerOne) },
                 )
 
                 ActivablePlayer(
                     player = playerTwo,
                     isActive = activePlayer == playerTwo,
                     modifier = Modifier.weight(1f),
-                    onClick = multiPlayerViewModel::activateOtherPlayer,
+                    onClick = { multiPlayerViewModel.setActivePlayer(playerTwo) },
                 )
             }
         }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.ui.showcases.misc
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.media3.common.Player
+import ch.srgssr.pillarbox.demo.shared.data.DemoItem
+import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
+import ch.srgssr.pillarbox.player.PillarboxPlayer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+
+/**
+ * The [ViewModel][androidx.lifecycle.ViewModel] for the [MultiPlayerShowcase].
+ *
+ * @param application The running [Application].
+ */
+class MultiPlayerViewModel(application: Application) : AndroidViewModel(application) {
+    private val _playerOne = PlayerModule.provideDefaultPlayer(application).apply {
+        repeatMode = Player.REPEAT_MODE_ONE
+        setMediaItem(DemoItem.LiveVideo.toMediaItem())
+        prepare()
+        play()
+    }
+    private val _playerTwo = PlayerModule.provideDefaultPlayer(application).apply {
+        repeatMode = Player.REPEAT_MODE_ONE
+        setMediaItem(DemoItem.DvrVideo.toMediaItem())
+        prepare()
+        play()
+    }
+
+    private val _activePlayer = MutableStateFlow(_playerOne)
+    private val swapPlayers = MutableStateFlow(false)
+
+    /**
+     * The currently active player.
+     */
+    val activePlayer: StateFlow<PillarboxPlayer> = _activePlayer
+
+    /**
+     * The first player to display.
+     */
+    val playerOne = swapPlayers.map { swapPlayers ->
+        if (swapPlayers) _playerTwo else _playerOne
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), _playerOne)
+
+    /**
+     * The second play to display.
+     */
+    val playerTwo = swapPlayers.map { swapPlayers ->
+        if (swapPlayers) _playerOne else _playerTwo
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), _playerTwo)
+
+    init {
+        setActivePlayer(_playerOne)
+    }
+
+    /**
+     * Activate the other player.
+     */
+    fun activateOtherPlayer() {
+        setActivePlayer(getOtherPlayer(_activePlayer.value))
+    }
+
+    /**
+     * Swap the two players.
+     */
+    fun swapPlayers() {
+        swapPlayers.update { !it }
+    }
+
+    override fun onCleared() {
+        _playerOne.release()
+        _playerTwo.release()
+    }
+
+    private fun setActivePlayer(activePlayer: PillarboxPlayer) {
+        _activePlayer.update { activePlayer }
+
+        activePlayer.volume = 1f
+        getOtherPlayer(activePlayer).volume = 0f
+    }
+
+    private fun getOtherPlayer(activePlayer: PillarboxPlayer): PillarboxPlayer {
+        return when (activePlayer) {
+            _playerOne -> _playerTwo
+            _playerTwo -> _playerOne
+            else -> error("Unrecognized player")
+        }
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -81,18 +81,13 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
      * @param activePlayer The new active player.
      */
     fun setActivePlayer(activePlayer: PillarboxPlayer) {
-        val inactivePlayer = when (activePlayer) {
-            _playerOne -> _playerTwo
-            _playerTwo -> _playerOne
-            else -> error("Unrecognized player")
-        }
-
+        val oldActivePlayer = mediaSession.player as PillarboxPlayer
         _activePlayer.update { activePlayer }
         mediaSession.player = activePlayer
         notificationManager.setPlayer(activePlayer)
 
-        inactivePlayer.volume = 0f
-        inactivePlayer.trackingEnabled = false
+        oldActivePlayer.volume = 0f
+        oldActivePlayer.trackingEnabled = false
 
         activePlayer.volume = 1f
         activePlayer.trackingEnabled = true

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -91,11 +91,11 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
         mediaSession.player = activePlayer
         notificationManager.setPlayer(activePlayer)
 
-        activePlayer.volume = 1f
-        activePlayer.trackingEnabled = true
-
         inactivePlayer.volume = 0f
         inactivePlayer.trackingEnabled = false
+
+        activePlayer.volume = 1f
+        activePlayer.trackingEnabled = true
     }
 
     /**

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -70,6 +70,7 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
 
     init {
         mediaSession = MediaSession.Builder(application, _playerOne)
+            .setId("MultiPlayerSession")
             .build()
         notificationManager.setMediaSessionToken(mediaSession.sessionCompatToken)
         setActivePlayer(_playerOne)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -8,8 +8,8 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
-import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import androidx.media3.ui.PlayerNotificationManager
+import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.notification.PillarboxMediaDescriptionAdapter
@@ -71,10 +71,25 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
     }
 
     /**
-     * Activate the other player.
+     * Set the currently active player.
+     *
+     * @param activePlayer The new active player.
      */
-    fun activateOtherPlayer() {
-        setActivePlayer(getOtherPlayer(_activePlayer.value))
+    fun setActivePlayer(activePlayer: PillarboxPlayer) {
+        val inactivePlayer = when (activePlayer) {
+            _playerOne -> _playerTwo
+            _playerTwo -> _playerOne
+            else -> error("Unrecognized player")
+        }
+
+        _activePlayer.update { activePlayer }
+        notificationManager.setPlayer(activePlayer)
+
+        activePlayer.volume = 1f
+        activePlayer.trackingEnabled = true
+
+        inactivePlayer.volume = 0f
+        inactivePlayer.trackingEnabled = false
     }
 
     /**
@@ -88,27 +103,6 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
         notificationManager.setPlayer(null)
         _playerOne.release()
         _playerTwo.release()
-    }
-
-    private fun setActivePlayer(activePlayer: PillarboxPlayer) {
-        _activePlayer.update { activePlayer }
-        notificationManager.setPlayer(activePlayer)
-
-        activePlayer.volume = 1f
-        activePlayer.trackingEnabled = true
-
-        getOtherPlayer(activePlayer).let { inactivePlayer ->
-            inactivePlayer.volume = 0f
-            inactivePlayer.trackingEnabled = false
-        }
-    }
-
-    private fun getOtherPlayer(activePlayer: PillarboxPlayer): PillarboxPlayer {
-        return when (activePlayer) {
-            _playerOne -> _playerTwo
-            _playerTwo -> _playerOne
-            else -> error("Unrecognized player")
-        }
     }
 
     private companion object {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -7,12 +7,14 @@ package ch.srgssr.pillarbox.demo.ui.showcases.misc
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.session.MediaSession
 import androidx.media3.ui.PlayerNotificationManager
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.extension.disableAudioTrack
 import ch.srgssr.pillarbox.player.notification.PillarboxMediaDescriptionAdapter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -69,7 +71,7 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), _playerTwo)
 
     init {
-        mediaSession = MediaSession.Builder(application, _playerOne)
+        mediaSession = MediaSession.Builder(application, _playerTwo)
             .setId("MultiPlayerSession")
             .build()
         notificationManager.setMediaSessionToken(mediaSession.sessionCompatToken)
@@ -87,12 +89,19 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
         mediaSession.player = activePlayer
         notificationManager.setPlayer(activePlayer)
 
-        oldActivePlayer.volume = 0f
+        oldActivePlayer.disableAudioTrack()
+        oldActivePlayer.trackSelectionParameters = oldActivePlayer.trackSelectionParameters.buildUpon().setTrackTypeDisabled(
+            C.TRACK_TYPE_AUDIO,
+            true
+        ).build()
         oldActivePlayer.trackingEnabled = false
         oldActivePlayer.setHandleAudioFocus(false)
         oldActivePlayer.setHandleAudioBecomingNoisy(false)
 
-        activePlayer.volume = 1f
+        activePlayer.trackSelectionParameters = activePlayer.trackSelectionParameters.buildUpon().setTrackTypeDisabled(
+            C.TRACK_TYPE_AUDIO,
+            false
+        ).build()
         activePlayer.trackingEnabled = true
         activePlayer.setHandleAudioFocus(true)
         activePlayer.setHandleAudioBecomingNoisy(true)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -95,7 +95,12 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
         notificationManager.setPlayer(activePlayer)
 
         activePlayer.volume = 1f
-        getOtherPlayer(activePlayer).volume = 0f
+        activePlayer.trackingEnabled = true
+
+        getOtherPlayer(activePlayer).let { inactivePlayer ->
+            inactivePlayer.volume = 0f
+            inactivePlayer.trackingEnabled = false
+        }
     }
 
     private fun getOtherPlayer(activePlayer: PillarboxPlayer): PillarboxPlayer {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -88,9 +88,13 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
 
         oldActivePlayer.volume = 0f
         oldActivePlayer.trackingEnabled = false
+        oldActivePlayer.setHandleAudioFocus(false)
+        oldActivePlayer.setHandleAudioBecomingNoisy(false)
 
         activePlayer.volume = 1f
         activePlayer.trackingEnabled = true
+        activePlayer.setHandleAudioFocus(true)
+        activePlayer.setHandleAudioBecomingNoisy(true)
     }
 
     /**

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -13,6 +13,7 @@ import androidx.media3.ui.PlayerNotificationManager
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.notification.PillarboxMediaDescriptionAdapter
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.update
 class MultiPlayerViewModel(application: Application) : AndroidViewModel(application) {
     private val notificationManager = PlayerNotificationManager.Builder(application, NOTIFICATION_ID, CHANNEL_ID)
         .setChannelNameResourceId(androidx.media3.session.R.string.default_notification_channel_name)
+        .setMediaDescriptionAdapter(PillarboxMediaDescriptionAdapter(null, application))
         .build()
     private val mediaSession: MediaSession
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/UpdatableMediaItemViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/UpdatableMediaItemViewModel.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.session.MediaSession
 import androidx.media3.ui.PlayerNotificationManager
 import ch.srgssr.pillarbox.core.business.SRGMediaItemBuilder
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
@@ -38,6 +39,7 @@ class UpdatableMediaItemViewModel(application: Application) : AndroidViewModel(a
     private val timer: Timer
     private val baseTitle = "Update title"
     private var counter = 0
+    private val mediaSession = MediaSession.Builder(application, player).build()
 
     init {
         player.prepare()
@@ -48,6 +50,7 @@ class UpdatableMediaItemViewModel(application: Application) : AndroidViewModel(a
             .setMediaDescriptionAdapter(PillarboxMediaDescriptionAdapter(context = application, pendingIntent = null))
             .build()
         notificationManager.setPlayer(player)
+        notificationManager.setMediaSessionToken(mediaSession.sessionCompatToken)
 
         timer = timer(name = "update-item", period = 3.seconds.inWholeMilliseconds) {
             viewModelScope.launch(Dispatchers.Main) {
@@ -91,6 +94,7 @@ class UpdatableMediaItemViewModel(application: Application) : AndroidViewModel(a
         super.onCleared()
         timer.cancel()
         notificationManager.setPlayer(null)
+        mediaSession.release()
         player.release()
     }
 

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 dependencies {
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.core)
-    api(libs.androidx.media)
+    implementation(libs.androidx.media)
     api(libs.androidx.media3.common)
     implementation(libs.androidx.media3.dash)
     implementation(libs.androidx.media3.datasource)

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -28,7 +28,7 @@ android {
 dependencies {
     implementation(libs.androidx.annotation)
     implementation(libs.androidx.core)
-    implementation(libs.androidx.media)
+    api(libs.androidx.media)
     api(libs.androidx.media3.common)
     implementation(libs.androidx.media3.dash)
     implementation(libs.androidx.media3.datasource)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -71,6 +71,8 @@ internal class CurrentMediaItemTracker internal constructor(
         }
         if (mediaItem.canHaveTrackingSession()) {
             startNewSession(mediaItem)
+            // Update current media item with tracker data
+            this.currentMediaItem = mediaItem
         }
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/CurrentMediaItemTracker.kt
@@ -69,10 +69,8 @@ internal class CurrentMediaItemTracker internal constructor(
             }
             return
         }
-        if (mediaItem.canHaveTrackingSession() && currentMediaItem?.getMediaItemTrackerDataOrNull() == null) {
+        if (mediaItem.canHaveTrackingSession()) {
             startNewSession(mediaItem)
-            // Update current media item with tracker data
-            this.currentMediaItem = mediaItem
         }
     }
 
@@ -88,8 +86,7 @@ internal class CurrentMediaItemTracker internal constructor(
     }
 
     private fun startNewSession(mediaItem: MediaItem) {
-        if (!enabled) return
-        require(trackers == null)
+        if (!enabled || trackers != null) return
         DebugLogger.info(TAG, "start new session for ${mediaItem.prettyString()}")
 
         mediaItem.getMediaItemTrackerData().also { trackerData ->


### PR DESCRIPTION
# Pull request

## Description

This PR improves the multi player showcase in the following ways:
- Only have one of the two players to play audio at a time
- Clicking on the inactive player activates it, and disables the other one
- A media notification is now shown with, linked with the current player
- Only the analytics for the currently active player are sent

## Changes made

- Create a `MultiPlayerViewModel` to manage the players, the active state toggling, and the media notification
- Add the missing `android.permission.POST_NOTIFICATIONS` permission in the `pillarbox-demo` manifest
- Make the `PlayerControls` background control customisable
- Update `CurrentMediaItemTracker` to support restarting tracking

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.