### PR TITLE
Replace usages of `MediaItemUrn` with `SRGMediaItemBuilder`

### DIFF
--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -24,7 +24,7 @@ import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType.Stop
 import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType.Uptime
 import ch.srgssr.pillarbox.analytics.commandersact.TCMediaEvent
 import ch.srgssr.pillarbox.core.business.DefaultPillarbox
-import ch.srgssr.pillarbox.core.business.MediaItemUrn
+import ch.srgssr.pillarbox.core.business.SRGMediaItemBuilder
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.DefaultHttpClient
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.HttpMediaCompositionService
@@ -117,14 +117,14 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared and playing, changing media item`() {
         val tcMediaEvents = mutableListOf<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
         TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
 
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
@@ -157,7 +157,7 @@ class CommandersActTrackerIntegrationTest {
     @Test
     fun `audio URN send any analytics`() {
         val tcMediaEventSlot = slot<TCMediaEvent>()
-        player.setMediaItem(MediaItemUrn(URN_AUDIO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_AUDIO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -192,7 +192,7 @@ class CommandersActTrackerIntegrationTest {
 
     @Test
     fun `player prepared but not playing`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
@@ -209,7 +209,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared and playing`() {
         val tcMediaEventSlot = slot<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -233,7 +233,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared and playing, change playback speed`() {
         val tcMediaEventSlot = slot<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
         player.setPlaybackSpeed(2f)
@@ -258,7 +258,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared and playing, change playback speed while playing`() {
         val tcMediaEventSlot = slot<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -287,7 +287,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared, playing and paused`() {
         val tcMediaEvents = mutableListOf<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -322,7 +322,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared, playing, paused, playing again`() {
         val tcMediaEvents = mutableListOf<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -368,7 +368,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared, playing and stopped`() {
         val tcMediaEvents = mutableListOf<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -402,7 +402,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player prepared, playing and seeking`() {
         val tcMediaEvents = mutableListOf<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -441,7 +441,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player pause, playing, seeking and playing`() {
         val tcMediaEventSlot = slot<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = false
 
@@ -471,7 +471,7 @@ class CommandersActTrackerIntegrationTest {
     fun `player playing, pause, seeking and pause`() = runTest(testDispatcher) {
         val tcMediaEvents = mutableListOf<TCMediaEvent>()
 
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -524,7 +524,7 @@ class CommandersActTrackerIntegrationTest {
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     fun `player pause, seeking and pause`() = runTest(testDispatcher) {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = false
 
@@ -548,7 +548,7 @@ class CommandersActTrackerIntegrationTest {
 
     @Test
     fun `player prepared and seek`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.seekTo(3.minutes.inWholeMilliseconds)
 
@@ -563,8 +563,8 @@ class CommandersActTrackerIntegrationTest {
     @Test
     fun `player seek to next item doesn't send seek event`() {
         val tcMediaEvents = mutableListOf<TCMediaEvent>()
-        player.addMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
-        player.addMediaItem(MediaItemUrn(URN_VOD_SHORT))
+        player.addMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
+        player.addMediaItem(SRGMediaItemBuilder(URN_VOD_SHORT).build())
         player.prepare()
         player.play()
 
@@ -597,7 +597,7 @@ class CommandersActTrackerIntegrationTest {
 
     @Test
     fun `player prepared and stopped`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.stop()
 
@@ -616,7 +616,7 @@ class CommandersActTrackerIntegrationTest {
         CommandersActStreaming.POS_PERIOD = 2.seconds
         CommandersActStreaming.UPTIME_PERIOD = 4.seconds
 
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -674,7 +674,7 @@ class CommandersActTrackerIntegrationTest {
         CommandersActStreaming.POS_PERIOD = 2.seconds
         CommandersActStreaming.UPTIME_PERIOD = 4.seconds
 
-        player.setMediaItem(MediaItemUrn(URN_DVR))
+        player.setMediaItem(SRGMediaItemBuilder(URN_DVR).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -729,7 +729,7 @@ class CommandersActTrackerIntegrationTest {
         CommandersActStreaming.POS_PERIOD = 2.seconds
         CommandersActStreaming.UPTIME_PERIOD = 4.seconds
 
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -781,7 +781,7 @@ class CommandersActTrackerIntegrationTest {
         CommandersActStreaming.POS_PERIOD = 2.seconds
         CommandersActStreaming.UPTIME_PERIOD = 4.seconds
 
-        player.setMediaItem(MediaItemUrn(URN_VOD_SHORT))
+        player.setMediaItem(SRGMediaItemBuilder(URN_VOD_SHORT).build())
         player.prepare()
         player.playWhenReady = true
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
@@ -16,7 +16,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import ch.srgssr.pillarbox.analytics.BuildConfig
 import ch.srgssr.pillarbox.core.business.DefaultPillarbox
-import ch.srgssr.pillarbox.core.business.MediaItemUrn
+import ch.srgssr.pillarbox.core.business.SRGMediaItemBuilder
 import ch.srgssr.pillarbox.core.business.tracker.DefaultMediaItemTrackerRepository
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
 import com.comscore.streaming.AssetMetadata
@@ -72,13 +72,13 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `player prepared and playing, changing media item`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
 
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
@@ -107,7 +107,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `audio URN don't send any analytics`() {
-        player.setMediaItem(MediaItemUrn(URN_AUDIO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_AUDIO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -130,7 +130,7 @@ class ComScoreTrackerIntegrationTest {
     @Test
     @Ignore("SurfaceView/SurfaceHolder not implemented in Robolectric")
     fun `surface size changed`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -186,7 +186,7 @@ class ComScoreTrackerIntegrationTest {
     // region Live media
     @Test
     fun `live - player prepared but not playing`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
@@ -204,7 +204,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared and playing`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -225,7 +225,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared and playing, change playback speed`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
         player.setPlaybackSpeed(2f)
@@ -248,7 +248,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared and playing, change playback speed while playing`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -272,7 +272,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared, playing and paused`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -299,7 +299,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared, playing, paused, playing again`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -333,7 +333,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared, playing and stopped`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -361,7 +361,7 @@ class ComScoreTrackerIntegrationTest {
     @Test
     @Ignore("Need a live DVR available outside of Switzerland")
     fun `live - player prepared, playing and seeking`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -393,7 +393,7 @@ class ComScoreTrackerIntegrationTest {
     @Test
     @Ignore("Need a live DVR available outside of Switzerland")
     fun `live - player prepared and seek`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.seekTo(3.minutes.inWholeMilliseconds)
 
@@ -412,7 +412,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared and stopped`() {
-        player.setMediaItem(MediaItemUrn(URN_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
         player.stop()
 
@@ -425,7 +425,7 @@ class ComScoreTrackerIntegrationTest {
     // region Not live media
     @Test
     fun `not live - player prepared but not playing`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
@@ -443,7 +443,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared and playing`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -464,7 +464,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared and playing, change playback speed`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
         player.setPlaybackSpeed(2f)
@@ -486,7 +486,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared and playing, change playback speed while playing`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -511,7 +511,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared, playing and paused`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -538,7 +538,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared, playing, paused, playing again`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -572,7 +572,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared, playing and stopped`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -599,7 +599,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared, playing and seeking`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.playWhenReady = true
 
@@ -630,7 +630,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared and seek`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.seekTo(3.minutes.inWholeMilliseconds)
 
@@ -649,7 +649,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `not live - player prepared and stopped`() {
-        player.setMediaItem(MediaItemUrn(URN_NOT_LIVE_VIDEO))
+        player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.prepare()
         player.stop()
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.media3.common.Player
-import ch.srgssr.pillarbox.core.business.MediaItemUrn
+import ch.srgssr.pillarbox.core.business.SRGMediaItemBuilder
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.ui.widget.player.SphericalSurface
 
@@ -24,7 +24,7 @@ fun SphericalSurfaceShowcase() {
     val context = LocalContext.current
     val player = remember {
         PlayerModule.provideDefaultPlayer(context = context).apply {
-            setMediaItem(MediaItemUrn("urn:rts:video:8414077"))
+            setMediaItem(SRGMediaItemBuilder("urn:rts:video:8414077").build())
             repeatMode = Player.REPEAT_MODE_ONE
         }
     }


### PR DESCRIPTION
# Pull request

## Description

`MediaItemUrn` was deprecated in Pillarbox 2.0.0, in favour of `SRGMediaItemBuilder`. This PR migrates the remaining `MediaItemUrn` in the project.

## Changes made

- Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.