### PR TITLE
580 implements custom listeners like media3

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTracker.kt
@@ -6,15 +6,15 @@ package ch.srgssr.pillarbox.core.business.tracker
 
 import android.util.Log
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.exoplayer.util.EventLogger
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
+import ch.srgssr.pillarbox.player.utils.PillarboxEventLogger
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Enable/Disable EventLogger when item is currently active.
  */
 class SRGEventLoggerTracker : MediaItemTracker {
-    private val eventLogger = EventLogger(TAG)
+    private val eventLogger = PillarboxEventLogger(TAG)
 
     override fun start(player: ExoPlayer, initialData: Any?) {
         Log.w(TAG, "---- Start")

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -77,7 +77,7 @@ class PillarboxExoPlayer internal constructor(
         set(value) {
             if (analyticsTracker.enabled != value) {
                 analyticsTracker.enabled = value
-                listeners.sendEvent(PillarboxPlayer.EVENT_SMOOTH_SEEKING_ENABLED_CHANGED) { listener ->
+                listeners.sendEvent(PillarboxPlayer.EVENT_TRACKING_ENABLED_CHANGED) { listener ->
                     listener.onTrackingEnabledChanged(value)
                 }
             }
@@ -88,7 +88,7 @@ class PillarboxExoPlayer internal constructor(
         this,
         object : TimeRangeTracker.Callback {
             override fun onBlockedTimeRange(blockedTimeRange: BlockedTimeRange) {
-                listeners.sendEvent(PillarboxPlayer.EVENT_CREDIT_CHANGED) { listener ->
+                listeners.sendEvent(PillarboxPlayer.EVENT_BLOCKED_TIME_RANGE_REACHED) { listener ->
                     listener.onBlockedTimeRangeReached(blockedTimeRange)
                 }
                 handleBlockedTimeRange(blockedTimeRange)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -326,6 +326,7 @@ class PillarboxExoPlayer internal constructor(
         if (playbackState != Player.STATE_IDLE) {
             stop()
         }
+        listeners.release()
         exoPlayer.release()
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -19,6 +19,7 @@ interface PillarboxPlayer : Player {
      * Listener
      */
     interface Listener : Player.Listener {
+
         /**
          * On smooth seeking enabled changed
          *
@@ -76,4 +77,32 @@ interface PillarboxPlayer : Player {
      * Enable or disable MediaItem tracking
      */
     var trackingEnabled: Boolean
+
+    companion object {
+
+        /**
+         * Event Blocked Time Range Reached.
+         */
+        const val EVENT_BLOCKED_TIME_RANGE_REACHED = 100
+
+        /**
+         * The current [Chapter] has changed.
+         */
+        const val EVENT_CHAPTER_CHANGED = 101
+
+        /**
+         * The current [Credit] Changed.
+         */
+        const val EVENT_CREDIT_CHANGED = 102
+
+        /**
+         * [trackingEnabled] has changed.
+         */
+        const val EVENT_TRACKING_ENABLED_CHANGED = 103
+
+        /**
+         * [smoothSeekingEnabled] has changed.
+         */
+        const val EVENT_SMOOTH_SEEKING_ENABLED_CHANGED = 104
+    }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.analytics
+
+import androidx.media3.common.util.Clock
+import androidx.media3.common.util.ListenerSet.Event
+import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
+import androidx.media3.exoplayer.analytics.DefaultAnalyticsCollector
+import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
+import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
+import ch.srgssr.pillarbox.player.asset.timeRange.Credit
+
+/**
+ * Pillarbox analytics collector
+ *
+ * @constructor
+ *
+ * @param clock The [Clock] used to generate timestamps.
+ */
+class PillarboxAnalyticsCollector(
+    clock: Clock = Clock.DEFAULT
+) : DefaultAnalyticsCollector(clock), PillarboxPlayer.Listener {
+
+    override fun onSmoothSeekingEnabledChanged(smoothSeekingEnabled: Boolean) {
+        val eventTime = generateCurrentPlayerMediaPeriodEventTime()
+
+        sendEventPillarbox(
+            eventTime, PillarboxAnalyticsListener.EVENT_SMOOTH_SEEKING_ENABLED_CHANGED
+        ) { listener -> listener.onSmoothSeekingEnabledChanged(eventTime, smoothSeekingEnabled) }
+    }
+
+    override fun onTrackingEnabledChanged(trackingEnabled: Boolean) {
+        val eventTime = generateCurrentPlayerMediaPeriodEventTime()
+
+        sendEventPillarbox(
+            eventTime, PillarboxAnalyticsListener.EVENT_TRACKING_ENABLED_CHANGED
+        ) { listener -> listener.onTrackingEnabledChanged(eventTime, trackingEnabled) }
+    }
+
+    override fun onChapterChanged(chapter: Chapter?) {
+        val eventTime = generateCurrentPlayerMediaPeriodEventTime()
+
+        sendEventPillarbox(
+            eventTime, PillarboxAnalyticsListener.EVENT_CHAPTER_CHANGED
+        ) { listener -> listener.onChapterChanged(eventTime, chapter) }
+    }
+
+    override fun onCreditChanged(credit: Credit?) {
+        val eventTime = generateCurrentPlayerMediaPeriodEventTime()
+
+        sendEventPillarbox(
+            eventTime, PillarboxAnalyticsListener.EVENT_CREDIT_CHANGED
+        ) { listener -> listener.onCreditChanged(eventTime, credit) }
+    }
+
+    override fun onBlockedTimeRangeReached(blockedTimeRange: BlockedTimeRange) {
+        val eventTime = generateCurrentPlayerMediaPeriodEventTime()
+
+        sendEventPillarbox(
+            eventTime, PillarboxAnalyticsListener.EVENT_BLOCKED_TIME_RANGE_REACHED
+        ) { listener -> listener.onBlockedTimeRangeReached(eventTime, blockedTimeRange) }
+    }
+
+    private fun sendEventPillarbox(eventTime: EventTime, eventFlag: Int, event: Event<PillarboxAnalyticsListener>) {
+        sendEvent(
+            eventTime, eventFlag
+        ) { listener -> if (listener is PillarboxAnalyticsListener) event.invoke(listener) }
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsListener.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsListener.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.analytics
+
+import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
+import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
+import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
+import ch.srgssr.pillarbox.player.asset.timeRange.Credit
+
+/**
+ * Pillarbox analytics listener
+ *
+ * @see [AnalyticsListener]
+ */
+interface PillarboxAnalyticsListener : AnalyticsListener {
+    /**
+     * On smooth seeking enabled changed
+     *
+     * @param eventTime The [EventTime].
+     * @param smoothSeekingEnabled The new value of [PillarboxPlayer.smoothSeekingEnabled]
+     */
+    fun onSmoothSeekingEnabledChanged(eventTime: EventTime, smoothSeekingEnabled: Boolean) {}
+
+    /**
+     * On tracking enabled changed
+     *
+     * @param eventTime The [EventTime].
+     * @param trackingEnabled The new value of [PillarboxPlayer.trackingEnabled]
+     */
+    fun onTrackingEnabledChanged(eventTime: EventTime, trackingEnabled: Boolean) {}
+
+    /**
+     * `onChapterChanged` is called when either:
+     * - The player position changes while playing automatically.
+     * - The use seeks to a new position.
+     * - The playlist changes.
+     *
+     * @param eventTime The [EventTime].
+     * @param chapter `null` when the current position is not in a chapter.
+     */
+    fun onChapterChanged(eventTime: EventTime, chapter: Chapter?) {}
+
+    /**
+     * On blocked time range reached
+     *
+     * @param eventTime The [EventTime].
+     * @param blockedTimeRange The [BlockedTimeRange] reached by the player.
+     */
+    fun onBlockedTimeRangeReached(eventTime: EventTime, blockedTimeRange: BlockedTimeRange) {}
+
+    /**
+     * `onCreditChanged` is called when either:
+     * - The player position changes while playing automatically.
+     * - The use seeks to a new position.
+     * - The playlist changes.
+     *
+     * @param eventTime The [EventTime]
+     * @param credit `null` when the current position is not in a Credit.
+     */
+    fun onCreditChanged(eventTime: EventTime, credit: Credit?) {}
+
+    companion object {
+        /**
+         * @see [PillarboxPlayer.EVENT_BLOCKED_TIME_RANGE_REACHED]
+         */
+        const val EVENT_BLOCKED_TIME_RANGE_REACHED = PillarboxPlayer.EVENT_BLOCKED_TIME_RANGE_REACHED
+
+        /**
+         * @see [PillarboxPlayer.EVENT_CREDIT_CHANGED]
+         */
+        const val EVENT_CREDIT_CHANGED = PillarboxPlayer.EVENT_CREDIT_CHANGED
+
+        /**
+         * @see [PillarboxPlayer.EVENT_CHAPTER_CHANGED]
+         */
+        const val EVENT_CHAPTER_CHANGED = PillarboxPlayer.EVENT_CHAPTER_CHANGED
+
+        /**
+         * @see [PillarboxPlayer.EVENT_TRACKING_ENABLED_CHANGED]
+         */
+        const val EVENT_TRACKING_ENABLED_CHANGED = PillarboxPlayer.EVENT_TRACKING_ENABLED_CHANGED
+
+        /**
+         * @see [PillarboxPlayer.EVENT_SMOOTH_SEEKING_ENABLED_CHANGED]
+         */
+        const val EVENT_SMOOTH_SEEKING_ENABLED_CHANGED = PillarboxPlayer.EVENT_SMOOTH_SEEKING_ENABLED_CHANGED
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaController.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaController.kt
@@ -618,6 +618,7 @@ open class PillarboxMediaController internal constructor() : PillarboxPlayer {
     }
 
     override fun release() {
+        listeners.release()
         mediaController.release()
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaController.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaController.kt
@@ -266,7 +266,8 @@ open class PillarboxMediaController internal constructor() : PillarboxPlayer {
 
             PillarboxSessionCommands.BLOCKED_CHANGED -> {
                 val blockedTimeRange: BlockedTimeRange? = BundleCompat.getParcelable(
-                    args, PillarboxSessionCommands.ARG_BLOCKED,
+                    args,
+                    PillarboxSessionCommands.ARG_BLOCKED,
                     BlockedTimeRange::class.java
                 )
                 blockedTimeRange?.let {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSession.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSession.kt
@@ -8,7 +8,6 @@ import android.app.PendingIntent
 import android.content.Context
 import android.os.Bundle
 import android.support.v4.media.session.MediaSessionCompat
-import android.util.Log
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.Util
 import androidx.media3.session.MediaLibraryService
@@ -203,7 +202,6 @@ open class PillarboxMediaSession internal constructor() {
                 putParcelable(PillarboxSessionCommands.ARG_CHAPTER_CHANGED, chapter)
             }
             _mediaSession.connectedControllers.forEach {
-                Log.d(TAG, "onChapterChanged $chapter")
                 _mediaSession.sendCustomCommand(it, PillarboxSessionCommands.COMMAND_CHAPTER_CHANGED, commandArg)
             }
         }
@@ -222,7 +220,6 @@ open class PillarboxMediaSession internal constructor() {
                 putParcelable(PillarboxSessionCommands.ARG_CREDIT, credit)
             }
             _mediaSession.connectedControllers.forEach {
-                Log.d("TAG", "onCreditChanged $credit")
                 _mediaSession.sendCustomCommand(it, PillarboxSessionCommands.COMMAND_CREDIT_CHANGED, commandArg)
             }
         }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
@@ -48,24 +48,9 @@ class PillarboxEventLogger(private val tag: String = "EventLogger") : EventLogge
     private fun getEventString(
         eventTime: EventTime,
         eventName: String,
-        eventDescription: String? = null,
-        throwable: Throwable? = null
+        eventDescription: String,
     ): String {
-        var eventString = eventName + " [" + getEventTimeString(eventTime)
-        if (throwable is PlaybackException) {
-            eventString += ", errorCode=" + throwable.errorCodeName
-        }
-        if (eventDescription != null) {
-            eventString += ", $eventDescription"
-        }
-        val throwableString = androidx.media3.common.util.Log.getThrowableString(throwable)
-        if (!TextUtils.isEmpty(throwableString)) {
-            eventString += """
-  ${throwableString!!.replace("\n", "\n  ")}
-"""
-        }
-        eventString += "]"
-        return eventString
+        return "$eventName [${getEventTimeString(eventTime)}, $eventDescription]"
     }
 
     private fun getEventTimeString(eventTime: EventTime): String {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
@@ -5,9 +5,7 @@
 package ch.srgssr.pillarbox.player.utils
 
 import android.os.SystemClock
-import android.text.TextUtils
 import android.util.Log
-import androidx.media3.common.PlaybackException
 import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
 import androidx.media3.exoplayer.util.EventLogger
 import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsListener

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
@@ -30,7 +30,7 @@ class PillarboxEventLogger(private val tag: String = "EventLogger") : EventLogge
     }
 
     override fun onSmoothSeekingEnabledChanged(eventTime: EventTime, smoothSeekingEnabled: Boolean) {
-        Log.d(tag, getEventString(eventTime, "SmoothSeekingEnabled", smoothSeekingEnabled.toString()))
+        Log.d(tag, getEventString(eventTime, "SmoothSeekingEnabledChanged", smoothSeekingEnabled.toString()))
     }
 
     override fun onBlockedTimeRangeReached(eventTime: EventTime, blockedTimeRange: BlockedTimeRange) {
@@ -69,22 +69,17 @@ class PillarboxEventLogger(private val tag: String = "EventLogger") : EventLogge
     }
 
     private fun getEventTimeString(eventTime: EventTime): String {
+        val mediaPeriodId = eventTime.mediaPeriodId
         var windowPeriodString = "window=" + eventTime.windowIndex
-        if (eventTime.mediaPeriodId != null) {
-            windowPeriodString +=
-                ", period=" + eventTime.timeline.getIndexOfPeriod(eventTime.mediaPeriodId!!.periodUid)
-            if (eventTime.mediaPeriodId!!.isAd) {
-                windowPeriodString += ", adGroup=" + eventTime.mediaPeriodId!!.adGroupIndex
-                windowPeriodString += ", ad=" + eventTime.mediaPeriodId!!.adIndexInAdGroup
+        if (mediaPeriodId != null) {
+            windowPeriodString += ", period=" + eventTime.timeline.getIndexOfPeriod(mediaPeriodId.periodUid)
+            if (mediaPeriodId.isAd) {
+                windowPeriodString += ", adGroup=" + mediaPeriodId.adGroupIndex
+                windowPeriodString += ", ad=" + mediaPeriodId.adIndexInAdGroup
             }
         }
-        return (
-            "eventTime=" +
-                (eventTime.realtimeMs - startTimeMs).milliseconds +
-                ", mediaPos=" +
-                eventTime.eventPlaybackPositionMs.milliseconds +
-                ", " +
-                windowPeriodString
-            )
+        return "eventTime=" + (eventTime.realtimeMs - startTimeMs).milliseconds +
+            ", mediaPos=" + eventTime.eventPlaybackPositionMs.milliseconds +
+            ", " + windowPeriodString
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/PillarboxEventLogger.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.utils
+
+import android.os.SystemClock
+import android.text.TextUtils
+import android.util.Log
+import androidx.media3.common.PlaybackException
+import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
+import androidx.media3.exoplayer.util.EventLogger
+import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsListener
+import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
+import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
+import ch.srgssr.pillarbox.player.asset.timeRange.Credit
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Pillarbox event logger
+ *
+ * @param tag The tag to use for logging
+ * @constructor Create empty Pillarbox event logger
+ */
+class PillarboxEventLogger(private val tag: String = "EventLogger") : EventLogger(tag), PillarboxAnalyticsListener {
+    private val startTimeMs: Long = SystemClock.elapsedRealtime()
+
+    override fun onTrackingEnabledChanged(eventTime: EventTime, trackingEnabled: Boolean) {
+        Log.d(tag, getEventString(eventTime, "TrackingEnabledChanged", trackingEnabled.toString()))
+    }
+
+    override fun onSmoothSeekingEnabledChanged(eventTime: EventTime, smoothSeekingEnabled: Boolean) {
+        Log.d(tag, getEventString(eventTime, "SmoothSeekingEnabled", smoothSeekingEnabled.toString()))
+    }
+
+    override fun onBlockedTimeRangeReached(eventTime: EventTime, blockedTimeRange: BlockedTimeRange) {
+        Log.d(tag, getEventString(eventTime, "BlockedTimeRangeReached", blockedTimeRange.toString()))
+    }
+
+    override fun onCreditChanged(eventTime: EventTime, credit: Credit?) {
+        Log.d(tag, getEventString(eventTime, "CreditChanged", credit.toString()))
+    }
+
+    override fun onChapterChanged(eventTime: EventTime, chapter: Chapter?) {
+        Log.d(tag, getEventString(eventTime, "ChapterChanged", chapter.toString()))
+    }
+
+    private fun getEventString(
+        eventTime: EventTime,
+        eventName: String,
+        eventDescription: String? = null,
+        throwable: Throwable? = null
+    ): String {
+        var eventString = eventName + " [" + getEventTimeString(eventTime)
+        if (throwable is PlaybackException) {
+            eventString += ", errorCode=" + throwable.errorCodeName
+        }
+        if (eventDescription != null) {
+            eventString += ", $eventDescription"
+        }
+        val throwableString = androidx.media3.common.util.Log.getThrowableString(throwable)
+        if (!TextUtils.isEmpty(throwableString)) {
+            eventString += """
+  ${throwableString!!.replace("\n", "\n  ")}
+"""
+        }
+        eventString += "]"
+        return eventString
+    }
+
+    private fun getEventTimeString(eventTime: EventTime): String {
+        var windowPeriodString = "window=" + eventTime.windowIndex
+        if (eventTime.mediaPeriodId != null) {
+            windowPeriodString +=
+                ", period=" + eventTime.timeline.getIndexOfPeriod(eventTime.mediaPeriodId!!.periodUid)
+            if (eventTime.mediaPeriodId!!.isAd) {
+                windowPeriodString += ", adGroup=" + eventTime.mediaPeriodId!!.adGroupIndex
+                windowPeriodString += ", ad=" + eventTime.mediaPeriodId!!.adIndexInAdGroup
+            }
+        }
+        return (
+            "eventTime=" +
+                (eventTime.realtimeMs - startTimeMs).milliseconds +
+                ", mediaPos=" +
+                eventTime.eventPlaybackPositionMs.milliseconds +
+                ", " +
+                windowPeriodString
+            )
+    }
+}


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to handle custom Pillarbox listener like Exoplayer does.

It allows integrators to do things like that:

```kotlin
class MyListener: PillarboxListener {
    override fun onEvents(player:Player, events: Player.Events) {
            if(events.contains(PillarboxPlayer.EVENT_CHAPTER_CHANGED) {
               doSomething()
            }
    }
}

player.addListener(MyListener())
```

And the same with `AnalyticsListener` with `PillarboxAnalyticsListener`.


## Changes made

- Introduce `PillarboxAnalyticsListener`
- Change `PillarboxExoPlayer` listener handling
- Introduce `PillarboxEventLogger` to log pillarbox events like `EventLogger`.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
