### PR TITLE
Don't filter out unsupported/forced tracks

### DIFF
--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/settings/PlaybackSettingsDrawer.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/settings/PlaybackSettingsDrawer.kt
@@ -58,6 +58,7 @@ import ch.srgssr.pillarbox.demo.shared.ui.player.settings.TracksSettingItem
 import ch.srgssr.pillarbox.demo.tv.ui.theme.paddings
 import ch.srgssr.pillarbox.player.extension.displayName
 import ch.srgssr.pillarbox.player.extension.hasAccessibilityRoles
+import ch.srgssr.pillarbox.player.extension.isForced
 
 /**
  * Drawer used to display a player's settings.
@@ -318,8 +319,10 @@ private fun NavigationDrawerScope.TracksSetting(
 
             tracksSetting.tracks.forEach { group ->
                 items(group.length) { trackIndex ->
+                    val format = group.getTrackFormat(trackIndex)
                     NavigationDrawerItem(
                         selected = group.isTrackSelected(trackIndex),
+                        enabled = group.isTrackSupported(trackIndex) && !format.isForced(),
                         onClick = { onTrackClick(group, trackIndex) },
                         leadingContent = {
                             AnimatedVisibility(visible = group.isTrackSelected(trackIndex)) {
@@ -330,7 +333,6 @@ private fun NavigationDrawerScope.TracksSetting(
                             }
                         },
                         content = {
-                            val format = group.getTrackFormat(trackIndex)
                             val label = buildString {
                                 append(format.displayName)
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/TrackSelectionSettings.kt
@@ -32,6 +32,7 @@ import ch.srgssr.pillarbox.demo.shared.ui.player.settings.TracksSettingItem
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import ch.srgssr.pillarbox.player.extension.displayName
 import ch.srgssr.pillarbox.player.extension.hasAccessibilityRoles
+import ch.srgssr.pillarbox.player.extension.isForced
 
 /**
  * Track selection settings
@@ -78,14 +79,15 @@ fun TrackSelectionSettings(
         }
         tracksSetting.tracks.forEach { group ->
             items(group.length) { trackIndex ->
+                val format = group.getTrackFormat(trackIndex)
                 SettingsOption(
                     modifier = itemModifier,
                     selected = group.isTrackSelected(trackIndex),
+                    enabled = group.isTrackSupported(trackIndex) && !format.isForced(),
                     onClick = {
                         onTrackClick(group, trackIndex)
                     },
                     content = {
-                        val format = group.getTrackFormat(trackIndex)
                         when (group.type) {
                             C.TRACK_TYPE_AUDIO -> {
                                 val str = StringBuilder()

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Tracks.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Tracks.kt
@@ -4,72 +4,28 @@
  */
 package ch.srgssr.pillarbox.player.extension
 
-import android.annotation.SuppressLint
 import androidx.media3.common.C
 import androidx.media3.common.C.TrackType
-import androidx.media3.common.Format
-import androidx.media3.common.TrackGroup
 import androidx.media3.common.Tracks
 
 /**
- * Text tracks
+ * Text tracks.
  */
 val Tracks.text: List<Tracks.Group>
-    get() = filterByTrackType(C.TRACK_TYPE_TEXT).mapNotNull { it.filterForcedAndUnsupported() }
+    get() = filterByTrackType(C.TRACK_TYPE_TEXT)
 
 /**
  * Audio tracks.
  */
 val Tracks.audio: List<Tracks.Group>
-    get() = filterByTrackType(C.TRACK_TYPE_AUDIO).mapNotNull { it.filterUnsupported() }
+    get() = filterByTrackType(C.TRACK_TYPE_AUDIO)
 
 /**
  * Video tracks.
  */
 val Tracks.video: List<Tracks.Group>
-    get() = filterByTrackType(C.TRACK_TYPE_VIDEO).mapNotNull { it.filterUnsupported() }
+    get() = filterByTrackType(C.TRACK_TYPE_VIDEO)
 
 private fun Tracks.filterByTrackType(trackType: @TrackType Int): List<Tracks.Group> {
     return groups.filter { it.type == trackType }
-}
-
-private fun Tracks.Group.filterForcedAndUnsupported(): Tracks.Group? {
-    return filterBy { group, i -> group.isTrackSupported(i) && !group.getTrackFormat(i).isForced() }
-}
-
-internal fun Tracks.Group.filterUnsupported(): Tracks.Group? {
-    return filterBy { group, i -> group.isTrackSupported(i) }
-}
-
-/**
- * Filter [Format] that matching [predicate].
- *
- * @param predicate function that takes the index of an element and the element itself and returns the result of predicate evaluation on the element.
- * @receiver
- * @return element matching [predicate] or null if filtered items is empty because [TrackGroup] can not be empty.
- */
-@SuppressLint("WrongConstant")
-@Suppress("SpreadOperator", "ReturnCount")
-internal fun Tracks.Group.filterBy(predicate: (Tracks.Group, Int) -> Boolean): Tracks.Group? {
-    val listIndexMatchingPredicate = ArrayList<Int>(length)
-    for (i in 0 until length) {
-        if (predicate(this, i)) {
-            listIndexMatchingPredicate.add(i)
-        }
-    }
-    // All format doesn't match predicate.
-    if (listIndexMatchingPredicate.isEmpty()) return null
-    // All format matching the predicate, nothing to change.
-    if (listIndexMatchingPredicate.size == length) return this
-    val count = listIndexMatchingPredicate.size
-    val formats = ArrayList<Format>(count)
-    val trackSupport = IntArray(count)
-    val trackSelect = BooleanArray(count)
-    for (i in 0 until count) {
-        val trackIndex = listIndexMatchingPredicate[i]
-        formats.add(getTrackFormat(trackIndex))
-        trackSupport[i] = getTrackSupport(trackIndex)
-        trackSelect[i] = isTrackSelected(trackIndex)
-    }
-    return Tracks.Group(TrackGroup(mediaTrackGroup.id, *formats.toTypedArray()), isAdaptiveSupported, trackSupport, trackSelect)
 }


### PR DESCRIPTION
# Pull request

## Description

This PR fixes the selection of alternative audio/text/video tracks, when some tracks have been filtered out. When selecting an other track, Media3 checks that the provided group is a known one, thus we keep filter out some tracks.

## Changes made

- Remove filtering on audio/text/video tracks
- Update demo apps to disable unsupported tracks
- Update tests to include unsupported tracks

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.