### PR TITLE
Remove usage of `List.removeIf`

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/components/Charts.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/components/Charts.kt
@@ -475,8 +475,10 @@ private fun generateRandomPreviewLiveData(
                 (data.last() + Random.nextDouble(nextItemVariation.start, nextItemVariation.endInclusive).toFloat()).coerceAtLeast(0f)
             }
 
-            data.add(newValue)
-            data.removeIf { data.size > dataSize }
+            val newData = (data + newValue).takeLast(dataSize)
+
+            data.clear()
+            data.addAll(newData)
 
             delay(refreshInterval)
         }


### PR DESCRIPTION
# Pull request

## Description

The `List.removeIf()` method was introduced in API 24 and our min is API 21.
This PR removes its usage in `Charts` in favor of an other approach to address the warning that Android Lint started to report.

## Changes made

- Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.