### PR TITLE
Make the Dependency Analysis plugin only fails for unused dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,6 @@ jobs:
       - name: Run Dependency Analysis
         run: ./gradlew buildHealth
       - name: Display analysis report
-        if: failure()
         run: cat build/reports/dependency-analysis/build-health-report.txt
 
   unit-test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Run Dependency Analysis
         run: ./gradlew buildHealth
       - name: Display analysis report
+        if: ${{ !cancelled() }}
         run: cat build/reports/dependency-analysis/build-health-report.txt
 
   unit-test:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -80,15 +80,12 @@ tasks.getByPath(":pillarbox-demo:preBuild").dependsOn(":installGitHook")
 dependencyAnalysis {
     issues {
         all {
-            onAny {
+            onUnusedDependencies {
                 severity("fail")
             }
         }
 
         structure {
-            // https://github.com/autonomousapps/dependency-analysis-gradle-plugin/wiki/Customizing-plugin-behavior
-            ignoreKtx(true) // default is false
-
             // Required because of https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/892
             bundle("kotlin-test") {
                 includeDependency(libs.kotlin.test)

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,9 +19,6 @@ org.gradle.parallel=true
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-# https://github.com/autonomousapps/dependency-analysis-gradle-plugin/issues/1079#issuecomment-1862266603
-dependency.analysis.test.analysis=false
-
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 


### PR DESCRIPTION
# Pull request

## Description

This PR makes the [Dependency Analysis plugin](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) fail only for unused dependencies. The other kind of issues are still reported, but are no longer considered as error.

The possible options are:
- `onAny`: all kind of issues
- `onUnusedDependencies`: unused dependencies
- `onUsedTransitiveDependencies`: transitive dependencies used
- `onIncorrectConfiguration`: incorrect configuration (mostly `api` vs `implementation`)
- `onCompileOnly`: a dependency should be `compileOnly`
- `onRuntimeOnly`: a dependency should be `runtimeOnly`
- `onUnusedAnnotationProcessors`: an unused annotation processor is used
- `onRedundantPlugins`: a plugin is declared redundantly
- `onModuleStructure`: the module structure is wrong

## Changes made

> Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.