### PR TITLE
Improve live edge detection and provide Player extension

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
@@ -25,14 +25,12 @@ import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.ui.player.LiveIndicator
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.player.extension.canSeek
+import ch.srgssr.pillarbox.player.extension.isAtLiveEdge
 import ch.srgssr.pillarbox.ui.extension.availableCommandsAsState
 import ch.srgssr.pillarbox.ui.extension.currentMediaMetadataAsState
 import ch.srgssr.pillarbox.ui.extension.currentPositionAsState
-import ch.srgssr.pillarbox.ui.extension.getCurrentDefaultPositionAsState
 import ch.srgssr.pillarbox.ui.extension.isCurrentMediaItemLiveAsState
 import ch.srgssr.pillarbox.ui.extension.playWhenReadyAsState
-
-private const val LiveEdgeThreshold = 5_000L
 
 /**
  * Player controls
@@ -54,10 +52,6 @@ fun PlayerControls(
 ) {
     val mediaMetadata by player.currentMediaMetadataAsState()
     val isCurrentItemLive by player.isCurrentMediaItemLiveAsState()
-    val currentPlaybackPosition by player.currentPositionAsState()
-    val currentDefaultPosition by player.getCurrentDefaultPositionAsState()
-    val playWhenReady by player.playWhenReadyAsState()
-    val isAtLiveEdge = playWhenReady && currentPlaybackPosition >= (currentDefaultPosition - LiveEdgeThreshold)
     val availableCommand by player.availableCommandsAsState()
     Box(
         modifier = modifier.background(color = backgroundColor),
@@ -93,6 +87,9 @@ fun PlayerControls(
                 }
 
                 if (isCurrentItemLive) {
+                    val currentPlaybackPosition by player.currentPositionAsState()
+                    val isPlayWhenReady by player.playWhenReadyAsState()
+                    val isAtLiveEdge = isPlayWhenReady && player.isAtLiveEdge(currentPlaybackPosition)
                     LiveIndicator(
                         modifier = Modifier
                             .padding(MaterialTheme.paddings.mini),

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Player.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Player.kt
@@ -63,15 +63,13 @@ fun Player.setHandleAudioFocus(handleAudioFocus: Boolean) {
 fun Player.isAtLiveEdge(positionMs: Long = currentPosition, window: Window = Window()): Boolean {
     if (!isCurrentMediaItemLive) return false
     currentTimeline.getWindow(currentMediaItemIndex, window)
-    val offsetSeconds = when (currentManifest) {
+    val offsetSeconds = when (val manifest = currentManifest) {
         is HlsManifest -> {
-            val hlsManifest = currentManifest as HlsManifest
-            hlsManifest.mediaPlaylist.targetDurationUs.microseconds.inWholeSeconds
+            manifest.mediaPlaylist.targetDurationUs.microseconds.inWholeSeconds
         }
 
         is DashManifest -> {
-            val dashManifest = currentManifest as DashManifest
-            dashManifest.minBufferTimeMs.milliseconds.inWholeSeconds
+            manifest.minBufferTimeMs.milliseconds.inWholeSeconds
         }
 
         else -> {

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
@@ -16,14 +16,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Player.Commands
-import androidx.media3.common.Timeline
-import androidx.media3.common.Timeline.Window
 import androidx.media3.common.VideoSize
 import ch.srgssr.pillarbox.player.DefaultUpdateInterval
 import ch.srgssr.pillarbox.player.availableCommandsAsFlow
@@ -34,7 +31,6 @@ import ch.srgssr.pillarbox.player.durationAsFlow
 import ch.srgssr.pillarbox.player.extension.getCurrentMediaItems
 import ch.srgssr.pillarbox.player.extension.getPlaybackSpeed
 import ch.srgssr.pillarbox.player.getAspectRatioAsFlow
-import ch.srgssr.pillarbox.player.getCurrentDefaultPositionAsFlow
 import ch.srgssr.pillarbox.player.getCurrentMediaItemIndexAsFlow
 import ch.srgssr.pillarbox.player.getCurrentMediaItemsAsFlow
 import ch.srgssr.pillarbox.player.getPlaybackSpeedAsFlow
@@ -251,20 +247,4 @@ fun Player.isCurrentMediaItemLiveAsState(): State<Boolean> {
         isCurrentMediaItemLiveAsFlow()
     }
     return flow.collectAsState(initial = isCurrentMediaItemLive)
-}
-
-/**
- * @return The current default position as state.
- * @see Timeline.Window.getDefaultPositionMs
- */
-@Composable
-fun Player.getCurrentDefaultPositionAsState(): LongState {
-    val flow = remember(this) {
-        getCurrentDefaultPositionAsFlow()
-    }
-    val window = remember {
-        Window()
-    }
-    val initialValue = if (!currentTimeline.isEmpty) currentTimeline.getWindow(currentMediaItemIndex, window).defaultPositionMs else C.TIME_UNSET
-    return flow.collectAsState(initial = initialValue).asLongState()
 }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to reduce the live edge detection for livestream. For live with dvr, the current player position is changing every time and it may introduce some bad detection. This PR try to reduce this effect.

If the problem persist for your use case you could try to setup how player handle live with a given item with

```kotlin
    val liveItem = MediaItem.Builder()
        .setLiveConfiguration(MediaItem.LiveConfiguration.Builder()
            .setTargetOffsetMs()
            .setMinOffsetMs()
            .setMaxOffsetMs()
            .build())
        .build()
```

## Changes made

- Add `Player.isAtLiveEdge`.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
