### PR TITLE
Fix: use `runUntilPendingCommandsAreFullyHandled` in `CommandersActTrackerIntegrationTest`

### DIFF
--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -122,7 +122,7 @@ class CommandersActTrackerIntegrationTest {
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         player.setMediaItem(SRGMediaItemBuilder(URN_NOT_LIVE_VIDEO).build())
         player.playWhenReady = true
@@ -214,7 +214,7 @@ class CommandersActTrackerIntegrationTest {
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         verifyOrder {
             commandersAct.enableRunningInBackground()
@@ -239,7 +239,7 @@ class CommandersActTrackerIntegrationTest {
         player.setPlaybackSpeed(2f)
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         verifyOrder {
             commandersAct.enableRunningInBackground()
@@ -263,7 +263,7 @@ class CommandersActTrackerIntegrationTest {
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         clock.advanceTime(5.minutes.inWholeMilliseconds)
         player.setPlaybackSpeed(2f)
@@ -292,7 +292,7 @@ class CommandersActTrackerIntegrationTest {
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         clock.advanceTime(2.minutes.inWholeMilliseconds)
         player.playWhenReady = false
@@ -327,7 +327,7 @@ class CommandersActTrackerIntegrationTest {
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         clock.advanceTime(2.minutes.inWholeMilliseconds)
         player.playWhenReady = false
@@ -373,7 +373,7 @@ class CommandersActTrackerIntegrationTest {
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         clock.advanceTime(2.minutes.inWholeMilliseconds)
         player.stop()
@@ -621,7 +621,7 @@ class CommandersActTrackerIntegrationTest {
         player.playWhenReady = true
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 0)
+        TestPlayerRunHelper.runUntilPendingCommandsAreFullyHandled(player)
 
         clock.advanceTime(playTime.inWholeMilliseconds)
         advanceTimeBy(playTime)

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
@@ -359,7 +359,6 @@ class ComScoreTrackerIntegrationTest {
     }
 
     @Test
-    @Ignore("Need a live DVR available outside of Switzerland")
     fun `live - player prepared, playing and seeking`() {
         player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()
@@ -391,7 +390,6 @@ class ComScoreTrackerIntegrationTest {
     }
 
     @Test
-    @Ignore("Need a live DVR available outside of Switzerland")
     fun `live - player prepared and seek`() {
         player.setMediaItem(SRGMediaItemBuilder(URN_LIVE_VIDEO).build())
         player.prepare()


### PR DESCRIPTION
# Pull request

## Description

This commit replaces `playUntilStartOfMediaItem` with `runUntilPendingCommandsAreFullyHandled` in the `CommandersActTrackerIntegrationTest` file.

## Changes made

- Switch from `playUntilStartOfMediaItem` to `runUntilPendingCommandsAreFullyHandled` in `CommandersActTrackerIntegrationTest`.
- Try to enable two `@Ignore`d tests in `ComScoreTrackerIntegrationTest`.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.