### PR TITLE
Avoid send null current chapter when not needed

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.player.tracker
 
+import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Player.DiscontinuityReason
@@ -137,7 +138,10 @@ private class ChapterCreditsTracker<T : TimeRange>(
             val timeRange = message as? T ?: return@Target
             when (messageType) {
                 TYPE_ENTER -> currentTimeRange = timeRange
-                TYPE_EXIT -> currentTimeRange = null
+                TYPE_EXIT -> {
+                    val nextTimeRange = timeRanges.firstOrNullAtPosition(player.currentPosition)
+                    if (nextTimeRange == null) currentTimeRange = null
+                }
             }
         }
         val playerMessages = mutableListOf<PlayerMessage>()
@@ -165,6 +169,7 @@ private class ChapterCreditsTracker<T : TimeRange>(
     }
 
     override fun clear() {
+        Log.d("Coucou", "Chapter cleared")
         currentTimeRange = null
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
@@ -4,7 +4,6 @@
  */
 package ch.srgssr.pillarbox.player.tracker
 
-import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Player.DiscontinuityReason
@@ -169,7 +168,6 @@ private class ChapterCreditsTracker<T : TimeRange>(
     }
 
     override fun clear() {
-        Log.d("Coucou", "Chapter cleared")
         currentTimeRange = null
     }
 

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/ChapterTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/ChapterTrackerTest.kt
@@ -68,12 +68,11 @@ class ChapterTrackerTest {
         player.addMediaItem(ChapterAssetLoader.MEDIA_ITEM)
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_ENDED)
 
-        val expectedChapters = listOf(ChapterAssetLoader.CHAPTER_1, null, ChapterAssetLoader.CHAPTER_2, null)
+        val expectedChapters = listOf(ChapterAssetLoader.CHAPTER_1, ChapterAssetLoader.CHAPTER_2, null)
         val receivedChapters = mutableListOf<Chapter?>()
         verify {
             listener.onChapterChanged(captureNullable(receivedChapters))
         }
-        assertEquals(expectedChapters.size, receivedChapters.size)
         assertEquals(expectedChapters, receivedChapters)
     }
 


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to avoid sending `onChapterChanged(null)` when seeking to a chapter start position and the previous chapter end position are the same.


## Changes made

- Self-explanatory.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
