### PR TITLE
Revert toolchain changes from #556

### DIFF
--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -3,14 +3,23 @@
  * License information is available from the LICENSE file.
  */
 
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `kotlin-dsl`
 }
 
 group = "ch.srgssr.pillarbox.gradle"
 
-kotlin {
-    jvmToolchain(17)
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.majorVersion
+    }
 }
 
 dependencies {

--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/AppConfig.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/AppConfig.kt
@@ -4,11 +4,17 @@
  */
 package ch.srgssr.pillarbox.gradle.internal
 
+import org.gradle.api.JavaVersion
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 internal object AppConfig {
+    // When changing this value, don't forget to also update the Detekt config in the root `build.gradle.kts` file
+    private val javaVersionName = "17"
+
     internal const val minSdk = 21
     internal const val targetSdk = 34
     internal const val compileSdk = 34
 
-    // When changing this value, don't forget to also update the Detekt config in the root `build.gradle.kts` file
-    internal val javaVersion = 17
+    internal val javaVersion = JavaVersion.valueOf("VERSION_$javaVersionName")
+    internal val jvmTarget = JvmTarget.fromTarget(javaVersionName)
 }

--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/ProjectExtensions.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/ProjectExtensions.kt
@@ -8,10 +8,10 @@ import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
-import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
-import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 internal val Project.libs: VersionCatalog
     get() = extensions.getByType<VersionCatalogsExtension>().named("libs")
@@ -25,6 +25,8 @@ internal fun Project.configureAndroidModule(extension: CommonExtension<*, *, *, 
     }
 
     compileOptions {
+        sourceCompatibility = AppConfig.javaVersion
+        targetCompatibility = AppConfig.javaVersion
         isCoreLibraryDesugaringEnabled = true
     }
 
@@ -40,9 +42,9 @@ internal fun Project.configureAndroidModule(extension: CommonExtension<*, *, *, 
 }
 
 internal fun Project.configureKotlinModule() {
-    extensions.configure<KotlinAndroidProjectExtension> {
+    tasks.withType<KotlinCompile>().configureEach {
         compilerOptions {
-            jvmToolchain(AppConfig.javaVersion)
+            jvmTarget.set(AppConfig.jvmTarget)
         }
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,8 +109,13 @@ The latest stable version is [![Last release](https://img.shields.io/github/v/re
 If not already enabled, you also need to turn on Java 17 support in every `build.gradle`/`build.gradle.kts` files using Pillarbox. To do so, add/update the following to/in the `android` section:
 
 ```kotlin
-kotlin {
-    jvmToolchain(17)
+compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+}
+
+kotlinOptions {
+    jvmTarget = "17"
 }
 ```
 
@@ -120,6 +125,8 @@ A change in AndroidX Media3 1.3.0 requires applications to use library desugarin
 
 ```kotlin
 compileOptions {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
     isCoreLibraryDesugaringEnabled = true
 }
 


### PR DESCRIPTION
# Pull request

## Description

This PR reverts the toolchain related changes from #556.

The other changes were left untouched (Gradle 8.8 update, Gradle wrapper task configuration, `.gitignore` updates, ...).

## Changes made

- Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.