### PR TITLE
Display metrics overlay in the TV demo and add a dedicated setting

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/metrics/MetricsOverlay.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/metrics/MetricsOverlay.kt
@@ -2,13 +2,14 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.demo.ui.player.metrics
+package ch.srgssr.pillarbox.demo.shared.ui.player.metrics
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
@@ -108,7 +109,13 @@ private fun OverlayText(
 ) {
     BasicText(
         modifier = modifier,
-        style = TextStyle.Default.copy(fontSize = overlayOptions.textSize),
+        style = TextStyle.Default.copy(
+            fontSize = overlayOptions.textSize,
+            shadow = Shadow(
+                color = Color.Black,
+                blurRadius = 4f,
+            ),
+        ),
         color = { overlayOptions.textColor },
         text = text,
     )

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/metrics/MetricsOverlay.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/metrics/MetricsOverlay.kt
@@ -10,9 +10,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shadow
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.sp
 import androidx.media3.common.Format
 import ch.srgssr.pillarbox.demo.shared.ui.settings.MetricsOverlayOptions
 import ch.srgssr.pillarbox.player.analytics.metrics.PlaybackMetrics
@@ -109,8 +107,7 @@ private fun OverlayText(
 ) {
     BasicText(
         modifier = modifier,
-        style = TextStyle.Default.copy(
-            fontSize = overlayOptions.textSize,
+        style = overlayOptions.textStyle.copy(
             shadow = Shadow(
                 color = Color.Black,
                 blurRadius = 4f,
@@ -124,7 +121,7 @@ private fun OverlayText(
 @Preview
 @Composable
 private fun OverlayTextPreview() {
-    val overlayOptions = MetricsOverlayOptions(textColor = Color.Yellow, textSize = 12.sp)
+    val overlayOptions = MetricsOverlayOptions()
     OverlayText(text = "Text; 12 ac1.mp3 channels:4 colors:4", overlayOptions = overlayOptions)
 }
 

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/settings/PlayerSettingsViewModel.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/settings/PlayerSettingsViewModel.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.demo.shared.ui.player.settings
 
 import android.app.Application
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Analytics
 import androidx.compose.material.icons.filled.ClosedCaption
 import androidx.compose.material.icons.filled.RecordVoiceOver
 import androidx.compose.material.icons.filled.SlowMotionVideo
@@ -16,7 +17,10 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.C
 import androidx.media3.common.Player
+import androidx.media3.common.TrackSelectionParameters
 import ch.srgssr.pillarbox.demo.shared.R
+import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettings
+import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsRepository
 import ch.srgssr.pillarbox.player.extension.displayName
 import ch.srgssr.pillarbox.player.extension.getPlaybackSpeed
 import ch.srgssr.pillarbox.player.extension.isAudioTrackDisabled
@@ -41,16 +45,19 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 /**
  * Player settings view model
  *
- * @constructor Create empty Player settings view model
+ * @constructor Create an empty Player settings `ViewModel`
  */
 class PlayerSettingsViewModel(
     private val player: Player,
-    private val application: Application
+    private val application: Application,
 ) : AndroidViewModel(application) {
+    private val appSettingsRepository = AppSettingsRepository(application)
+
     private val trackSelectionParameters = player.getTrackSelectionParametersAsFlow()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), player.trackSelectionParameters)
 
@@ -59,6 +66,9 @@ class PlayerSettingsViewModel(
 
     private val playbackSpeed = player.getPlaybackSpeedAsFlow()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), player.getPlaybackSpeed())
+
+    private val appSettings = appSettingsRepository.getAppSettings()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), AppSettings())
 
     /**
      * All the available subtitle for the current [player].
@@ -128,7 +138,15 @@ class PlayerSettingsViewModel(
         videoTracks,
         trackSelectionParameters,
         playbackSpeed,
-    ) { subtitles, audioTracks, videoTracks, trackSelectionParameters, playbackSpeed ->
+        appSettings,
+    ) { settings ->
+        val subtitles = settings[SETTING_INDEX_SUBTITLES] as TracksSettingItem?
+        val audioTracks = settings[SETTING_INDEX_AUDIO_TRACKS] as TracksSettingItem?
+        val videoTracks = settings[SETTING_INDEX_VIDEO_TRACKS] as TracksSettingItem?
+        val trackSelectionParameters = settings[SETTING_INDEX_TRACK_SELECTION_PARAMETERS] as TrackSelectionParameters
+        val playbackSpeed = settings[SETTING_INDEX_PLAYBACK_SPEED] as Float
+        val appSettings = settings[SETTING_INDEX_APP_SETTINGS] as AppSettings
+
         buildList {
             add(
                 SettingItem(
@@ -180,6 +198,19 @@ class PlayerSettingsViewModel(
                     )
                 )
             }
+
+            add(
+                SettingItem(
+                    title = application.getString(R.string.metrics_overlay),
+                    subtitle = if (appSettings.metricsOverlayEnabled) {
+                        application.getString(R.string.metrics_overlay_enabled)
+                    } else {
+                        application.getString(R.string.metrics_overlay_disabled)
+                    },
+                    icon = Icons.Default.Analytics,
+                    destination = SettingsRoutes.MetricsOverlay(appSettings.metricsOverlayEnabled),
+                )
+            )
         }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), emptyList())
 
@@ -243,6 +274,17 @@ class PlayerSettingsViewModel(
         player.setPlaybackSpeed(playbackSpeed.rawSpeed)
     }
 
+    /**
+     * Enable or disable the metrics overlay.
+     *
+     * @param enabled
+     */
+    fun setMetricsOverlayEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            appSettingsRepository.setMetricsOverlayEnabled(enabled)
+        }
+    }
+
     private fun getTracksSubtitle(
         tracks: List<Track>,
         disabled: Boolean,
@@ -252,8 +294,7 @@ class PlayerSettingsViewModel(
         } else {
             tracks.filter { it.isSelected }
                 .map { it.format.displayName }
-                .filter { it != C.LANGUAGE_UNDETERMINED }
-                .firstOrNull()
+                .firstOrNull { it != C.LANGUAGE_UNDETERMINED }
         }
     }
 
@@ -267,6 +308,13 @@ class PlayerSettingsViewModel(
 
     private companion object {
         private val speeds = floatArrayOf(0.25f, 0.5f, 0.75f, 1f, 1.25f, 1.5f, 1.75f, 2f)
+
+        private const val SETTING_INDEX_SUBTITLES = 0
+        private const val SETTING_INDEX_AUDIO_TRACKS = 1
+        private const val SETTING_INDEX_VIDEO_TRACKS = 2
+        private const val SETTING_INDEX_TRACK_SELECTION_PARAMETERS = 3
+        private const val SETTING_INDEX_PLAYBACK_SPEED = 4
+        private const val SETTING_INDEX_APP_SETTINGS = 5
     }
 
     /**
@@ -274,7 +322,7 @@ class PlayerSettingsViewModel(
      *
      * @param player
      * @param application
-     * @constructor Create empty Factory
+     * @constructor Create an empty Factory
      */
     @Suppress("UndocumentedPublicClass")
     class Factory(

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/settings/SettingsRoutes.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/settings/SettingsRoutes.kt
@@ -34,4 +34,13 @@ sealed class SettingsRoutes(val route: String) {
      * The route for the video track setting.
      */
     data object VideoTrack : SettingsRoutes(route = "settings/video_track")
+
+    /**
+     * The route for the metrics overlay setting.
+     *
+     * @property enabled Whether the metrics overlay is enabled.
+     */
+    data class MetricsOverlay(
+        val enabled: Boolean,
+    ) : SettingsRoutes(route = "settings/metrics_overlay")
 }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/AppSettings.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/AppSettings.kt
@@ -27,9 +27,9 @@ class AppSettings(
      * @property size the [TextUnit].
      */
     enum class TextSize(val size: TextUnit) {
-        Small(8.sp),
-        Medium(12.sp),
-        Large(18.sp),
+        Small(12.sp),
+        Medium(14.sp),
+        Large(16.sp),
     }
 
     /**

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/AppSettings.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/AppSettings.kt
@@ -5,8 +5,6 @@
 package ch.srgssr.pillarbox.demo.shared.ui.settings
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.TextUnit
-import androidx.compose.ui.unit.sp
 
 /**
  * App settings
@@ -23,13 +21,11 @@ class AppSettings(
 
     /**
      * Text size
-     *
-     * @property size the [TextUnit].
      */
-    enum class TextSize(val size: TextUnit) {
-        Small(12.sp),
-        Medium(14.sp),
-        Large(16.sp),
+    enum class TextSize {
+        Small,
+        Medium,
+        Large,
     }
 
     /**

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/AppSettingsViewModel.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/AppSettingsViewModel.kt
@@ -7,6 +7,8 @@ package ch.srgssr.pillarbox.demo.shared.ui.settings
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -20,6 +22,7 @@ class AppSettingsViewModel(private val appSettingsRepository: AppSettingsReposit
      * Current app settings
      */
     val currentAppSettings = appSettingsRepository.getAppSettings()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(), AppSettings())
 
     /**
      * Set metrics overlay enabled

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/MetricsOverlayOptions.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/settings/MetricsOverlayOptions.kt
@@ -5,16 +5,15 @@
 package ch.srgssr.pillarbox.demo.shared.ui.settings
 
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.text.TextStyle
 
 /**
  * Metrics overlay options
  *
  * @property textColor The [Color] for the text overlay.
- * @property textSize The [TextUnit] for the text overlay.
+ * @property textStyle The [TextStyle] for the text overlay.
  */
-
 data class MetricsOverlayOptions(
     val textColor: Color = Color.Yellow,
-    val textSize: TextUnit = TextUnit.Unspecified,
+    val textStyle: TextStyle = TextStyle.Default,
 )

--- a/pillarbox-demo-shared/src/main/res/values/strings.xml
+++ b/pillarbox-demo-shared/src/main/res/values/strings.xml
@@ -14,6 +14,9 @@
     <string name="settings">Settings</string>
     <string name="audio_track">Audio tracks</string>
     <string name="video_tracks">Video tracks</string>
+    <string name="metrics_overlay">Metrics Overlay</string>
+    <string name="metrics_overlay_enabled">Enabled</string>
+    <string name="metrics_overlay_disabled">Disabled</string>
     <string name="subtitles">Subtitles</string>
     <string name="speed">Speed</string>
     <string name="speed_normal">Normal</string>

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/PlayerActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/PlayerActivity.kt
@@ -9,11 +9,17 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.viewModels
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.IntentCompat
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
+import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsRepository
+import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsViewModel
+import ch.srgssr.pillarbox.demo.shared.ui.settings.MetricsOverlayOptions
 import ch.srgssr.pillarbox.demo.tv.ui.player.compose.PlayerView
 import ch.srgssr.pillarbox.demo.tv.ui.theme.PillarboxTheme
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
@@ -27,6 +33,9 @@ import ch.srgssr.pillarbox.player.session.PillarboxMediaSession
 class PlayerActivity : ComponentActivity() {
     private lateinit var player: PillarboxExoPlayer
     private lateinit var mediaSession: PillarboxMediaSession
+    private val appSettingsViewModel by viewModels<AppSettingsViewModel> {
+        AppSettingsViewModel.Factory(AppSettingsRepository(this))
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -45,9 +54,16 @@ class PlayerActivity : ComponentActivity() {
 
         setContent {
             PillarboxTheme {
+                val appSettings by appSettingsViewModel.currentAppSettings.collectAsState()
+
                 PlayerView(
                     player = player,
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
+                    metricsOverlayEnabled = appSettings.metricsOverlayEnabled,
+                    metricsOverlayOptions = MetricsOverlayOptions(
+                        textColor = appSettings.metricsOverlayTextColor.color,
+                        textSize = appSettings.metricsOverlayTextSize.size,
+                    ),
                 )
             }
         }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/PlayerActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/PlayerActivity.kt
@@ -15,8 +15,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.core.content.IntentCompat
+import androidx.tv.material3.MaterialTheme
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
+import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettings
 import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsRepository
 import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsViewModel
 import ch.srgssr.pillarbox.demo.shared.ui.settings.MetricsOverlayOptions
@@ -62,7 +64,11 @@ class PlayerActivity : ComponentActivity() {
                     metricsOverlayEnabled = appSettings.metricsOverlayEnabled,
                     metricsOverlayOptions = MetricsOverlayOptions(
                         textColor = appSettings.metricsOverlayTextColor.color,
-                        textSize = appSettings.metricsOverlayTextSize.size,
+                        textStyle = when (appSettings.metricsOverlayTextSize) {
+                            AppSettings.TextSize.Small -> MaterialTheme.typography.bodySmall
+                            AppSettings.TextSize.Medium -> MaterialTheme.typography.bodyMedium
+                            AppSettings.TextSize.Large -> MaterialTheme.typography.bodyLarge
+                        },
                     ),
                 )
             }

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/PlayerView.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/PlayerView.kt
@@ -143,9 +143,11 @@ fun PlayerView(
                     )
 
                     if (metricsOverlayEnabled) {
-                        val currentMetrics by player.currentPositionAsFlow(updateInterval = 500.milliseconds)
-                            .map { player.getCurrentMetrics() }
-                            .collectAsState(initial = player.getCurrentMetrics())
+                        val currentMetricsFlow = remember(player) {
+                            player.currentPositionAsFlow(updateInterval = 500.milliseconds)
+                                .map { player.getCurrentMetrics() }
+                        }
+                        val currentMetrics by currentMetricsFlow.collectAsState(initial = player.getCurrentMetrics())
 
                         currentMetrics?.let {
                             MetricsOverlay(

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/settings/PlaybackSettingsDrawer.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/settings/PlaybackSettingsDrawer.kt
@@ -147,7 +147,13 @@ private fun NavigationDrawerScope.NavigationDrawerNavHost(
                 items = settings,
                 isItemSelected = { false },
                 onItemClick = { setting ->
-                    navController.navigate(setting.destination.route)
+                    val destination = setting.destination
+
+                    if (destination is SettingsRoutes.MetricsOverlay) {
+                        settingsViewModel.setMetricsOverlayEnabled(!destination.enabled)
+                    } else {
+                        navController.navigate(destination.route)
+                    }
                 },
                 leadingContent = { setting ->
                     Icon(

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
@@ -25,6 +25,7 @@ import androidx.media3.common.Player
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettings
 import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsRepository
 import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsViewModel
 import ch.srgssr.pillarbox.demo.shared.ui.settings.MetricsOverlayOptions
@@ -45,7 +46,7 @@ import com.google.accompanist.navigation.material.rememberBottomSheetNavigator
  * @param player The [Player] to observe.
  * @param modifier The modifier to be applied to the layout.
  * @param pictureInPicture The picture in picture state.
- * @param pictureInPictureClick he picture in picture button action. If null no button.
+ * @param pictureInPictureClick The picture in picture button action. If `null` no button is displayed.
  * @param displayPlaylist If it displays playlist ui or not.
  */
 @OptIn(ExperimentalMaterialNavigationApi::class)
@@ -141,7 +142,11 @@ private fun PlayerContent(
             overlayEnabled = appSettings.metricsOverlayEnabled,
             overlayOptions = MetricsOverlayOptions(
                 textColor = appSettings.metricsOverlayTextColor.color,
-                textSize = appSettings.metricsOverlayTextSize.size
+                textStyle = when (appSettings.metricsOverlayTextSize) {
+                    AppSettings.TextSize.Small -> MaterialTheme.typography.bodySmall
+                    AppSettings.TextSize.Medium -> MaterialTheme.typography.bodyMedium
+                    AppSettings.TextSize.Large -> MaterialTheme.typography.bodyLarge
+                },
             ),
         ) {
             PlayerBottomToolbar(

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/DemoPlayerView.kt
@@ -20,12 +20,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.media3.common.Player
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettings
 import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsRepository
+import ch.srgssr.pillarbox.demo.shared.ui.settings.AppSettingsViewModel
 import ch.srgssr.pillarbox.demo.shared.ui.settings.MetricsOverlayOptions
 import ch.srgssr.pillarbox.demo.ui.components.ShowSystemUi
 import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerBottomToolbar
@@ -95,6 +96,9 @@ fun DemoPlayerView(
 @Composable
 private fun PlayerContent(
     player: Player,
+    appSettingsViewModel: AppSettingsViewModel = viewModel<AppSettingsViewModel>(
+        factory = AppSettingsViewModel.Factory(AppSettingsRepository(LocalContext.current)),
+    ),
     pictureInPicture: Boolean = false,
     pictureInPictureClick: (() -> Unit)? = null,
     displayPlaylist: Boolean = false,
@@ -106,11 +110,7 @@ private fun PlayerContent(
     val fullScreenToggle: (Boolean) -> Unit = { fullScreenEnabled ->
         fullScreenState = fullScreenEnabled
     }
-    val context = LocalContext.current
-    val appSettingsRepository = remember {
-        AppSettingsRepository(context)
-    }
-    val appSettings by appSettingsRepository.getAppSettings().collectAsStateWithLifecycle(AppSettings())
+    val appSettings by appSettingsViewModel.currentAppSettings.collectAsStateWithLifecycle()
     ShowSystemUi(isShowed = !fullScreenState)
     Column(modifier = Modifier.fillMaxSize()) {
         var pinchScaleMode by remember(fullScreenState) {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/PlayerView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/PlayerView.kt
@@ -22,13 +22,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.media3.common.Player
+import ch.srgssr.pillarbox.demo.shared.ui.player.metrics.MetricsOverlay
 import ch.srgssr.pillarbox.demo.shared.ui.settings.MetricsOverlayOptions
 import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerControls
 import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerError
 import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerNoContent
 import ch.srgssr.pillarbox.demo.ui.player.controls.SkipButton
 import ch.srgssr.pillarbox.demo.ui.player.controls.rememberProgressTrackerState
-import ch.srgssr.pillarbox.demo.ui.player.metrics.MetricsOverlay
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.currentPositionAsFlow

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSettingsContent.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/settings/PlaybackSettingsContent.kt
@@ -54,8 +54,14 @@ fun PlaybackSettingsContent(player: Player) {
                 SettingsHome(
                     settings = settings,
                     settingsClicked = {
-                        navController.navigate(it.destination.route) {
-                            launchSingleTop = true
+                        val destination = it.destination
+
+                        if (destination is SettingsRoutes.MetricsOverlay) {
+                            settingsViewModel.setMetricsOverlayEnabled(!destination.enabled)
+                        } else {
+                            navController.navigate(destination.route) {
+                                launchSingleTop = true
+                            }
                         }
                     },
                 )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/settings/AppSettingsView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/settings/AppSettingsView.kt
@@ -68,7 +68,7 @@ fun AppSettingsView(
     settingsViewModel: AppSettingsViewModel,
     modifier: Modifier = Modifier,
 ) {
-    val appSettings by settingsViewModel.currentAppSettings.collectAsStateWithLifecycle(AppSettings())
+    val appSettings by settingsViewModel.currentAppSettings.collectAsStateWithLifecycle()
 
     Column(
         modifier = modifier


### PR DESCRIPTION
# Pull request

## Description

This PR adds a new playback setting to enable or disable the metrics overlay. It also displays the metrics overlay based on that setting. I didn't add the text color and size settings, as we did on the mobile demo, but used the yellow text color and medium text size instead.

## Changes made

- Add a playback setting in `pillarbox-demo-tv` to enable/disable the metrics overlay.
- Display the metrics overlay if the corresponding setting is enabled.
- Move `MetricsOverlay` to `pillarbox-demo-shared`.
- Add a shadow on the text of the `MetricsOverlay` to improve readability.
- Change the metrics overlay text size to 12sp, 14sp, 16sp to match Material's body small, body medium, and body large text sizes respectively. Let me know if you prefer to keep the original values.

## Screenshots

| Description | Screenshot |
|-----|-----|
| Metrics overlay setting disabled | ![Screenshot_20240730_145524](https://github.com/user-attachments/assets/8d8ff435-c247-44bc-ad4f-6685cce214cc) |
| Metrics overlay setting enabled | ![Screenshot_20240730_145438](https://github.com/user-attachments/assets/bed4323b-551f-4fb4-b655-dfe3fa49a409) |
| Metrics overlay displayed with controls visible | ![Screenshot_20240730_145448](https://github.com/user-attachments/assets/7d40f583-3fcf-4c35-b7cd-27e61ea25d60) |
| Metrics overlay displayed with controls hidden | ![Screenshot_20240730_145453](https://github.com/user-attachments/assets/7959abbf-516f-4e21-a069-13d155ea0d5a) |

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.