### PR TITLE
Don't let Dependabot update ComScore and CommandersAct

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,5 @@ updates:
         patterns:
           - "androidx.*"
     ignore:
-      - dependency-name: "com.comscore:*
+      - dependency-name: "com.comscore:*"
       - dependency-name: "com.tagcommander.lib:*"
-      

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,4 +21,7 @@ updates:
       androidx:
         patterns:
           - "androidx.*"
+    ignore:
+      - dependency-name: "com.comscore:*
+      - dependency-name: "com.tagcommander.lib:*"
       


### PR DESCRIPTION
# Pull request

## Description

This PR updates Dependabot's configuration to ignore ComScore and CommandersAct dependencies. We will update them manually when needed.

## Changes made

- Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.