### PR TITLE
PLAY-6636 CommandersAct media event send media_audiodescription_on

### DIFF
--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEvent.kt
@@ -53,6 +53,11 @@ class TCMediaEvent(
      */
     var audioTrackLanguage: String? = null
 
+    /**
+     * Audio track has audio description
+     */
+    var audioTrackHasAudioDescription: Boolean = false
+
     override fun getJsonObject(): JSONObject {
         val jsonObject = super.getJsonObject()
         for (asset in assets) {
@@ -75,6 +80,7 @@ class TCMediaEvent(
         audioTrackLanguage?.let {
             jsonObject.putIfValid(MEDIA_AUDIO_TRACK, it.uppercase())
         }
+        jsonObject.putIfValid(MEDIA_AUDIO_DESCRIPTION_ON, audioTrackHasAudioDescription.toString())
 
         return jsonObject
     }
@@ -94,6 +100,7 @@ class TCMediaEvent(
         private const val MEDIA_SUBTITLES_ON = "media_subtitles_on"
         private const val MEDIA_AUDIO_TRACK = "media_audio_track"
         private const val MEDIA_SUBTITLE_SELECTION = "media_subtitle_selection"
+        private const val MEDIA_AUDIO_DESCRIPTION_ON = "media_audiodescription_on"
         private const val KEY_SOURCE_ID = "source_id"
 
         private fun toSeconds(duration: Duration): Long {

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEventTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TCMediaEventTest.kt
@@ -20,7 +20,7 @@ class TCMediaEventTest {
         )
         val json = tcEvent.jsonObject
 
-        assertEquals(6, json.length())
+        assertEquals(7, json.length())
 
         // Properties set by TCEvent
         assertEquals("play", json.getString("event_name"))
@@ -34,6 +34,7 @@ class TCMediaEventTest {
         assertEquals(BuildConfig.VERSION_NAME, json.getString("media_player_version"))
         assertEquals("Pillarbox", json.getString("media_player_display"))
         assertEquals("false", json.getString("media_subtitles_on"))
+        assertEquals("false", json.getString("media_audiodescription_on"))
     }
 
     @Test
@@ -54,10 +55,11 @@ class TCMediaEventTest {
             isSubtitlesOn = true
             subtitleSelectionLanguage = "German"
             audioTrackLanguage = "French"
+            audioTrackHasAudioDescription = true
         }
         val json = tcEvent.jsonObject
 
-        assertEquals(13, json.length())
+        assertEquals(14, json.length())
 
         // Properties set by TCEvent
         assertEquals("play", json.getString("event_name"))
@@ -78,5 +80,6 @@ class TCMediaEventTest {
         assertEquals("true", json.getString("media_subtitles_on"))
         assertEquals("GERMAN", json.getString("media_subtitle_selection"))
         assertEquals("FRENCH", json.getString("media_audio_track"))
+        assertEquals("true", json.getString("media_audiodescription_on"))
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActStreaming.kt
@@ -13,6 +13,7 @@ import ch.srgssr.pillarbox.analytics.commandersact.CommandersAct
 import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType
 import ch.srgssr.pillarbox.analytics.commandersact.TCMediaEvent
 import ch.srgssr.pillarbox.core.business.tracker.TotalPlaytimeCounter
+import ch.srgssr.pillarbox.player.extension.hasAccessibilityRoles
 import ch.srgssr.pillarbox.player.extension.isForced
 import ch.srgssr.pillarbox.player.tracks.audioTracks
 import ch.srgssr.pillarbox.player.utils.DebugLogger
@@ -234,14 +235,15 @@ internal class CommandersActStreaming(
     }
 
     private fun handleAudioTrack(event: TCMediaEvent) {
-        val audioTrackLanguage = player.currentTracks
-            .audioTracks
-            .find { it.isSelected }
+        val currentAudioTrack = player.currentTracks.audioTracks.find { it.isSelected }
+        val audioTrackLanguage = currentAudioTrack
             ?.format
             ?.language
             ?: C.LANGUAGE_UNDETERMINED
 
         event.audioTrackLanguage = audioTrackLanguage
+
+        event.audioTrackHasAudioDescription = currentAudioTrack?.format?.hasAccessibilityRoles() ?: false
     }
 
     companion object {

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoItem.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoItem.kt
@@ -447,5 +447,12 @@ data class DemoItem(
             uri = "urn:srf:video:d57f5c1c-080f-49a2-864e-4a1a83e41ae1",
             imageUrl = "https://ws.srf.ch/asset/image/audio/75c3d4a4-4357-4703-b407-2d076aa15fd7/EPISODE_IMAGE/1384985072.png"
         )
+
+        val MultiAudioWithAccessibility = DemoItem(
+            title = "Multi audio with AD track",
+            description = "Bonjour la Suisse (5/5) - Que du bonheur?",
+            uri = "urn:rts:video:8806923",
+            imageUrl = "https://www.rts.ch/2017/07/28/21/11/8806915.image/16x9"
+        )
     }
 }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
@@ -133,6 +133,7 @@ data class Playlist(val title: String, val items: List<DemoItem>, val descriptio
                     uri = "urn:srf:audio:b9706015-632f-4e24-9128-5de074d98eda",
                     description = "On-demand audio stream"
                 ),
+                DemoItem.MultiAudioWithAccessibility,
                 DemoItem.BlockedSegment,
                 DemoItem.OverlapinglockedSegments
             )

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/PlayerView.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/PlayerView.kt
@@ -267,7 +267,8 @@ private fun PlayerTimeRow(
 
     @Suppress("Indentation", "Wrapping")
     val onSeekProxy = remember(durationMs, positionMs) {
-        { newPosition: Long ->
+        {
+                newPosition: Long ->
             if (newPosition in 0..durationMs && newPosition != positionMs) {
                 onSeek(newPosition)
             }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to add `media_audiodescription_on` with CommandersAct media event when the current audio track has audio description.

## Changes made

- Self-explanatory

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
