### PR TITLE
Move Chapters and Credits into MediaMetadata

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/DefaultMediaMetaDataProvider.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/DefaultMediaMetaDataProvider.kt
@@ -10,6 +10,8 @@ import ch.srgssr.pillarbox.core.business.integrationlayer.ImageScalingService
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Resource
+import ch.srgssr.pillarbox.player.extension.setChapters
+import ch.srgssr.pillarbox.player.extension.setCredits
 
 /**
  * A [SRGAssetLoader.MediaMetadataProvider] filling [MediaMetadata] from [Chapter].
@@ -29,6 +31,12 @@ class DefaultMediaMetaDataProvider : SRGAssetLoader.MediaMetadataProvider {
                 imageUrl = chapter.imageUrl
             ).toUri()
             mediaMetadataBuilder.setArtworkUri(artworkUri)
+        }
+        ChapterAdapter.getChapters(mediaComposition).takeIf { it.isNotEmpty() }?.let {
+            mediaMetadataBuilder.setChapters(it)
+        }
+        TimeIntervalAdapter.getCredits(chapter.timeIntervalList).takeIf { it.isNotEmpty() }?.let {
+            mediaMetadataBuilder.setCredits(it)
         }
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/SRGAssetLoader.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/SRGAssetLoader.kt
@@ -168,8 +168,6 @@ class SRGAssetLoader(
                 )
             }.build(),
             blockedTimeRanges = SegmentAdapter.getBlockedTimeRanges(chapter.listSegment),
-            chapters = ChapterAdapter.getChapters(result),
-            credits = TimeIntervalAdapter.getCredits(result.mainChapter.timeIntervalList),
         )
     }
 

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/SRGAssetLoaderTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/SRGAssetLoaderTest.kt
@@ -26,6 +26,7 @@ import ch.srgssr.pillarbox.core.business.integrationlayer.service.MediaCompositi
 import ch.srgssr.pillarbox.core.business.source.SRGAssetLoader
 import ch.srgssr.pillarbox.core.business.source.SegmentAdapter
 import ch.srgssr.pillarbox.core.business.source.TimeIntervalAdapter
+import ch.srgssr.pillarbox.player.extension.credits
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.runner.RunWith
@@ -160,7 +161,7 @@ class SRGAssetLoaderTest {
         val expectedCredits = TimeIntervalAdapter.getCredits(
             listOf(DummyMediaCompositionProvider.TIME_INTERVAL_1, DummyMediaCompositionProvider.TIME_INTERVAL_2)
         )
-        assertEquals(expectedCredits, asset.credits)
+        assertEquals(expectedCredits, asset.mediaMetadata.credits)
     }
 
     internal class DummyMediaCompositionProvider : MediaCompositionService {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/ChaptersShowcaseViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/ChaptersShowcaseViewModel.kt
@@ -11,10 +11,10 @@ import androidx.media3.common.Player
 import ch.srgssr.pillarbox.core.business.DefaultPillarbox
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
-import ch.srgssr.pillarbox.player.currentMediaItemAsFlow
+import ch.srgssr.pillarbox.player.currentMediaMetadataAsFlow
+import ch.srgssr.pillarbox.player.extension.chapters
 import ch.srgssr.pillarbox.player.extension.getChapterAtPosition
 import ch.srgssr.pillarbox.player.extension.getCurrentChapters
-import ch.srgssr.pillarbox.player.extension.pillarboxData
 import ch.srgssr.pillarbox.ui.SimpleProgressTrackerState
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -48,8 +48,8 @@ class ChaptersShowcaseViewModel(application: Application) : AndroidViewModel(app
     val progressTracker = SimpleProgressTrackerState(player, viewModelScope)
 
     init {
-        chapters = player.currentMediaItemAsFlow().map {
-            it?.pillarboxData?.chapters ?: emptyList()
+        chapters = player.currentMediaMetadataAsFlow().map { mediaMetadata ->
+            mediaMetadata.chapters ?: emptyList()
         }.stateIn(
             viewModelScope, SharingStarted.Lazily, player.getCurrentChapters()
         )

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/Asset.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/Asset.kt
@@ -4,7 +4,6 @@
  */
 package ch.srgssr.pillarbox.player.asset
 
-import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.exoplayer.source.MediaSource
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
@@ -16,13 +15,11 @@ import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
  * @property mediaSource The [MediaSource] used by the player to play something.
  * @property trackersData The [MediaItemTrackerData] to set to the [PillarboxData].
  * @property mediaMetadata The [MediaMetadata] to set to the player media item.
