### PR TITLE
Mitigate missing aspect ratio issue

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/VideoSize.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/VideoSize.kt
@@ -8,12 +8,10 @@ import android.util.Rational
 import androidx.media3.common.VideoSize
 
 /**
- * Compute aspect ratio, return [unknownAspectRatioValue] if aspect ratio can't be computed.
- *
- * @param unknownAspectRatioValue
+ * Compute the aspect ratio, return `null` if the aspect ratio can't be computed.
  */
-fun VideoSize.computeAspectRatio(unknownAspectRatioValue: Float): Float {
-    return if (height == 0 || width == 0) unknownAspectRatioValue else width * this.pixelWidthHeightRatio / height
+fun VideoSize.computeAspectRatioOrNull(): Float? {
+    return if (height == 0 || width == 0) null else width * this.pixelWidthHeightRatio / height
 }
 
 /**

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPlayerCallbackFlow.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPlayerCallbackFlow.kt
@@ -433,6 +433,54 @@ class TestPlayerCallbackFlow {
     }
 
     @Test
+    fun `get aspect ratio as flow, video tracks no video size, has video size`() = runTest {
+        val videoTracks = Tracks(
+            listOf(
+                createTrackGroup(
+                    selectedIndex = 1,
+                    createVideoFormat("v1", width = Format.NO_VALUE, height = Format.NO_VALUE),
+                    createVideoFormat("v2", width = Format.NO_VALUE, height = Format.NO_VALUE),
+                    createVideoFormat("v3", width = Format.NO_VALUE, height = Format.NO_VALUE),
+                )
+            )
+        )
+
+        val fakePlayer = PlayerListenerCommander(player)
+
+        fakePlayer.getAspectRatioAsFlow(0f).test {
+            fakePlayer.onVideoSizeChanged(VideoSize(1920, 1080))
+            fakePlayer.onTracksChanged(videoTracks)
+
+            assertEquals(0f, awaitItem())
+            assertEquals(16 / 9f, awaitItem())
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `get aspect ratio as flow, video tracks no video size, no video size`() = runTest {
+        val videoTracks = Tracks(
+            listOf(
+                createTrackGroup(
+                    selectedIndex = 1,
+                    createVideoFormat("v1", width = Format.NO_VALUE, height = Format.NO_VALUE),
+                    createVideoFormat("v2", width = Format.NO_VALUE, height = Format.NO_VALUE),
+                    createVideoFormat("v3", width = Format.NO_VALUE, height = Format.NO_VALUE),
+                )
+            )
+        )
+
+        val fakePlayer = PlayerListenerCommander(player)
+
+        fakePlayer.getAspectRatioAsFlow(0f).test {
+            fakePlayer.onTracksChanged(videoTracks)
+
+            assertEquals(0f, awaitItem())
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
     fun `get aspect ratio as flow, video tracks without selection`() = runTest {
         val videoTracksWithoutSelection = Tracks(
             listOf(

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/extension/VideoSizeTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/extension/VideoSizeTest.kt
@@ -10,71 +10,60 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 class VideoSizeTest {
     @Test
     fun `computeAspectRatio unknown video size`() {
         val input = VideoSize.UNKNOWN
-        val expectedAspectRatio = 16f / 9
-        val unknownAspectRatio = 16f / 9
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertNull(input.computeAspectRatioOrNull())
     }
 
     @Test
     fun `computeAspectRatio with height set to 0`() {
         val input = VideoSize(0, 100)
-        val expectedAspectRatio = 16f / 9
-        val unknownAspectRatio = 16f / 9
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertNull(input.computeAspectRatioOrNull())
     }
 
     @Test
     fun `computeAspectRatio with width set to 0`() {
         val input = VideoSize(240, 0)
-        val expectedAspectRatio = 16f / 9
-        val unknownAspectRatio = 16f / 9
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertNull(input.computeAspectRatioOrNull())
     }
 
     @Test
     fun `computeAspectRatio with width and height set to 0`() {
         val input = VideoSize(0, 0)
-        val expectedAspectRatio = 16f / 9
-        val unknownAspectRatio = 16f / 9
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertNull(input.computeAspectRatioOrNull())
     }
 
     @Test
     fun `computeAspectRatio with a 16-9 aspect ratio`() {
         val input = VideoSize(1920, 1080)
         val expectedAspectRatio = 16f / 9
-        val unknownAspectRatio = 1f
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertEquals(expectedAspectRatio, input.computeAspectRatioOrNull())
     }
 
     @Test
     fun `computeAspectRatio with a 9-16 aspect ratio`() {
         val input = VideoSize(1080, 1920)
         val expectedAspectRatio = 9f / 16
-        val unknownAspectRatio = 1f
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertEquals(expectedAspectRatio, input.computeAspectRatioOrNull())
     }
 
     @Test
     fun `computeAspectRatio with a 4-3 aspect ratio`() {
         val input = VideoSize(800, 600)
         val expectedAspectRatio = 4f / 3
-        val unknownAspectRatio = 1f
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertEquals(expectedAspectRatio, input.computeAspectRatioOrNull())
     }
 
     @Test
     fun `computeAspectRatio with a square aspect ratio`() {
         val input = VideoSize(500, 500)
         val expectedAspectRatio = 1f
-        val unknownAspectRatio = 0f
-        assertEquals(expectedAspectRatio, input.computeAspectRatio(unknownAspectRatio))
+        assertEquals(expectedAspectRatio, input.computeAspectRatioOrNull())
     }
 
     @Test

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
@@ -54,7 +54,7 @@ fun PlayerSurface(
     displayDebugView: Boolean = false,
     surfaceContent: @Composable (BoxScope.() -> Unit)? = { ExoPlayerSubtitleView(player = player) },
 ) {
-    var lastKnownVideoAspectRatio by remember { mutableFloatStateOf(defaultAspectRatio ?: 0f) }
+    var lastKnownVideoAspectRatio by remember { mutableFloatStateOf(defaultAspectRatio ?: 1f) }
     val videoAspectRatio by player.getAspectRatioAsState(defaultAspectRatio = lastKnownVideoAspectRatio)
 
     // If the media has tracks, but no video tracks, we reset the aspect ratio to 0


### PR DESCRIPTION
# Pull request

## Description

This PR uses the video size as a fallback when computing the video aspect ratio, when the tracks don't contain the video dimension.
This results in the aspect ratio quickly changing, while loading the first frames, but it still happen a lot less often compared to before #466.

## Changes made

- Try to compute the aspect ratio from the video size, if the tracks don't provide the video dimension.
- Change the aspect ratio default value back to `1f`.
- Change the methods computing an aspect ratio to return `null` is the value can not be computed.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.