### PR TITLE
Enable edge-to-edge in the demo application

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/MainActivity.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.demo
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -20,7 +21,10 @@ import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
  */
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+
         super.onCreate(savedInstanceState)
+
         setContent {
             PillarboxTheme {
                 // A surface container using the 'background' color from the theme

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -15,8 +15,10 @@ import android.os.Bundle
 import android.os.IBinder
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
@@ -45,11 +47,11 @@ import java.net.URL
 /**
  * Simple player activity that can handle picture in picture.
  *
- * It handle basic background playback, as it will stop playback when the Activity is destroyed!
- * To have pure background playback with good integration from other device like Auto, Wear, etc... we need *MediaSessionService*
+ * It handles basic background playback, as it will stop playback when the Activity is destroyed!
+ * To have pure background playback with good integration from other devices like Auto, Wear, etc... we need *MediaSessionService*
  *
  * For this demo, only the picture in picture button can enable picture in picture.
- * But feel free to call [startPictureInPicture] whenever you decide, for example when [onUserLeaveHint]
+ * But feel free to call [startPictureInPicture] whenever you decide, for example, when [onUserLeaveHint]
  */
 class SimplePlayerActivity : ComponentActivity(), ServiceConnection {
 
@@ -64,7 +66,10 @@ class SimplePlayerActivity : ComponentActivity(), ServiceConnection {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+
         super.onCreate(savedInstanceState)
+
         val ilHost = IntentCompat.getSerializableExtra(intent, ARG_IL_HOST, URL::class.java) ?: IlHost.DEFAULT
         playerViewModel = ViewModelProvider(this, factory = SimplePlayerViewModel.Factory(application, ilHost))[SimplePlayerViewModel::class.java]
         readIntent(intent)
@@ -83,7 +88,12 @@ class SimplePlayerActivity : ComponentActivity(), ServiceConnection {
         bindPlaybackService()
         setContent {
             PillarboxTheme {
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                Surface(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .statusBarsPadding(),
+                    color = MaterialTheme.colorScheme.background,
+                ) {
                     MainContent(playerViewModel.player)
                 }
             }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -10,14 +10,17 @@ import android.content.Context
 import android.content.Intent
 import android.content.ServiceConnection
 import android.content.res.Configuration
+import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
 import android.os.IBinder
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -66,7 +69,10 @@ class SimplePlayerActivity : ComponentActivity(), ServiceConnection {
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(Color.BLACK),
+            navigationBarStyle = SystemBarStyle.dark(Color.BLACK),
+        )
 
         super.onCreate(savedInstanceState)
 
@@ -91,7 +97,8 @@ class SimplePlayerActivity : ComponentActivity(), ServiceConnection {
                 Surface(
                     modifier = Modifier
                         .fillMaxSize()
-                        .statusBarsPadding(),
+                        .statusBarsPadding()
+                        .navigationBarsPadding(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
                     MainContent(playerViewModel.player)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/search/SearchHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/search/SearchHome.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -287,7 +288,8 @@ private fun SearchInput(
                 }
             }
         },
-        shape = MaterialTheme.shapes.large
+        shape = MaterialTheme.shapes.large,
+        windowInsets = WindowInsets(0.dp),
     ) {}
 
     LaunchedEffect(Unit) {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/PillarboxTheme.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/theme/PillarboxTheme.kt
@@ -4,17 +4,12 @@
  */
 package ch.srgssr.pillarbox.demo.ui.theme
 
-import android.app.Activity
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 import ch.srgssr.pillarbox.demo.shared.ui.theme.md_theme_dark_background
 import ch.srgssr.pillarbox.demo.shared.ui.theme.md_theme_dark_error
 import ch.srgssr.pillarbox.demo.shared.ui.theme.md_theme_dark_errorContainer
@@ -155,15 +150,6 @@ fun PillarboxTheme(
         darkColorScheme
     } else {
         lightColorScheme
-    }
-
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
     }
 
     MaterialTheme(colorScheme = colorScheme) {

--- a/pillarbox-demo/src/main/res/values-night/themes.xml
+++ b/pillarbox-demo/src/main/res/values-night/themes.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="Theme.PillarboxDemo" parent="android:Theme.Material.NoActionBar" />
+</resources>


### PR DESCRIPTION
# Pull request

## Description

This PR enables edge-to-edge in the demo application. This makes the status bar and navigation bar more integrated in the design of the app.

## Screenshots

| Light mode | Dark mode |
|-----|-----|
| ![Screenshot_20240729_172400](https://github.com/user-attachments/assets/b9fceb5f-0106-4d6e-a566-2f53c4f6740f) | ![Screenshot_20240729_172352](https://github.com/user-attachments/assets/263bd28b-bf16-4e6f-b1b0-ab4774d5368f) |

## Changes made

- Enable edge-to-edge.
- Adjust `SimplePlayerActivity` so it does not go behind the status bar.
- Disable the default inset on the search bar.
- Remove manual status bar color management.
- Add XML theme for dark mode.
- Fix some typos.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.