### PR TITLE
Enable desugaring of java 8+ feature for android < 24

### DIFF
--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/ProjectExtensions.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/ProjectExtensions.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.gradle.internal
 
 import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -20,11 +21,17 @@ internal fun Project.configureAndroidModule(extension: CommonExtension<*, *, *, 
     compileOptions {
         sourceCompatibility = AppConfig.javaVersion
         targetCompatibility = AppConfig.javaVersion
+        isCoreLibraryDesugaringEnabled = true
     }
 
     buildFeatures {
         resValues = false
         shaders = false
+    }
+
+    dependencies {
+        // coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
+        add("coreLibraryDesugaring", "com.android.tools:desugar_jdk_libs:2.0.4")
     }
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,19 +106,19 @@ kotlinOptions {
 }
 ```
 
-### Targeting android device < 24
+### Support Android API < 24
 
-When you target devices < 24 you have to enabled library desugaring like describe in the android documentation ( [here](https://developer.android.com/studio/write/java8-support#library-desugaring))
+If your min SDK version is below 24, you have to enabled library desugaring as describe in the [Android documentation](https://developer.android.com/studio/write/java8-support#library-desugaring):
 
 ```kotlin
-  compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-        isCoreLibraryDesugaringEnabled = true
-    }
+compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+    isCoreLibraryDesugaringEnabled = true
+}
 
 dependencies {
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.4")
 }
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -106,6 +106,22 @@ kotlinOptions {
 }
 ```
 
+### Targeting android device < 24
+
+When you target devices < 24 you have to enabled library desugaring like describe in the android documentation ( [here](https://developer.android.com/studio/write/java8-support#library-desugaring))
+
+```kotlin
+  compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+        isCoreLibraryDesugaringEnabled = true
+    }
+
+dependencies {
+    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+}
+```
+
 ### Integrate Pillarbox
 
 To start using Pillarbox in your project, you can check each module's documentation:


### PR DESCRIPTION
# Pull request

## Description

Since media3 1.3.1 they are using java8 special feature inside the library. For application running on android lesser than 24. you have to add like documented by android [here](https://developer.android.com/studio/write/java8-support#library-desugaring)

```kotlin
  compileOptions {
        sourceCompatibility = JavaVersion.VERSION_11
        targetCompatibility = JavaVersion.VERSION_11
        isCoreLibraryDesugaringEnabled = true
    }

dependencies {
    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
}
```

## Changes made

- Update build file

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
