### PR TITLE
Custom blocked segments

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
@@ -8,6 +8,7 @@ package ch.srgssr.pillarbox.demo.shared.data
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import ch.srgssr.pillarbox.demo.shared.source.BlockedTimeRangeAssetLoader
 import java.io.Serializable
 
 /**
@@ -464,7 +465,10 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                     title = "Custom MediaSource",
                     uri = "https://custom-media.ch/fondue",
                     description = "Using a custom CustomMediaSource"
-                )
+                ),
+                BlockedTimeRangeAssetLoader.DemoItemBlockedTimeRangeAtStartAndEnd,
+                BlockedTimeRangeAssetLoader.DemoItemBlockedTimeRangeOverlaps,
+                BlockedTimeRangeAssetLoader.DemoItemBlockedTimeRangeIncluded,
             )
         )
 

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
@@ -11,6 +11,7 @@ import ch.srgssr.dataprovider.paging.DataProviderPaging
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.IlHost
 import ch.srgssr.pillarbox.core.business.source.SRGAssetLoader
 import ch.srgssr.pillarbox.core.business.tracker.DefaultMediaItemTrackerRepository
+import ch.srgssr.pillarbox.demo.shared.source.BlockedTimeRangeAssetLoader
 import ch.srgssr.pillarbox.demo.shared.source.CustomAssetLoader
 import ch.srgssr.pillarbox.demo.shared.ui.integrationLayer.data.ILRepository
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
@@ -31,6 +32,7 @@ object PlayerModule {
             mediaSourceFactory = PillarboxMediaSourceFactory(context).apply {
                 addAssetLoader(SRGAssetLoader(context))
                 addAssetLoader(CustomAssetLoader(context))
+                addAssetLoader(BlockedTimeRangeAssetLoader(context))
             },
             mediaItemTrackerProvider = DefaultMediaItemTrackerRepository()
         )

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/source/BlockedTimeRangeAssetLoader.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/source/BlockedTimeRangeAssetLoader.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.shared.source
+
+import android.content.Context
+import androidx.media3.common.MediaItem
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import ch.srgssr.pillarbox.demo.shared.data.DemoItem
+import ch.srgssr.pillarbox.player.asset.Asset
+import ch.srgssr.pillarbox.player.asset.AssetLoader
+import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * An AssetLoader to demonstrate some edge cases with [BlockedTimeRange].
+ */
+class BlockedTimeRangeAssetLoader(context: Context) : AssetLoader(DefaultMediaSourceFactory(context)) {
+
+    override fun canLoadAsset(mediaItem: MediaItem): Boolean {
+        return mediaItem.localConfiguration?.uri?.toString()?.startsWith("blocked:") ?: false
+    }
+
+    override suspend fun loadAsset(mediaItem: MediaItem): Asset {
+        val mediaId = mediaItem.mediaId
+        return Asset(
+            mediaSource = mediaSourceFactory.createMediaSource(MediaItem.fromUri(URL)),
+            blockedTimeRanges = createBlockedTimeRangesFromId(mediaId)
+        )
+    }
+
+    @Suppress("MagicNumber")
+    private fun createBlockedTimeRangesFromId(mediaId: String): List<BlockedTimeRange> {
+        return when (mediaId) {
+            ID_START_END -> {
+                listOf(
+                    BlockedTimeRange(0, 10_000L),
+                    BlockedTimeRange(start = (videoDuration - 5.minutes).inWholeMilliseconds, end = videoDuration.inWholeMilliseconds)
+                )
+            }
+
+            ID_OVERLAP -> {
+                listOf(
+                    BlockedTimeRange(10_000L, 50_000L),
+                    BlockedTimeRange(15_000L, 5.minutes.inWholeMilliseconds)
+                )
+            }
+
+            ID_INCLUDED -> {
+                listOf(
+                    BlockedTimeRange(15_000L, 30_000L, reason = "contained"),
+                    BlockedTimeRange(10_000L, 60_000L, reason = "big"),
+                )
+            }
+
+            else -> emptyList()
+        }
+    }
+
+    companion object {
+        private val URL = DemoItem.AppleBasic_16_9_TS_HLS.uri
+        private val videoDuration = 1800.05.seconds
+
+        private const val ID_START_END = "blocked://StartEnd"
+        private const val ID_OVERLAP = "blocked://Overlap"
+        private const val ID_INCLUDED = "blocked://Included"
+
+        /**
+         * DemoItem to test BlockedTimeRange at start and end of the media.
+         */
+        val DemoItemBlockedTimeRangeAtStartAndEnd = DemoItem(
+            title = "Start and ends with a blocked time range",
+            uri = ID_START_END,
+            description = "Blocked times ranges at 00:00"
+        )
+        /**
+         * DemoItem to test overlapping BlockedTimeRange.
+         */
+        val DemoItemBlockedTimeRangeOverlaps = DemoItem(
+            title = "Blocked time range are overlapping",
+            uri = ID_OVERLAP,
+            description = "Two blocked time range are overlapping at 10s"
+        )
+
+        /**
+         * DemoItem to test included BlockedTimeRange
+         */
+        val DemoItemBlockedTimeRangeIncluded = DemoItem(
+            title = "Blocked time range is included",
+            uri = ID_INCLUDED,
+            description = "One blocked time range is included inside the other"
+        )
+    }
+}

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/source/BlockedTimeRangeAssetLoader.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/source/BlockedTimeRangeAssetLoader.kt
@@ -24,10 +24,9 @@ class BlockedTimeRangeAssetLoader(context: Context) : AssetLoader(DefaultMediaSo
     }
 
     override suspend fun loadAsset(mediaItem: MediaItem): Asset {
-        val mediaId = mediaItem.mediaId
         return Asset(
             mediaSource = mediaSourceFactory.createMediaSource(MediaItem.fromUri(URL)),
-            blockedTimeRanges = createBlockedTimeRangesFromId(mediaId)
+            blockedTimeRanges = createBlockedTimeRangesFromId(mediaItem.mediaId),
         )
     }
 
