### PR TITLE
680 fix position playbacksession

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -279,7 +279,7 @@ class PlaybackSessionManager {
                 notifyListeners { onSessionCreated(newSession) }
 
                 if (_currentSession == null) {
-                    setCurrentSession(SessionInfo(newSession, eventTime.currentPlaybackPositionMs), eventTime.currentPlaybackPositionMs)
+                    setCurrentSession(SessionInfo(newSession, eventTime.currentPlaybackPositionMs), oldPosition = C.TIME_UNSET)
                 }
 
                 session = newSession

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -14,8 +14,10 @@ import androidx.media3.common.Player.TimelineChangeReason
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
+import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
+import ch.srgssr.pillarbox.player.analytics.extension.getUidOfPeriod
 import ch.srgssr.pillarbox.player.utils.DebugLogger
 import ch.srgssr.pillarbox.player.utils.StringUtil
 import java.util.UUID
@@ -46,29 +48,45 @@ class PlaybackSessionManager {
     }
 
     /**
+     * Session info
+     *
+     * @property session The [Session]
+     * @property position The position in milliseconds when a session changes occurs.
+     */
+    data class SessionInfo(
+        val session: Session,
+        val position: Long,
+    )
+
+    /**
      * Listener
      */
     interface Listener {
         /**
          * On session created
          *
-         * @param session
+         * @param session The newly created [Session].
          */
         fun onSessionCreated(session: Session) = Unit
 
         /**
-         * On current session
+         * On session finished The session won't be current any more.
          *
-         * @param session
+         * @param session The destroyed [Session].
          */
-        fun onCurrentSession(session: Session) = Unit
+        fun onSessionDestroyed(session: Session) = Unit
 
         /**
-         * On session finished
+         * On current session changed from [oldSession] to [newSession].
+         * [onSessionCreated] with [oldSession] is called right after.
          *
-         * @param session
+         * @param oldSession The current session if any.
+         * @param newSession The next current session if any.
          */
-        fun onSessionFinished(session: Session) = Unit
+        fun onCurrentSessionChanged(
+            oldSession: SessionInfo?,
+            newSession: SessionInfo?,
+        ) = Unit
     }
 
     private val analyticsListener = SessionManagerAnalyticsListener()
@@ -76,19 +94,22 @@ class PlaybackSessionManager {
     private val sessions = mutableMapOf<Any, Session>()
     private val window = Timeline.Window()
 
-    private var currentSession: Session? = null
-        set(value) {
-            if (field != value) {
-                field?.let { session ->
-                    notifyListeners { onSessionFinished(session) }
-                    sessions.remove(session.periodUid)
-                }
-                field = value
-                field?.let { session ->
-                    notifyListeners { onCurrentSession(session) }
-                }
+    private var _currentSession: Session? = null
+
+    private fun setCurrentSession(newSession: SessionInfo?, oldPosition: Long) {
+        if (_currentSession != newSession?.session) {
+            val oldSession = _currentSession
+            _currentSession = newSession?.session
+            notifyListeners {
+                onCurrentSessionChanged(oldSession?.let { SessionInfo(it, oldPosition) }, newSession)
+            }
+            // Clear session
+            oldSession?.let { session ->
+                notifyListeners { onSessionDestroyed(session) }
+                sessions.remove(session.periodUid)
             }
         }
+    }
 
     /**
      * Set the player
@@ -123,7 +144,7 @@ class PlaybackSessionManager {
      * @return
      */
     fun getCurrentSession(): Session? {
-        return currentSession
+        return _currentSession
     }
 
     /**
@@ -141,7 +162,7 @@ class PlaybackSessionManager {
      *
      * @param eventTime The [AnalyticsListener.EventTime].
      */
-    fun getSessionFromEventTime(eventTime: AnalyticsListener.EventTime): Session? {
+    fun getSessionFromEventTime(eventTime: EventTime): Session? {
         if (eventTime.timeline.isEmpty) {
             return null
         }
@@ -169,7 +190,7 @@ class PlaybackSessionManager {
 
     private inner class SessionManagerAnalyticsListener : PillarboxAnalyticsListener {
         override fun onPositionDiscontinuity(
-            eventTime: AnalyticsListener.EventTime,
+            eventTime: EventTime,
             oldPosition: Player.PositionInfo,
             newPosition: Player.PositionInfo,
             @DiscontinuityReason reason: Int
@@ -177,15 +198,16 @@ class PlaybackSessionManager {
             val oldItemIndex = oldPosition.mediaItemIndex
             val newItemIndex = newPosition.mediaItemIndex
 
+            if (eventTime.timeline.isEmpty) return
             DebugLogger.debug(TAG, "onPositionDiscontinuity reason = ${StringUtil.discontinuityReasonString(reason)}")
-
             if (oldItemIndex != newItemIndex && !eventTime.timeline.isEmpty) {
-                currentSession = getOrCreateSession(eventTime)
+                val newSession = getOrCreateSession(eventTime)!! // Return null only if timeline is empty
+                setCurrentSession(SessionInfo(newSession, newPosition.positionMs), oldPosition.positionMs)
             }
         }
 
         override fun onMediaItemTransition(
-            eventTime: AnalyticsListener.EventTime,
+            eventTime: EventTime,
             mediaItem: MediaItem?,
             @MediaItemTransitionReason reason: Int,
         ) {
@@ -193,12 +215,12 @@ class PlaybackSessionManager {
                 TAG,
                 "onMediaItemTransition reason = ${StringUtil.mediaItemTransitionReasonString(reason)} ${mediaItem?.mediaMetadata?.title}",
             )
-
-            currentSession = mediaItem?.let { getOrCreateSession(eventTime) }
+            // Already handled in position discontinuity?
+            // currentSession = mediaItem?.let { getOrCreateSession(eventTime) }
         }
 
         override fun onTimelineChanged(
-            eventTime: AnalyticsListener.EventTime,
+            eventTime: EventTime,
             @TimelineChangeReason reason: Int,
         ) {
             val mediaItem = if (eventTime.timeline.isEmpty) {
@@ -211,7 +233,7 @@ class PlaybackSessionManager {
 
             val timeline = eventTime.timeline
             if (timeline.isEmpty) {
-                finishAllSessions()
+                finishAllSessions(eventTime)
                 return
             }
 
@@ -221,10 +243,10 @@ class PlaybackSessionManager {
                 val periodUid = session.periodUid
                 val periodIndex = timeline.getIndexOfPeriod(periodUid)
                 if (periodIndex == C.INDEX_UNSET) {
-                    if (session == currentSession) {
-                        currentSession = null
+                    if (session == _currentSession) {
+                        setCurrentSession(null, eventTime.currentPlaybackPositionMs)
                     } else {
-                        notifyListeners { onSessionFinished(session) }
+                        notifyListeners { onSessionDestroyed(session) }
                         sessions.remove(session.periodUid)
                     }
                 }
@@ -232,7 +254,7 @@ class PlaybackSessionManager {
         }
 
         override fun onLoadStarted(
-            eventTime: AnalyticsListener.EventTime,
+            eventTime: EventTime,
             loadEventInfo: LoadEventInfo,
             mediaLoadData: MediaLoadData,
         ) {
@@ -240,41 +262,42 @@ class PlaybackSessionManager {
         }
 
         override fun onPlayerError(
-            eventTime: AnalyticsListener.EventTime,
+            eventTime: EventTime,
             error: PlaybackException,
         ) {
             DebugLogger.debug(TAG, "onPlayerError", error)
             getOrCreateSession(eventTime)
         }
-        override fun onPlayerReleased(eventTime: AnalyticsListener.EventTime) {
+
+        override fun onPlayerReleased(eventTime: EventTime) {
             DebugLogger.debug(TAG, "onPlayerReleased")
-            finishAllSessions()
+            finishAllSessions(eventTime)
             listeners.clear()
         }
 
-        override fun onPlaybackStateChanged(eventTime: AnalyticsListener.EventTime, state: Int) {
+        override fun onPlaybackStateChanged(eventTime: EventTime, state: Int) {
             DebugLogger.debug(TAG, "onPlaybackStateChanged ${StringUtil.playerStateString(state)}")
             if (state == Player.STATE_IDLE) {
-                finishAllSessions()
+                finishAllSessions(eventTime)
             } else {
                 getOrCreateSession(eventTime)
             }
         }
 
-        private fun getOrCreateSession(eventTime: AnalyticsListener.EventTime): Session? {
+        private fun getOrCreateSession(eventTime: EventTime): Session? {
             if (eventTime.timeline.isEmpty) {
                 return null
             }
             eventTime.timeline.getWindow(eventTime.windowIndex, window)
-            val periodUid = eventTime.timeline.getUidOfPeriod(window.firstPeriodIndex)
+            val periodUid = eventTime.getUidOfPeriod(window)
             var session = getSessionFromPeriodUid(periodUid)
             if (session == null) {
                 val newSession = Session(periodUid, window.mediaItem)
                 sessions[periodUid] = newSession
                 notifyListeners { onSessionCreated(newSession) }
 
-                if (currentSession == null) {
-                    currentSession = newSession
+                if (_currentSession == null) {
+                    setCurrentSession(SessionInfo(newSession, eventTime.currentPlaybackPositionMs), eventTime.currentPlaybackPositionMs)
                 }
 
                 session = newSession
@@ -283,11 +306,11 @@ class PlaybackSessionManager {
             return session
         }
 
-        private fun finishAllSessions() {
-            currentSession = null
+        private fun finishAllSessions(eventTime: EventTime) {
+            setCurrentSession(null, eventTime.currentPlaybackPositionMs)
 
             sessions.values.forEach { session ->
-                notifyListeners { onSessionFinished(session) }
+                notifyListeners { onSessionDestroyed(session) }
             }
             sessions.clear()
         }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -194,13 +194,9 @@ class PlaybackSessionManager {
             newPosition: Player.PositionInfo,
             @DiscontinuityReason reason: Int
         ) {
-            val oldItemIndex = oldPosition.mediaItemIndex
-            val newItemIndex = newPosition.mediaItemIndex
-
-            if (eventTime.timeline.isEmpty) return
             DebugLogger.debug(TAG, "onPositionDiscontinuity reason = ${StringUtil.discontinuityReasonString(reason)}")
-            if (oldItemIndex != newItemIndex && !eventTime.timeline.isEmpty) {
-                val newSession = getOrCreateSession(eventTime)!! // Return null only if timeline is empty
+            if (oldPosition.mediaItemIndex != newPosition.mediaItemIndex && !eventTime.timeline.isEmpty) {
+                val newSession = checkNotNull(getOrCreateSession(eventTime)) // Return null only if timeline is empty
                 setCurrentSession(SessionInfo(newSession, newPosition.positionMs), oldPosition.positionMs)
             }
         }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -31,7 +31,7 @@ class PlaybackSessionManager {
      * - A session is linked to the period inside the timeline, see [Timeline.getUidOfPeriod][androidx.media3.common.Timeline.getUidOfPeriod].
      * - A session is created when the player does something with a [MediaItem].
      * - A session is current if the media item associated with the session is the current [MediaItem].
-     * - A session is finished when it is no longer the current session, or when the session is removed from the player.
+     * - A session is destroyed when it is no longer the current session, or when the session is removed from the player.
      *
      * @property periodUid The period id from [Timeline.getUidOfPeriod][androidx.media3.common.Timeline.getUidOfPeriod] for [mediaItem].
      * @property mediaItem The [MediaItem] linked to the session.

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -77,7 +77,7 @@ class PlaybackSessionManager {
 
         /**
          * On current session changed from [oldSession] to [newSession].
-         * [onSessionCreated] with [oldSession] is called right after.
+         * [onSessionDestroyed] with [oldSession] is called right after.
          *
          * @param oldSession The current session, if any.
          * @param newSession The next current session, if any.

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -51,7 +51,7 @@ class PlaybackSessionManager {
      * Session info
      *
      * @property session The [Session]
-     * @property position The position in milliseconds when a session changes occurs.
+     * @property position The position in milliseconds when a session change occurs.
      */
     data class SessionInfo(
         val session: Session,
@@ -70,7 +70,7 @@ class PlaybackSessionManager {
         fun onSessionCreated(session: Session) = Unit
 
         /**
-         * On session finished The session won't be current any more.
+         * On session destroyed. The session won't be current anymore.
          *
          * @param session The destroyed [Session].
          */
@@ -80,8 +80,8 @@ class PlaybackSessionManager {
          * On current session changed from [oldSession] to [newSession].
          * [onSessionCreated] with [oldSession] is called right after.
          *
-         * @param oldSession The current session if any.
-         * @param newSession The next current session if any.
+         * @param oldSession The current session, if any.
+         * @param newSession The next current session, if any.
          */
         fun onCurrentSessionChanged(
             oldSession: SessionInfo?,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -9,7 +9,6 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Player.DiscontinuityReason
-import androidx.media3.common.Player.MediaItemTransitionReason
 import androidx.media3.common.Player.TimelineChangeReason
 import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
@@ -204,19 +203,6 @@ class PlaybackSessionManager {
                 val newSession = getOrCreateSession(eventTime)!! // Return null only if timeline is empty
                 setCurrentSession(SessionInfo(newSession, newPosition.positionMs), oldPosition.positionMs)
             }
-        }
-
-        override fun onMediaItemTransition(
-            eventTime: EventTime,
-            mediaItem: MediaItem?,
-            @MediaItemTransitionReason reason: Int,
-        ) {
-            DebugLogger.debug(
-                TAG,
-                "onMediaItemTransition reason = ${StringUtil.mediaItemTransitionReasonString(reason)} ${mediaItem?.mediaMetadata?.title}",
-            )
-            // Already handled in position discontinuity?
-            // currentSession = mediaItem?.let { getOrCreateSession(eventTime) }
         }
 
         override fun onTimelineChanged(

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
@@ -89,7 +89,7 @@ class MetricsCollectorTest {
         val slotFinished = slot<PlaybackMetrics>()
         verify {
             metricsListener.onMetricSessionReady(capture(slotReady))
-            metricsListener.onMetricSessionFinished(capture(slotFinished))
+            metricsListener.onMetricSessionFinished(capture(slotFinished), any())
         }
         confirmVerified(metricsListener)
 
@@ -130,7 +130,7 @@ class MetricsCollectorTest {
         val finishedMetrics = mutableListOf<PlaybackMetrics>()
         verify {
             metricsListener.onMetricSessionReady(capture(startedMetrics))
-            metricsListener.onMetricSessionFinished(capture(finishedMetrics))
+            metricsListener.onMetricSessionFinished(capture(finishedMetrics), any())
         }
         confirmVerified(metricsListener)
 


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to send the position of the player before item transition.

## Changes made

- Changes `PlaybackSession.Listener` to have more information during session transition.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