- * @property customData The custom data will be available as `tag` in [MediaItem.localConfiguration]
  * @property blockedTimeRanges The [BlockedTimeRange] list.
  */
 data class Asset(
     val mediaSource: MediaSource,
     val trackersData: MediaItemTrackerData = MediaItemTrackerData.EMPTY,
     val mediaMetadata: MediaMetadata = MediaMetadata.EMPTY,
-    val customData: Any? = null,
     val blockedTimeRanges: List<BlockedTimeRange> = emptyList(),
 )

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/Asset.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/Asset.kt
@@ -4,11 +4,10 @@
  */
 package ch.srgssr.pillarbox.player.asset
 
+import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.exoplayer.source.MediaSource
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
-import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
-import ch.srgssr.pillarbox.player.asset.timeRange.Credit
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
 
 /**
@@ -17,15 +16,13 @@ import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
  * @property mediaSource The [MediaSource] used by the player to play something.
  * @property trackersData The [MediaItemTrackerData] to set to the [PillarboxData].
  * @property mediaMetadata The [MediaMetadata] to set to the player media item.
+ * @property customData The custom data will be available as `tag` in [MediaItem.localConfiguration]
  * @property blockedTimeRanges The [BlockedTimeRange] list.
- * @property chapters The [Chapter] list.
- * @property credits The [Credit] list.
  */
 data class Asset(
     val mediaSource: MediaSource,
     val trackersData: MediaItemTrackerData = MediaItemTrackerData.EMPTY,
     val mediaMetadata: MediaMetadata = MediaMetadata.EMPTY,
+    val customData: Any? = null,
     val blockedTimeRanges: List<BlockedTimeRange> = emptyList(),
-    val chapters: List<Chapter> = emptyList(),
-    val credits: List<Credit> = emptyList(),
 )

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/PillarboxData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/PillarboxData.kt
@@ -5,8 +5,6 @@
 package ch.srgssr.pillarbox.player.asset
 
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
-import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
-import ch.srgssr.pillarbox.player.asset.timeRange.Credit
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
 
 /**
@@ -14,14 +12,10 @@ import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
  *
  * @property trackersData The [MediaItemTrackerData].
  * @property blockedTimeRanges The [BlockedTimeRange] list.
- * @property chapters The [Chapter] list.
- * @property credits The [Credit] list.
  */
 data class PillarboxData(
     val trackersData: MediaItemTrackerData = MediaItemTrackerData.EMPTY,
-    val blockedTimeRanges: List<BlockedTimeRange> = emptyList(),
-    val chapters: List<Chapter> = emptyList(),
-    val credits: List<Credit> = emptyList(),
+    val blockedTimeRanges: List<BlockedTimeRange> = emptyList()
 ) {
     companion object {
         /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaMetadata.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaMetadata.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.extension
+
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.core.os.BundleCompat
+import androidx.media3.common.MediaMetadata
+import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
+import ch.srgssr.pillarbox.player.asset.timeRange.Credit
+
+/**
+ * Chapters
+ */
+val MediaMetadata.chapters: List<Chapter>?
+    get() {
+        return extras?.let { BundleCompat.getParcelableArrayList(it, KeyChapters, Chapter::class.java) }
+    }
+
+/**
+ * Sets the [MediaMetadata.chapters].
+ *
+ * @param chapters The list of [Chapter].
+ */
+fun MediaMetadata.Builder.setChapters(chapters: List<Chapter>): MediaMetadata.Builder {
+    return setExtras(KeyChapters, chapters)
+}
+
+/**
+ * Credits
+ */
+val MediaMetadata.credits: List<Credit>?
+    get() {
+        return extras?.let { BundleCompat.getParcelableArrayList(it, KeyCredits, Credit::class.java) }
+    }
+
+/**
+ * Sets the [MediaMetadata.credits]
+ *
+ * @param credits The list of [Credit].
+ */
+fun MediaMetadata.Builder.setCredits(credits: List<Credit>): MediaMetadata.Builder {
+    return setExtras(KeyCredits, credits)
+}
+
+private fun <T : Parcelable> MediaMetadata.Builder.setExtras(key: String, items: List<T>): MediaMetadata.Builder {
+    val extras = build().extras ?: Bundle()
+    extras.putParcelableArrayList(key, ArrayList(items))
+    return setExtras(extras)
+}
+
+private const val KeyCredits = "Pillarbox-credits"
+private const val KeyChapters = "Pillarbox-chapters"

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaMetadata.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaMetadata.kt
@@ -15,9 +15,7 @@ import ch.srgssr.pillarbox.player.asset.timeRange.Credit
  * Chapters
  */
 val MediaMetadata.chapters: List<Chapter>?
-    get() {
-        return extras?.let { BundleCompat.getParcelableArrayList(it, KeyChapters, Chapter::class.java) }
-    }
+    get() = getExtra(KeyChapters)
 
 /**
  * Sets the [MediaMetadata.chapters].
@@ -25,16 +23,14 @@ val MediaMetadata.chapters: List<Chapter>?
  * @param chapters The list of [Chapter].
  */
 fun MediaMetadata.Builder.setChapters(chapters: List<Chapter>): MediaMetadata.Builder {
-    return setExtras(KeyChapters, chapters)
+    return setExtra(KeyChapters, chapters)
 }
 
 /**
  * Credits
  */
 val MediaMetadata.credits: List<Credit>?
-    get() {
-        return extras?.let { BundleCompat.getParcelableArrayList(it, KeyCredits, Credit::class.java) }
-    }
+    get() = getExtra(KeyCredits)
 
 /**
  * Sets the [MediaMetadata.credits]
@@ -42,10 +38,14 @@ val MediaMetadata.credits: List<Credit>?
  * @param credits The list of [Credit].
  */
 fun MediaMetadata.Builder.setCredits(credits: List<Credit>): MediaMetadata.Builder {
-    return setExtras(KeyCredits, credits)
+    return setExtra(KeyCredits, credits)
 }
 
-private fun <T : Parcelable> MediaMetadata.Builder.setExtras(key: String, items: List<T>): MediaMetadata.Builder {
+private inline fun <reified T : Parcelable> MediaMetadata.getExtra(key: String): List<T>? {
+    return extras?.let { BundleCompat.getParcelableArrayList(it, key, T::class.java) }
+}
+
+private fun <T : Parcelable> MediaMetadata.Builder.setExtra(key: String, items: List<T>): MediaMetadata.Builder {
     val extras = build().extras ?: Bundle()
     extras.putParcelableArrayList(key, ArrayList(items))
     return setExtras(extras)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaMetadata.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/MediaMetadata.kt
@@ -21,7 +21,7 @@ val MediaMetadata.chapters: List<Chapter>?
 
 /**
  * Sets the [MediaMetadata.chapters].
- *
+ * Calling [MediaMetadata.Builder.setExtras] after will reset this call.
  * @param chapters The list of [Chapter].
  */
 fun MediaMetadata.Builder.setChapters(chapters: List<Chapter>): MediaMetadata.Builder {
@@ -38,7 +38,7 @@ val MediaMetadata.credits: List<Credit>?
 
 /**
  * Sets the [MediaMetadata.credits]
- *
+ * Calling [MediaMetadata.Builder.setExtras] after will reset this call.
  * @param credits The list of [Credit].
  */
 fun MediaMetadata.Builder.setCredits(credits: List<Credit>): MediaMetadata.Builder {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Player.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Player.kt
@@ -60,14 +60,14 @@ fun Player.setHandleAudioFocus(handleAudioFocus: Boolean) {
  * @return The current media item chapters or an empty list.
  */
 fun Player.getCurrentChapters(): List<Chapter> {
-    return currentMediaItem?.pillarboxData?.chapters ?: emptyList()
+    return currentMediaItem?.mediaMetadata?.chapters ?: emptyList()
 }
 
 /**
  * @return The current media item credits or an empty list.
  */
 fun Player.getCurrentCredits(): List<Credit> {
-    return currentMediaItem?.pillarboxData?.credits.orEmpty()
+    return currentMediaItem?.mediaMetadata?.credits.orEmpty()
 }
 
 /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSource.kt
@@ -51,8 +51,6 @@ class PillarboxMediaSource internal constructor(
                         PillarboxData(
                             trackersData = asset.trackersData,
                             blockedTimeRanges = asset.blockedTimeRanges,
-                            chapters = asset.chapters,
-                            credits = asset.credits,
                         )
                     )
                     .build()

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
@@ -5,6 +5,7 @@
 package ch.srgssr.pillarbox.player.tracker
 
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.common.Player.DiscontinuityReason
 import androidx.media3.exoplayer.PlayerMessage
@@ -16,6 +17,8 @@ import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
 import ch.srgssr.pillarbox.player.asset.timeRange.Credit
 import ch.srgssr.pillarbox.player.asset.timeRange.TimeRange
 import ch.srgssr.pillarbox.player.asset.timeRange.firstOrNullAtPosition
+import ch.srgssr.pillarbox.player.extension.chapters
+import ch.srgssr.pillarbox.player.extension.credits
 
 internal class TimeRangeTracker(
     private val pillarboxPlayer: PillarboxExoPlayer,
@@ -38,38 +41,43 @@ internal class TimeRangeTracker(
             // set current item to null
             return
         }
-        createMessages(data)
+        createMessages(mediaItem.mediaMetadata, data.blockedTimeRanges)
     }
 
-    private fun createMessages(data: PillarboxData) {
+    private fun createMessages(mediaMetadata: MediaMetadata, timeRanges: List<BlockedTimeRange>) {
         val position = pillarboxPlayer.currentPosition
-        if (data.blockedTimeRanges.isNotEmpty()) {
+        if (timeRanges.isNotEmpty()) {
             listTrackers.add(
                 BlockedTimeRangeTracker(
                     initialPosition = position,
-                    timeRanges = data.blockedTimeRanges,
+                    timeRanges = timeRanges,
                     callback = callback::onBlockedTimeRange
                 )
             )
         }
-        if (data.chapters.isNotEmpty()) {
-            listTrackers.add(
-                ChapterCreditsTracker(
-                    initialPosition = position,
-                    timeRanges = data.chapters,
-                    callback = callback::onChapterChanged
+
+        mediaMetadata.chapters?.let { chapters ->
+            if (chapters.isNotEmpty()) {
+                listTrackers.add(
+                    ChapterCreditsTracker(
+                        initialPosition = position,
+                        timeRanges = chapters,
+                        callback = callback::onChapterChanged
+                    )
                 )
-            )
+            }
         }
 
-        if (data.credits.isNotEmpty()) {
-            listTrackers.add(
-                ChapterCreditsTracker(
-                    initialPosition = position,
-                    timeRanges = data.credits,
-                    callback = callback::onCreditChanged
+        mediaMetadata.credits?.let { credits ->
+            if (credits.isNotEmpty()) {
+                listTrackers.add(
+                    ChapterCreditsTracker(
+                        initialPosition = position,
+                        timeRanges = credits,
+                        callback = callback::onCreditChanged
+                    )
                 )
-            )
+            }
         }
 
         listTrackers.forEach {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/TimeRangeTracker.kt
@@ -56,28 +56,24 @@ internal class TimeRangeTracker(
             )
         }
 
-        mediaMetadata.chapters?.let { chapters ->
-            if (chapters.isNotEmpty()) {
-                listTrackers.add(
-                    ChapterCreditsTracker(
-                        initialPosition = position,
-                        timeRanges = chapters,
-                        callback = callback::onChapterChanged
-                    )
+        mediaMetadata.chapters.takeUnless { it.isNullOrEmpty() }?.let { chapters ->
+            listTrackers.add(
+                ChapterCreditsTracker(
+                    initialPosition = position,
+                    timeRanges = chapters,
+                    callback = callback::onChapterChanged
                 )
-            }
+            )
         }
 
-        mediaMetadata.credits?.let { credits ->
-            if (credits.isNotEmpty()) {
-                listTrackers.add(
-                    ChapterCreditsTracker(
-                        initialPosition = position,
-                        timeRanges = credits,
-                        callback = callback::onCreditChanged
-                    )
+        mediaMetadata.credits.takeUnless { it.isNullOrEmpty() }?.let { credits ->
+            listTrackers.add(
+                ChapterCreditsTracker(
+                    initialPosition = position,
+                    timeRanges = credits,
+                    callback = callback::onCreditChanged
                 )
-            }
+            )
         }
 
         listTrackers.forEach {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/extension/PlayerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/extension/PlayerTest.kt
@@ -5,6 +5,7 @@
 package ch.srgssr.pillarbox.player.extension
 
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -89,7 +90,7 @@ class PlayerTest {
     }
 
     @Test
-    fun `getTimeIntervals, without MediaItem`() {
+    fun `getCurrentCredits, without MediaItem`() {
         val player = mockk<Player> {
             every { currentMediaItem } returns null
         }
@@ -119,12 +120,16 @@ class PlayerTest {
     }
 
     @Test
-    fun `getTimeIntervals, with MediaItem, with PillarboxData, with credits`() {
+    fun `getCurrentCredits, with MediaItem, with PillarboxData, with credits`() {
         val credits = listOf<Credit>(mockk())
         val player = mockk<Player> {
             every { currentMediaItem } returns MediaItem.Builder()
                 .setUri("https://example.com/")
-                .setTag(PillarboxData(credits = credits))
+                .setMediaMetadata(
+                    MediaMetadata.Builder()
+                        .setCredits(credits)
+                        .build()
+                )
                 .build()
         }
 

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/ChapterTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/ChapterTrackerTest.kt
@@ -10,7 +10,6 @@ import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
 import androidx.test.core.app.ApplicationProvider
@@ -18,9 +17,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.SeekIncrement
-import ch.srgssr.pillarbox.player.asset.Asset
-import ch.srgssr.pillarbox.player.asset.AssetLoader
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
+import ch.srgssr.pillarbox.player.extension.setChapters
 import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
 import io.mockk.clearAllMocks
 import io.mockk.spyk
@@ -49,9 +47,7 @@ class ChapterTrackerTest {
             seekIncrement = SeekIncrement(),
             loadControl = DefaultLoadControl(),
             clock = fakeClock,
-            mediaSourceFactory = PillarboxMediaSourceFactory(context).apply {
-                addAssetLoader(ChapterAssetLoader(context))
-            },
+            mediaSourceFactory = PillarboxMediaSourceFactory(context),
         )
         player.addListener(listener)
         player.prepare()
@@ -68,10 +64,10 @@ class ChapterTrackerTest {
 
     @Test
     fun `chapter transition while playing`() {
-        player.addMediaItem(ChapterAssetLoader.MEDIA_ITEM)
+        player.addMediaItem(MEDIA_ITEM)
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_ENDED)
 
-        val expectedChapters = listOf(ChapterAssetLoader.CHAPTER_1, ChapterAssetLoader.CHAPTER_2, null)
+        val expectedChapters = listOf(CHAPTER_1, CHAPTER_2, null)
         val receivedChapters = mutableListOf<Chapter?>()
         verify {
             listener.onChapterChanged(captureNullable(receivedChapters))
@@ -82,8 +78,8 @@ class ChapterTrackerTest {
     @Test
     fun `chapter transition after seek inside a chapter`() {
         player.pause()
-        val chapter = ChapterAssetLoader.CHAPTER_2
-        player.setMediaItem(ChapterAssetLoader.MEDIA_ITEM, chapter.end)
+        val chapter = CHAPTER_2
+        player.setMediaItem(MEDIA_ITEM, chapter.end)
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
 
@@ -91,7 +87,7 @@ class ChapterTrackerTest {
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
 
-        val expectedChapters = listOf(ChapterAssetLoader.CHAPTER_2)
+        val expectedChapters = listOf(CHAPTER_2)
         val receivedChapters = mutableListOf<Chapter>()
         verifyOrder {
             listener.onChapterChanged(capture(receivedChapters))
@@ -101,12 +97,12 @@ class ChapterTrackerTest {
 
     @Test
     fun `chapter transition after seek back`() {
-        player.addMediaItem(ChapterAssetLoader.MEDIA_ITEM_WITH_CHAPTER)
-        TestPlayerRunHelper.playUntilPosition(player, 0, ChapterAssetLoader.CHAPTER_3.start + 1_000L)
+        player.addMediaItem(MEDIA_ITEM_WITH_CHAPTER)
+        TestPlayerRunHelper.playUntilPosition(player, 0, CHAPTER_3.start + 1_000L)
         player.seekBack()
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_ENDED)
 
-        val expectedChapters = listOf(ChapterAssetLoader.CHAPTER_3, null, ChapterAssetLoader.CHAPTER_3, null, ChapterAssetLoader.CHAPTER_4, null)
+        val expectedChapters = listOf(CHAPTER_3, null, CHAPTER_3, null, CHAPTER_4, null)
         val receivedChapters = mutableListOf<Chapter?>()
 
         verify {
@@ -117,12 +113,12 @@ class ChapterTrackerTest {
 
     @Test
     fun `chapter transition skip next`() {
-        player.addMediaItems(listOf(ChapterAssetLoader.MEDIA_ITEM_WITH_CHAPTER, ChapterAssetLoader.NO_CHAPTER_MEDIA_ITEM))
-        TestPlayerRunHelper.playUntilPosition(player, 0, ChapterAssetLoader.CHAPTER_3.start + 1_000L)
+        player.addMediaItems(listOf(MEDIA_ITEM_WITH_CHAPTER, NO_CHAPTER_MEDIA_ITEM))
+        TestPlayerRunHelper.playUntilPosition(player, 0, CHAPTER_3.start + 1_000L)
         player.seekToNext()
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_ENDED)
 
-        val expectedChapters = listOf(ChapterAssetLoader.CHAPTER_3, null)
+        val expectedChapters = listOf(CHAPTER_3, null)
         val receivedChapters = mutableListOf<Chapter?>()
 
         verify {
@@ -130,59 +126,39 @@ class ChapterTrackerTest {
         }
         assertEquals(expectedChapters, receivedChapters)
     }
-}
-
-private class ChapterAssetLoader(context: Context) : AssetLoader(DefaultMediaSourceFactory(context)) {
-
-    override fun canLoadAsset(mediaItem: MediaItem): Boolean {
-        return mediaItem.localConfiguration != null
-    }
-
-    override suspend fun loadAsset(mediaItem: MediaItem): Asset {
-        val itemBuilder = mediaItem.buildUpon()
-        val mediaSource = mediaSourceFactory.createMediaSource(itemBuilder.build())
-        return when (mediaItem.mediaId) {
-            ID_START_WITH_CHAPTER -> {
-                Asset(
-                    mediaSource = mediaSource,
-                    mediaMetadata = mediaItem.mediaMetadata,
-                    chapters = listOf(CHAPTER_1, CHAPTER_2)
-                )
-            }
-
-            ID_WITH_CHAPTER -> {
-                Asset(
-                    mediaSource = mediaSource,
-                    mediaMetadata = mediaItem.mediaMetadata,
-                    chapters = listOf(CHAPTER_3, CHAPTER_4)
-                )
-            }
-
-            else -> {
-                Asset(
-                    mediaSource = mediaSource,
-                    mediaMetadata = mediaItem.mediaMetadata,
-                    chapters = emptyList()
-                )
-            }
-        }
-    }
 
     companion object {
         private const val URL = "https://rts-vod-amd.akamaized.net/ww/13317145/f1d49f18-f302-37ce-866c-1c1c9b76a824/master.m3u8"
         const val ID_START_WITH_CHAPTER = "ID_START_WITH_CHAPTER"
         const val ID_WITH_CHAPTER = "ID_WITH_CHAPTER"
-
-        val MEDIA_ITEM = MediaItem.Builder().setMediaId(ID_START_WITH_CHAPTER).setUri(URL).build()
-        val MEDIA_ITEM_WITH_CHAPTER = MediaItem.Builder().setMediaId(ID_WITH_CHAPTER).setUri(URL).build()
-        val NO_CHAPTER_MEDIA_ITEM = MediaItem.Builder().setMediaId("NoChapter").setUri(URL).build()
-
         const val NEAR_END_POSITION_MS = 15_000L // the video has 17 sec duration
 
         val CHAPTER_1 = Chapter(id = "Chapter1", 0, 5_000L, MediaMetadata.EMPTY)
         val CHAPTER_2 = Chapter(id = "Chapter2", 5_000L, NEAR_END_POSITION_MS, MediaMetadata.EMPTY)
-
         val CHAPTER_3 = Chapter(id = "Chapter3", 2_000L, 5_000L, MediaMetadata.EMPTY)
         val CHAPTER_4 = Chapter(id = "Chapter4", 10_000L, NEAR_END_POSITION_MS, MediaMetadata.EMPTY)
+
+        val MEDIA_ITEM = MediaItem.Builder()
+            .setMediaId(ID_START_WITH_CHAPTER)
+            .setUri(URL)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setChapters(listOf(CHAPTER_1, CHAPTER_2))
+                    .build()
+            )
+            .build()
+        val MEDIA_ITEM_WITH_CHAPTER = MediaItem.Builder()
+            .setMediaId(ID_WITH_CHAPTER)
+            .setUri(URL)
+            .setMediaMetadata(
+                MediaMetadata.Builder()
+                    .setChapters(listOf(CHAPTER_3, CHAPTER_4))
+                    .build()
+            )
+            .build()
+        val NO_CHAPTER_MEDIA_ITEM = MediaItem.Builder()
+            .setMediaId("NoChapter")
+            .setUri(URL)
+            .build()
     }
 }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to move Pillarbox metadata to the actual MediaMetadata of Media3. `BlockedTimeRange` has not been changed has it is more like a feature than actual metadata.

## Changes made

- `Asset` has been simplified to reflet changes.
- To add `Chapters` to Pillarbox `MediaMetadata.Builder.setChapters` has been added.
- To add `Credits` to Pillarbox `MediaMetadata.Builder.setCredits` has been added.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
- [x] All pull request status checks pass.