@@ -36,22 +35,42 @@ class BlockedTimeRangeAssetLoader(context: Context) : AssetLoader(DefaultMediaSo
         return when (mediaId) {
             ID_START_END -> {
                 listOf(
-                    BlockedTimeRange(0, 10_000L),
-                    BlockedTimeRange(start = (videoDuration - 5.minutes).inWholeMilliseconds, end = videoDuration.inWholeMilliseconds)
+                    BlockedTimeRange(
+                        start = 0L,
+                        end = 10.seconds.inWholeMilliseconds,
+                    ),
+                    BlockedTimeRange(
+                        start = (videoDuration - 5.minutes).inWholeMilliseconds,
+                        end = videoDuration.inWholeMilliseconds,
+                    )
                 )
             }
 
             ID_OVERLAP -> {
                 listOf(
-                    BlockedTimeRange(10_000L, 50_000L),
-                    BlockedTimeRange(15_000L, 5.minutes.inWholeMilliseconds)
+                    BlockedTimeRange(
+                        start = 10.seconds.inWholeMilliseconds,
+                        end = 50.seconds.inWholeMilliseconds,
+                    ),
+                    BlockedTimeRange(
+                        start = 15.seconds.inWholeMilliseconds,
+                        end = 5.minutes.inWholeMilliseconds,
+                    )
                 )
             }
 
             ID_INCLUDED -> {
                 listOf(
-                    BlockedTimeRange(15_000L, 30_000L, reason = "contained"),
-                    BlockedTimeRange(10_000L, 60_000L, reason = "big"),
+                    BlockedTimeRange(
+                        start = 15.seconds.inWholeMilliseconds,
+                        end = 30.seconds.inWholeMilliseconds,
+                        reason = "contained",
+                    ),
+                    BlockedTimeRange(
+                        start = 10.seconds.inWholeMilliseconds,
+                        end = 1.minutes.inWholeMilliseconds,
+                        reason = "big",
+                    ),
                 )
             }
 
@@ -68,29 +87,30 @@ class BlockedTimeRangeAssetLoader(context: Context) : AssetLoader(DefaultMediaSo
         private const val ID_INCLUDED = "blocked://Included"
 
         /**
-         * DemoItem to test BlockedTimeRange at start and end of the media.
+         * [DemoItem] to test [BlockedTimeRange] at start and end of the media.
          */
         val DemoItemBlockedTimeRangeAtStartAndEnd = DemoItem(
-            title = "Start and ends with a blocked time range",
+            title = "Starts and ends with a blocked time range",
             uri = ID_START_END,
-            description = "Blocked times ranges at 00:00"
-        )
-        /**
-         * DemoItem to test overlapping BlockedTimeRange.
-         */
-        val DemoItemBlockedTimeRangeOverlaps = DemoItem(
-            title = "Blocked time range are overlapping",
-            uri = ID_OVERLAP,
-            description = "Two blocked time range are overlapping at 10s"
+            description = "Blocked times ranges at 00:00 - 00:10 and 25:00 - 30:00",
         )
 
         /**
-         * DemoItem to test included BlockedTimeRange
+         * [DemoItem] to test overlapping [BlockedTimeRange].
+         */
+        val DemoItemBlockedTimeRangeOverlaps = DemoItem(
+            title = "Blocked time ranges are overlapping",
+            uri = ID_OVERLAP,
+            description = "Blocked times ranges at 00:10 to 00:50 and 00:15 to 05:00"
+        )
+
+        /**
+         * [DemoItem] to test included [BlockedTimeRange].
          */
         val DemoItemBlockedTimeRangeIncluded = DemoItem(
-            title = "Blocked time range is included",
+            title = "Blocked time range is included in an other one",
             uri = ID_INCLUDED,
-            description = "One blocked time range is included inside the other"
+            description = "Blocked times ranges at 00:15 - 00:30 and 00:10 - 01:00"
         )
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
@@ -188,6 +188,8 @@ private class BlockedTimeRangeTracker(
     override fun onEvents(player: Player, events: Player.Events) {
         val blockedInterval = timeRanges.firstOrNullAtPosition(player.currentPosition)
         blockedInterval?.let {
+            // Ignore Blocked time range that end at the same time as the media. Otherwise infinite seek operations.
+            if (player.currentPosition >= player.duration) return@let
             callback(it)
         }
     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
@@ -188,7 +188,7 @@ private class BlockedTimeRangeTracker(
     override fun onEvents(player: Player, events: Player.Events) {
         val blockedInterval = timeRanges.firstOrNullAtPosition(player.currentPosition)
         blockedInterval?.let {
-            // Ignore Blocked time range that end at the same time as the media. Otherwise infinite seek operations.
+            // Ignore blocked time ranges that end at the same time as the media. Otherwise infinite seek operations.
             if (player.currentPosition >= player.duration) return@let
             callback(it)
         }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to add some edge cases sample for `BlockedTimeRange`. The edge cases covered are

1. Overlapping of BlockedTimeRange
2. BlockTimeRange included in another one.
3. BlockTimeRange are present at the start and one to the end of the media.

## Changes made

- BlockedTimeRange at the end of the media seek to the end of the media and so the last frame of the content will be visible.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
