### PR TITLE
Fix `PillarboxSlider` min/max values

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/components/PillarboxSlider.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/components/PillarboxSlider.kt
@@ -331,12 +331,18 @@ private fun Modifier.dragThumb(
     }
 
     return this then Modifier.pointerInput(Unit) {
+        fun notifySliderValueChange(offset: Offset) {
+            val offsetX = offset.x.coerceIn(0f, size.width.toFloat())
+
+            onSliderValueChange(offsetX / size.width)
+        }
+
         detectHorizontalDragGestures(
             onDragStart = { offset ->
                 startInteraction = DragInteraction.Start()
                     .also { interactionSource.tryEmit(it) }
 
-                onSliderValueChange(offset.x / size.width)
+                notifySliderValueChange(offset)
             },
             onDragEnd = {
                 destroyStartInteraction(DragInteraction::Stop)
@@ -345,7 +351,7 @@ private fun Modifier.dragThumb(
                 destroyStartInteraction(DragInteraction::Cancel)
             },
             onHorizontalDrag = { change, _ ->
-                onSliderValueChange(change.position.x / size.width)
+                notifySliderValueChange(change.position)
             },
         )
     }


### PR DESCRIPTION
# Pull request

## Description

When sliding on a `PillarboxSlider` outside of its bounds, the display value may be negative, or bigger than the media duration.
This PR changes that by making sure that the gesture horizontal offset is in [0, sliderWidth].

## Changes made

- Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.