### PR TITLE
559 ghost start issue

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -208,7 +208,7 @@ empty-blocks:
     active: true
   EmptyFunctionBlock:
     active: true
-    ignoreOverridden: false
+    ignoreOverridden: true
   EmptyIfBlock:
     active: true
   EmptyInitBlock:

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
@@ -128,31 +128,21 @@ internal object ComScoreSrg : ComScore, Application.ActivityLifecycleCallbacks {
         requireNotNull(config) { "ComScore init has to be called before start." }
     }
 
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+    override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
         start(activity.applicationContext)
     }
 
-    override fun onActivityStarted(activity: Activity) {
-        // Nothing
-    }
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
 
-    override fun onActivityResumed(activity: Activity) {
-        // Nothing
-    }
+    override fun onActivityStarted(activity: Activity) {}
 
-    override fun onActivityPaused(activity: Activity) {
-        // Nothing
-    }
+    override fun onActivityResumed(activity: Activity) {}
 
-    override fun onActivityStopped(activity: Activity) {
-        // Nothing
-    }
+    override fun onActivityPaused(activity: Activity) {}
 
-    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
-        // Nothing
-    }
+    override fun onActivityStopped(activity: Activity) {}
 
-    override fun onActivityDestroyed(activity: Activity) {
-        // Nothing
-    }
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+
+    override fun onActivityDestroyed(activity: Activity) {}
 }

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
@@ -29,7 +29,6 @@ internal object ComScoreSrg : ComScore, Application.ActivityLifecycleCallbacks {
     private const val publisherId = "6036016"
     private val started = AtomicBoolean(false)
 
-
     /**
      * Init ComScore if [context] is an [Activity] we init ComScpre directly otherwise we start it when an [Activity] as been created.
      *
@@ -81,7 +80,7 @@ internal object ComScoreSrg : ComScore, Application.ActivityLifecycleCallbacks {
     internal fun start(appContext: Context) {
         if (!started.getAndSet(true)) {
             checkInitialized()
-            Log.i("COMSCORE", "Start")
+            Log.i("COMSCORE", "Start Comscore for SRG")
             Analytics.start(appContext)
         }
     }
@@ -128,7 +127,6 @@ internal object ComScoreSrg : ComScore, Application.ActivityLifecycleCallbacks {
     private fun checkInitialized() {
         requireNotNull(config) { "ComScore init has to be called before start." }
     }
-
 
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         start(activity.applicationContext)

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrg.kt
@@ -5,7 +5,9 @@
 package ch.srgssr.pillarbox.analytics.comscore
 
 import android.app.Activity
+import android.app.Application
 import android.content.Context
+import android.os.Bundle
 import android.util.Log
 import ch.srgssr.pillarbox.analytics.AnalyticsConfig
 import ch.srgssr.pillarbox.analytics.BuildConfig
@@ -22,10 +24,11 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * SRGSSR doc : https://confluence.srg.beecollaboration.com/pages/viewpage.action?pageId=13188965
  */
-internal object ComScoreSrg : ComScore {
+internal object ComScoreSrg : ComScore, Application.ActivityLifecycleCallbacks {
     private var config: AnalyticsConfig? = null
     private const val publisherId = "6036016"
     private val started = AtomicBoolean(false)
+
 
     /**
      * Init ComScore if [context] is an [Activity] we init ComScpre directly otherwise we start it when an [Activity] as been created.
@@ -71,7 +74,7 @@ internal object ComScoreSrg : ComScore {
         if (BuildConfig.DEBUG) {
             Analytics.getConfiguration().enableImplementationValidationMode()
         }
-        start(applicationContext)
+        (applicationContext as Application).registerActivityLifecycleCallbacks(this)
         return this
     }
 
@@ -124,5 +127,34 @@ internal object ComScoreSrg : ComScore {
 
     private fun checkInitialized() {
         requireNotNull(config) { "ComScore init has to be called before start." }
+    }
+
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        start(activity.applicationContext)
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivityPaused(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // Nothing
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+        // Nothing
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        // Nothing
     }
 }

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
@@ -39,6 +39,7 @@ class ComScoreSrgTest {
 
         mockkStatic(Analytics::class)
         ComScoreSrg.init(config = config, context = context)
+        ComScoreSrg.start(context)
     }
 
     @AfterTest


### PR DESCRIPTION
# Pull request

## Description

Some application hasn't been validated by Kantar / Comscore because of ghost start. Those ghost start may occurs when the `Application` is created in background and `Analytics.start` is called during `onCreate`. The application may be recrated in background when
- Push notification is received
- A background BroadCastReceiver receive event
- Probably Widget
- Any other background WorkManager or Service may create the application in background.

The goal of this PR is to start Comscore only when the first Activity is created. So we ensure that the start is send only when something is presented to the user.


## Changes made

- Comscore `Analytics.start` is send only when the first Activity is created.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
