### PR TITLE
Add backend integration for QoS event

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/akamai/AkamaiTokenProvider.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/akamai/AkamaiTokenProvider.kt
@@ -6,7 +6,8 @@ package ch.srgssr.pillarbox.core.business.akamai
 
 import android.net.Uri
 import android.net.UrlQuerySanitizer
-import ch.srgssr.pillarbox.core.business.integrationlayer.service.DefaultHttpClient
+import ch.srgssr.pillarbox.core.business.akamai.AkamaiTokenProvider.Companion.TOKEN_SERVICE_URL
+import ch.srgssr.pillarbox.player.network.PillarboxHttpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -16,16 +17,15 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
- * Akamai token provider fetch and rewrite given Uri with a Token received from [tokenService]
- *
+ * Akamai token provider fetch and rewrite given Uri with a Token received from [TOKEN_SERVICE_URL].
  */
-class AkamaiTokenProvider(private val httpClient: HttpClient = DefaultHttpClient()) {
+class AkamaiTokenProvider(private val httpClient: HttpClient = PillarboxHttpClient()) {
 
     /**
-     * Request and append a Akamai token to [uri]
+     * Request and append an Akamai token to [uri]
      *
      * @param uri protected by a token
-     * @return tokenized [uri] or [uri] if it fail
+     * @return tokenized [uri] or [uri] if it fails
      */
     suspend fun tokenizeUri(uri: Uri): Uri {
         val acl = getAcl(uri)

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/HttpMediaCompositionService.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/HttpMediaCompositionService.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.core.business.integrationlayer.service
 
 import android.net.Uri
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
+import ch.srgssr.pillarbox.player.network.PillarboxHttpClient
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
@@ -19,7 +20,7 @@ import java.net.URL
  * @param httpClient Ktor HttpClient to make requests.
  */
 class HttpMediaCompositionService(
-    private val httpClient: HttpClient = DefaultHttpClient(),
+    private val httpClient: HttpClient = PillarboxHttpClient(),
 ) : MediaCompositionService {
 
     override suspend fun fetchMediaComposition(uri: Uri): Result<MediaComposition> {

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/TestJsonSerialization.kt
@@ -7,7 +7,7 @@ package ch.srgssr.pillarbox.core.business
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.BlockReason
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
-import ch.srgssr.pillarbox.core.business.integrationlayer.service.DefaultHttpClient.jsonSerializer
+import ch.srgssr.pillarbox.player.network.PillarboxHttpClient.jsonSerializer
 import kotlinx.serialization.SerializationException
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/utils/LocalMediaCompositionWithFallbackService.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/utils/LocalMediaCompositionWithFallbackService.kt
@@ -7,9 +7,9 @@ package ch.srgssr.pillarbox.core.business.utils
 import android.content.Context
 import android.net.Uri
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
-import ch.srgssr.pillarbox.core.business.integrationlayer.service.DefaultHttpClient
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.HttpMediaCompositionService
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.MediaCompositionService
+import ch.srgssr.pillarbox.player.network.PillarboxHttpClient
 
 internal class LocalMediaCompositionWithFallbackService(
     context: Context,
@@ -19,7 +19,7 @@ internal class LocalMediaCompositionWithFallbackService(
 
     init {
         val json = context.assets.open("media-compositions.json").bufferedReader().use { it.readText() }
-        mediaCompositions = DefaultHttpClient.jsonSerializer.decodeFromString(json)
+        mediaCompositions = PillarboxHttpClient.jsonSerializer.decodeFromString(json)
     }
 
     override suspend fun fetchMediaComposition(uri: Uri): Result<MediaComposition> {

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     alias(libs.plugins.pillarbox.android.library.publishing)
     alias(libs.plugins.pillarbox.android.library.tested.module)
     alias(libs.plugins.kotlin.parcelize)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -45,6 +46,17 @@ dependencies {
     implementation(libs.kotlinx.coroutines.guava)
     runtimeOnly(libs.kotlinx.coroutines.android)
     api(libs.kotlinx.coroutines.core)
+    api(libs.kotlinx.serialization.core)
+    implementation(libs.kotlinx.serialization.json)
+    implementation(libs.ktor.client.content.negotiation)
+    api(libs.ktor.client.core)
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.http)
+    implementation(libs.ktor.serialization)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.utils)
+    implementation(libs.okhttp)
+    implementation(libs.okhttp.logging.interceptor)
 
     testImplementation(project(":pillarbox-player-testutils"))
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -292,14 +292,6 @@ class PillarboxExoPlayer internal constructor(
         exoPlayer.replaceMediaItems(fromIndex, toIndex, mediaItems.map { it.clearTag() })
     }
 
-    internal fun getCurrentQoETimings(): QoETimings? {
-        return qosCoordinator.getCurrentQoETimings()
-    }
-
-    internal fun getCurrentQoSTimings(): QoSTimings? {
-        return qosCoordinator.getCurrentQoSTimings()
-    }
-
     private fun handleBlockedTimeRange(timeRange: BlockedTimeRange) {
         clearSeeking()
         exoPlayer.seekTo(timeRange.end + 1)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -141,8 +141,8 @@ class PillarboxExoPlayer internal constructor(
         QoSCoordinator(
             context = context,
             player = this,
-            messageHandler = qosMessageHandler,
             metricsCollector = metricsCollector,
+            messageHandler = qosMessageHandler,
             sessionManager = sessionManager,
             coroutineContext = coroutineContext,
         )
@@ -227,7 +227,7 @@ class PillarboxExoPlayer internal constructor(
         mediaItemTrackerProvider = mediaItemTrackerProvider,
         analyticsCollector = analyticsCollector,
         metricsCollector = metricsCollector,
-        qosMessageHandler,
+        qosMessageHandler = qosMessageHandler,
     )
 
     /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -31,8 +31,12 @@ import ch.srgssr.pillarbox.player.asset.timeRange.Credit
 import ch.srgssr.pillarbox.player.extension.getPlaybackSpeed
 import ch.srgssr.pillarbox.player.extension.setPreferredAudioRoleFlagsToAccessibilityManagerSettings
 import ch.srgssr.pillarbox.player.extension.setSeekIncrements
+import ch.srgssr.pillarbox.player.network.PillarboxHttpClient
+import ch.srgssr.pillarbox.player.qos.LogcatQoSMessageHandler
+import ch.srgssr.pillarbox.player.qos.NoOpQoSMessageHandler
 import ch.srgssr.pillarbox.player.qos.QoSCoordinator
 import ch.srgssr.pillarbox.player.qos.QoSMessageHandler
+import ch.srgssr.pillarbox.player.qos.RemoteQoSMessageHandler
 import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
 import ch.srgssr.pillarbox.player.tracker.AnalyticsMediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.CurrentMediaItemPillarboxDataTracker
@@ -40,9 +44,11 @@ import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerProvider
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerRepository
 import ch.srgssr.pillarbox.player.tracker.TimeRangeTracker
 import ch.srgssr.pillarbox.player.utils.PillarboxEventLogger
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
+import java.net.URL
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -56,6 +62,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * @param mediaItemTrackerProvider The [MediaItemTrackerProvider].
  * @param analyticsCollector The [PillarboxAnalyticsCollector].
  * @param metricsCollector The [MetricsCollector].
+ * @param qosMessageHandler The class to handle each QoS message.
  */
 class PillarboxExoPlayer internal constructor(
     context: Context,
@@ -64,6 +71,7 @@ class PillarboxExoPlayer internal constructor(
     mediaItemTrackerProvider: MediaItemTrackerProvider,
     analyticsCollector: PillarboxAnalyticsCollector,
     private val metricsCollector: MetricsCollector = MetricsCollector(),
+    qosMessageHandler: QoSMessageHandler,
 ) : PillarboxPlayer, ExoPlayer by exoPlayer {
     private val listeners = ListenerSet<PillarboxPlayer.Listener>(applicationLooper, clock) { listener, flags ->
         listener.onEvents(this, Player.Events(flags))
@@ -72,22 +80,6 @@ class PillarboxExoPlayer internal constructor(
     private val analyticsTracker = AnalyticsMediaItemTracker(this, mediaItemTrackerProvider)
     internal val sessionManager = PlaybackSessionManager()
     private val window = Window()
-    private val qosCoordinator = QoSCoordinator(
-        context = context,
-        player = this,
-        metricsCollector = metricsCollector,
-        sessionManager = sessionManager,
-        coroutineContext = coroutineContext,
-    )
-
-    /**
-     * The class to handle each QoS message.
-     */
-    var qosMessageHandler: QoSMessageHandler
-        get() = qosCoordinator.messageHandler
-        set(value) {
-            qosCoordinator.messageHandler = value
-        }
 
     override var smoothSeekingEnabled: Boolean = false
         set(value) {
@@ -146,6 +138,14 @@ class PillarboxExoPlayer internal constructor(
     init {
         sessionManager.setPlayer(this)
         metricsCollector.setPlayer(this)
+        QoSCoordinator(
+            context = context,
+            player = this,
+            messageHandler = qosMessageHandler,
+            metricsCollector = metricsCollector,
+            sessionManager = sessionManager,
+            coroutineContext = coroutineContext,
+        )
         addListener(analyticsCollector)
         exoPlayer.addListener(ComponentListener())
         itemPillarboxDataTracker.addCallback(timeRangeTracker)
@@ -162,6 +162,16 @@ class PillarboxExoPlayer internal constructor(
         mediaItemTrackerProvider: MediaItemTrackerProvider = MediaItemTrackerRepository(),
         seekIncrement: SeekIncrement = SeekIncrement(),
         maxSeekToPreviousPosition: Duration = DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION,
+        coroutineContext: CoroutineContext = Dispatchers.Default,
+        qosMessageHandler: QoSMessageHandler = if (BuildConfig.DEBUG) {
+            RemoteQoSMessageHandler(
+                httpClient = PillarboxHttpClient(),
+                endpointUrl = URL("https://httpbin.org/post"),
+                coroutineScope = CoroutineScope(coroutineContext),
+            )
+        } else {
+            LogcatQoSMessageHandler()
+        },
     ) : this(
         context = context,
         mediaSourceFactory = mediaSourceFactory,
@@ -170,7 +180,8 @@ class PillarboxExoPlayer internal constructor(
         seekIncrement = seekIncrement,
         maxSeekToPreviousPosition = maxSeekToPreviousPosition,
         clock = Clock.DEFAULT,
-        coroutineContext = Dispatchers.Default,
+        coroutineContext = coroutineContext,
+        qosMessageHandler = qosMessageHandler,
     )
 
     @VisibleForTesting
@@ -184,7 +195,8 @@ class PillarboxExoPlayer internal constructor(
         clock: Clock,
         coroutineContext: CoroutineContext,
         analyticsCollector: PillarboxAnalyticsCollector = PillarboxAnalyticsCollector(clock),
-        metricsCollector: MetricsCollector = MetricsCollector()
+        metricsCollector: MetricsCollector = MetricsCollector(),
+        qosMessageHandler: QoSMessageHandler = NoOpQoSMessageHandler,
     ) : this(
         context,
         coroutineContext,
@@ -215,6 +227,7 @@ class PillarboxExoPlayer internal constructor(
         mediaItemTrackerProvider = mediaItemTrackerProvider,
         analyticsCollector = analyticsCollector,
         metricsCollector = metricsCollector,
+        qosMessageHandler,
     )
 
     /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -292,6 +292,14 @@ class PillarboxExoPlayer internal constructor(
         exoPlayer.replaceMediaItems(fromIndex, toIndex, mediaItems.map { it.clearTag() })
     }
 
+    internal fun getCurrentQoETimings(): QoETimings? {
+        return qosCoordinator.getCurrentQoETimings()
+    }
+
+    internal fun getCurrentQoSTimings(): QoSTimings? {
+        return qosCoordinator.getCurrentQoSTimings()
+    }
+
     private fun handleBlockedTimeRange(timeRange: BlockedTimeRange) {
         clearSeeking()
         exoPlayer.seekTo(timeRange.end + 1)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSCoordinator.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSCoordinator.kt
@@ -11,7 +11,6 @@ import android.os.Build
 import android.util.Log
 import androidx.media3.common.C
 import androidx.media3.common.PlaybackException
-import androidx.media3.common.Timeline
 import androidx.media3.common.Timeline.Window
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
@@ -54,7 +53,7 @@ internal class QoSCoordinator(
 ) : PillarboxAnalyticsListener,
     MetricsCollector.Listener,
     PlaybackSessionManager.Listener {
-    private val window = Timeline.Window()
+    private val window = Window()
 
     var messageHandler: QoSMessageHandler = if (BuildConfig.DEBUG) {
         RemoteQoSMessageHandler(

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSCoordinator.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSCoordinator.kt
@@ -17,38 +17,54 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
+import ch.srgssr.pillarbox.player.BuildConfig
 import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsListener
 import ch.srgssr.pillarbox.player.analytics.PlaybackSessionManager
 import ch.srgssr.pillarbox.player.analytics.metrics.MetricsCollector
 import ch.srgssr.pillarbox.player.analytics.metrics.PlaybackMetrics
+import ch.srgssr.pillarbox.player.network.PillarboxHttpClient
 import ch.srgssr.pillarbox.player.qos.models.QoETimings
 import ch.srgssr.pillarbox.player.qos.models.QoSError
 import ch.srgssr.pillarbox.player.qos.models.QoSEvent
 import ch.srgssr.pillarbox.player.qos.models.QoSEvent.StreamType
 import ch.srgssr.pillarbox.player.qos.models.QoSMedia
 import ch.srgssr.pillarbox.player.qos.models.QoSMessage
+import ch.srgssr.pillarbox.player.qos.models.QoSMessage.EventName
+import ch.srgssr.pillarbox.player.qos.models.QoSMessageData
 import ch.srgssr.pillarbox.player.qos.models.QoSSession
 import ch.srgssr.pillarbox.player.qos.models.QoSStall
 import ch.srgssr.pillarbox.player.qos.models.QoSTimings
 import ch.srgssr.pillarbox.player.runOnApplicationLooper
 import ch.srgssr.pillarbox.player.utils.DebugLogger
 import ch.srgssr.pillarbox.player.utils.Heartbeat
+import kotlinx.coroutines.CoroutineScope
 import java.io.IOException
+import java.net.URL
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
 internal class QoSCoordinator(
     private val context: Context,
     private val player: ExoPlayer,
     private val metricsCollector: MetricsCollector,
-    private val messageHandler: QoSMessageHandler,
     private val sessionManager: PlaybackSessionManager,
     private val coroutineContext: CoroutineContext,
 ) : PillarboxAnalyticsListener,
     MetricsCollector.Listener,
     PlaybackSessionManager.Listener {
     private val window = Timeline.Window()
+
+    var messageHandler: QoSMessageHandler = if (BuildConfig.DEBUG) {
+        RemoteQoSMessageHandler(
+            httpClient = PillarboxHttpClient(),
+            endpointUrl = URL("https://httpbin.org/post"),
+            coroutineScope = CoroutineScope(coroutineContext),
+        )
+    } else {
+        LogcatQoSMessageHandler()
+    }
 
     internal class SessionHolder(
         val session: PlaybackSessionManager.Session,
@@ -109,7 +125,7 @@ internal class QoSCoordinator(
     override fun onSessionCreated(session: PlaybackSessionManager.Session) {
         sessionHolders[session.sessionId] = SessionHolder(session, coroutineContext = coroutineContext) {
             player.runOnApplicationLooper {
-                sendEvent(EVENT_HB, session)
+                sendEvent(EventName.HEARTBEAT, session)
             }
         }
     }
@@ -125,7 +141,7 @@ internal class QoSCoordinator(
                 if (holder.state == SessionHolder.State.STARTED) {
                     holder.state = SessionHolder.State.STOPPED
                     sendEvent(
-                        eventName = EVENT_STOP,
+                        eventName = EventName.STOP,
                         session = holder.session,
                         data = metrics.toQoSEvent(oldSession.position, oldSession.session.window),
                     )
@@ -137,9 +153,9 @@ internal class QoSCoordinator(
         val metrics = metricsCollector.getMetricsForSession(session) ?: return
 
         sessionHolders[session.sessionId]?.qosTimings = QoSTimings(
-            asset = metrics.loadDuration.source,
-            drm = metrics.loadDuration.drm,
-            metadata = metrics.loadDuration.asset.takeIf { it != ZERO },
+            asset = metrics.loadDuration.source?.inWholeMilliseconds,
+            drm = metrics.loadDuration.drm?.inWholeMilliseconds,
+            metadata = metrics.loadDuration.asset.takeIf { it != ZERO }?.inWholeMilliseconds,
         )
     }
 
@@ -147,13 +163,15 @@ internal class QoSCoordinator(
         DebugLogger.info(TAG, "onMetricSessionReady $metrics")
         sessionHolders[metrics.sessionId]?.let { holder ->
             val loadDuration = metrics.loadDuration
-            val assetLoadingTime = ((loadDuration.source ?: ZERO) - (holder.qosTimings.asset ?: ZERO)).takeIf { it != ZERO }
-            val metadataLoadingTime = ((loadDuration.asset ?: ZERO) - (holder.qosTimings.metadata ?: ZERO)).takeIf { it != ZERO }
+            val assetLoadingTime = ((loadDuration.source ?: ZERO) - (holder.qosTimings.asset?.milliseconds ?: ZERO))
+                .takeIf { it != ZERO }
+            val metadataLoadingTime = ((loadDuration.asset ?: ZERO) - (holder.qosTimings.metadata?.milliseconds ?: ZERO))
+                .takeIf { it != ZERO }
 
             holder.qoeTimings = QoETimings(
-                asset = assetLoadingTime,
-                metadata = metadataLoadingTime,
-                total = loadDuration.timeToReady,
+                asset = assetLoadingTime?.inWholeMilliseconds,
+                metadata = metadataLoadingTime?.inWholeMilliseconds,
+                total = loadDuration.timeToReady?.inWholeMilliseconds,
             )
 
             sendStartEvent(sessionHolder = holder)
@@ -190,7 +208,7 @@ internal class QoSCoordinator(
             holder.error = error
 
             sendEvent(
-                eventName = EVENT_ERROR,
+                eventName = EventName.ERROR,
                 session = session,
                 data = QoSError(
                     throwable = error,
@@ -211,9 +229,9 @@ internal class QoSCoordinator(
     }
 
     private fun sendEvent(
-        eventName: String,
+        eventName: EventName,
         session: PlaybackSessionManager.Session,
-        data: Any? = null,
+        data: QoSMessageData? = null,
     ) {
         val dataToSend = data
             ?: metricsCollector.getMetricsForSession(session)?.toQoSEvent(
@@ -262,7 +280,7 @@ internal class QoSCoordinator(
 
     private fun sendStartEvent(sessionHolder: SessionHolder) {
         sendEvent(
-            eventName = EVENT_START,
+            eventName = EventName.START,
             session = sessionHolder.session,
             data = QoSSession(
                 context = context,
@@ -281,10 +299,6 @@ internal class QoSCoordinator(
     private companion object {
         private val HEARTBEAT_PERIOD = 30.seconds
         private const val TAG = "QoSCoordinator"
-        private const val EVENT_START = "START"
-        private const val EVENT_ERROR = "ERROR"
-        private const val EVENT_STOP = "STOP"
-        private const val EVENT_HB = "HEARTBEAT"
 
         private fun Window.getPositionTimestamp(position: Long): Long? {
             if (position == C.TIME_UNSET || windowStartTimeMs == C.TIME_UNSET) return null

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSCoordinator.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSCoordinator.kt
@@ -16,12 +16,10 @@ import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
-import ch.srgssr.pillarbox.player.BuildConfig
 import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsListener
 import ch.srgssr.pillarbox.player.analytics.PlaybackSessionManager
 import ch.srgssr.pillarbox.player.analytics.metrics.MetricsCollector
 import ch.srgssr.pillarbox.player.analytics.metrics.PlaybackMetrics
-import ch.srgssr.pillarbox.player.network.PillarboxHttpClient
 import ch.srgssr.pillarbox.player.qos.models.QoETimings
 import ch.srgssr.pillarbox.player.qos.models.QoSError
 import ch.srgssr.pillarbox.player.qos.models.QoSEvent
@@ -36,9 +34,7 @@ import ch.srgssr.pillarbox.player.qos.models.QoSTimings
 import ch.srgssr.pillarbox.player.runOnApplicationLooper
 import ch.srgssr.pillarbox.player.utils.DebugLogger
 import ch.srgssr.pillarbox.player.utils.Heartbeat
-import kotlinx.coroutines.CoroutineScope
 import java.io.IOException
-import java.net.URL
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
@@ -48,22 +44,13 @@ internal class QoSCoordinator(
     private val context: Context,
     private val player: ExoPlayer,
     private val metricsCollector: MetricsCollector,
+    private val messageHandler: QoSMessageHandler,
     private val sessionManager: PlaybackSessionManager,
     private val coroutineContext: CoroutineContext,
 ) : PillarboxAnalyticsListener,
     MetricsCollector.Listener,
     PlaybackSessionManager.Listener {
     private val window = Window()
-
-    var messageHandler: QoSMessageHandler = if (BuildConfig.DEBUG) {
-        RemoteQoSMessageHandler(
-            httpClient = PillarboxHttpClient(),
-            endpointUrl = URL("https://httpbin.org/post"),
-            coroutineScope = CoroutineScope(coroutineContext),
-        )
-    } else {
-        LogcatQoSMessageHandler()
-    }
 
     internal class SessionHolder(
         val session: PlaybackSessionManager.Session,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSMessageHandler.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/QoSMessageHandler.kt
@@ -6,6 +6,14 @@ package ch.srgssr.pillarbox.player.qos
 
 import android.util.Log
 import ch.srgssr.pillarbox.player.qos.models.QoSMessage
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import java.net.URL
 
 /**
  * QoS message handler
@@ -20,12 +28,47 @@ interface QoSMessageHandler {
 }
 
 /**
- * Dummy QoS handler
+ * QoS message handler that does nothing.
  */
-object DummyQoSHandler : QoSMessageHandler {
-    private const val TAG = "DummyQoSHandler"
+object NoOpQoSMessageHandler : QoSMessageHandler {
+    override fun sendEvent(event: QoSMessage) = Unit
+}
 
+/**
+ * QoS message handler that logs each event in Logcat.
+ *
+ * @param priority The priority of this message.
+ * @param tag The tag to use to log the events in Logcat.
+ */
+class LogcatQoSMessageHandler(
+    private val priority: Int = Log.DEBUG,
+    private val tag: String = "LogcatQoSHandler",
+) : QoSMessageHandler {
     override fun sendEvent(event: QoSMessage) {
-        Log.d(TAG, "sendEvent($event)")
+        Log.println(priority, tag, "event=$event")
+    }
+}
+
+/**
+ * QoS message handler that posts each event to the [endpointUrl].
+ *
+ * @param httpClient The [HttpClient] to use to send the events.
+ * @param endpointUrl The endpoint receiving QoS messages.
+ * @param coroutineScope The scope used to send the QoS message.
+ */
+class RemoteQoSMessageHandler(
+    private val httpClient: HttpClient,
+    private val endpointUrl: URL,
+    private val coroutineScope: CoroutineScope,
+) : QoSMessageHandler {
+    override fun sendEvent(event: QoSMessage) {
+        coroutineScope.launch {
+            runCatching {
+                httpClient.post(endpointUrl) {
+                    contentType(ContentType.Application.Json)
+                    setBody(event)
+                }
+            }
+        }
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoETimings.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoETimings.kt
@@ -4,18 +4,19 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
-import kotlin.time.Duration
+import kotlinx.serialization.Serializable
 
 /**
  * Represents the timings until the current media started to play, as experienced by the user.
  *
- * @property asset The time spent to load the asset.
- * @property metadata The time spent to load the media source.
+ * @property asset The time spent to load the asset, in milliseconds.
+ * @property metadata The time spent to load the media source, in milliseconds.
  * @property total The time spent to load from the moment the [MediaItem][androidx.media3.common.MediaItem] became the current item until it
- * started to play.
+ * started to play, in milliseconds.
  */
+@Serializable
 data class QoETimings(
-    val asset: Duration? = null,
-    val metadata: Duration? = null,
-    val total: Duration? = null,
+    val asset: Long? = null,
+    val metadata: Long? = null,
+    val total: Long? = null,
 )

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSDevice.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSDevice.kt
@@ -4,6 +4,9 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Information about the device.
  *
@@ -11,20 +14,27 @@ package ch.srgssr.pillarbox.player.qos.models
  * @property model The model of the device.
  * @property type The type of device.
  */
+@Serializable
 data class QoSDevice(
     val id: String,
     val model: String,
-    val type: DeviceType,
+    val type: DeviceType?,
 ) {
     /**
      * The type of device.
      */
     enum class DeviceType {
+        @SerialName("Car")
         CAR,
+
+        @SerialName("Desktop")
         DESKTOP,
+
+        @SerialName("Phone")
         PHONE,
+
+        @SerialName("Tablet")
         TABLET,
         TV,
-        UNKNOWN,
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSError.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSError.kt
@@ -7,11 +7,13 @@ package ch.srgssr.pillarbox.player.qos.models
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.player.extension.getPositionTimestamp
 import ch.srgssr.pillarbox.player.qos.models.QoSError.Severity
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
  * Represents a [Player][androidx.media3.common.Player] error to send to a QoS server.
  *
- * @property duration The duration of the media being player.
+ * @property duration The duration of the media being player, in milliseconds.
  * @property log The log associated with the error.
  * @property message The error message.
  * @property name The name of the error.
@@ -20,16 +22,17 @@ import ch.srgssr.pillarbox.player.qos.models.QoSError.Severity
  * @property severity The severity of the error, either [FATAL][Severity.FATAL] or [WARNING][Severity.WARNING].
  * @property url The last loaded url.
  */
+@Serializable
 data class QoSError(
     val duration: Long?,
     val log: String,
     val message: String,
     val name: String,
     val position: Long?,
-    val positionTimestamp: Long?,
+    @SerialName("position_timestamp") val positionTimestamp: Long?,
     val severity: Severity,
     val url: String,
-) {
+) : QoSMessageData {
     /**
      * Represents a [Player][androidx.media3.common.Player] error severity.
      */

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSEvent.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSEvent.kt
@@ -4,13 +4,16 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Represents a generic event, which contains metrics about the current media stream.
  *
  * @property bandwidth The device-measured network bandwidth, in bits per second.
  * @property bitrate The bitrate of the current stream, in bits per second.
  * @property bufferDuration The forward duration of the buffer, in milliseconds.
- * @property duration The duration of the media being player.
+ * @property duration The duration of the media being player, in milliseconds.
  * @property playbackDuration The duration of the playback, in milliseconds.
  * @property position The position of the player, in milliseconds.
  * @property positionTimestamp The current player timestamp, as retrieved from the playlist.
@@ -19,24 +22,28 @@ package ch.srgssr.pillarbox.player.qos.models
  * @property url The URL of the stream.
  * @property vpn `true` if a VPN is enabled, `false` otherwise, `null` if the status could not be determined.
  */
+@Serializable
 data class QoSEvent(
     val bandwidth: Long,
     val bitrate: Long,
-    val bufferDuration: Long,
+    @SerialName("buffered_duration") val bufferDuration: Long,
     val duration: Long,
-    val playbackDuration: Long,
+    @SerialName("playback_duration") val playbackDuration: Long,
     val position: Long,
-    val positionTimestamp: Long?,
+    @SerialName("position_timestamp") val positionTimestamp: Long?,
     val stall: QoSStall,
-    val streamType: StreamType,
+    @SerialName("stream_type") val streamType: StreamType,
     val url: String,
     val vpn: Boolean?,
-) {
+) : QoSMessageData {
     /**
      * The type of stream (live or on demand).
      */
     enum class StreamType {
+        @SerialName("Live")
         LIVE,
+
+        @SerialName("On-demand")
         ON_DEMAND,
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSMedia.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSMedia.kt
@@ -4,6 +4,9 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Information about the media being played.
  *
@@ -12,9 +15,10 @@ package ch.srgssr.pillarbox.player.qos.models
  * @property metadataUrl The URL of the metadata.
  * @property origin The origin of the media.
  */
+@Serializable
 data class QoSMedia(
-    val assetUrl: String,
+    @SerialName("asset_url") val assetUrl: String,
     val id: String,
-    val metadataUrl: String,
+    @SerialName("metadata_url") val metadataUrl: String,
     val origin: String,
 )

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSMessage.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSMessage.kt
@@ -4,6 +4,9 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
 /**
  * Represents a QoS message.
  *
@@ -13,10 +16,21 @@ package ch.srgssr.pillarbox.player.qos.models
  * @property timestamp The current timestamp.
  * @property version The version of the schema used in [data].
  */
+@Serializable
 data class QoSMessage(
-    val data: Any,
-    val eventName: String,
-    val sessionId: String,
+    val data: QoSMessageData,
+    @SerialName("event_name") val eventName: EventName,
+    @SerialName("session_id") val sessionId: String,
     val timestamp: Long = System.currentTimeMillis(),
     val version: Int = 1,
-)
+) {
+    /**
+     * The name of the event that triggered this QoS message.
+     */
+    enum class EventName {
+        ERROR,
+        HEARTBEAT,
+        START,
+        STOP,
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSMessageData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSMessageData.kt
@@ -7,13 +7,7 @@ package ch.srgssr.pillarbox.player.qos.models
 import kotlinx.serialization.Serializable
 
 /**
- * Information about the device screen.
- *
- * @property height The height of the screen, in pixels.
- * @property width The width of the screen, in pixels.
+ * Base interface for all QoS message data.
  */
 @Serializable
-data class QoSScreen(
-    val height: Int,
-    val width: Int,
-)
+sealed interface QoSMessageData

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSOS.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSOS.kt
@@ -4,12 +4,15 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
+import kotlinx.serialization.Serializable
+
 /**
  * Information about the operating system.
  *
  * @property name The name of the operating system.
  * @property version The version of the operating system.
  */
+@Serializable
 data class QoSOS(
     val name: String,
     val version: String,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSPlayer.kt
@@ -4,6 +4,8 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
+import kotlinx.serialization.Serializable
+
 /**
  * Information about the player.
  *
@@ -11,6 +13,7 @@ package ch.srgssr.pillarbox.player.qos.models
  * @property platform The platform of the player.
  * @property version The version of the player.
  */
+@Serializable
 data class QoSPlayer(
     val name: String,
     val platform: String,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSSession.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSSession.kt
@@ -13,6 +13,8 @@ import android.provider.Settings.Secure
 import android.view.WindowManager
 import ch.srgssr.pillarbox.player.BuildConfig
 import ch.srgssr.pillarbox.player.qos.models.QoSDevice.DeviceType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 /**
  * Represents a QoS session, which contains information about the device, current media, and player.
@@ -25,10 +27,11 @@ import ch.srgssr.pillarbox.player.qos.models.QoSDevice.DeviceType
  * @property qosTimings The metrics about the time needed to load the various media components, during the preload phase.
  * @property screen The information about the device screen.
  */
+@Serializable
 data class QoSSession(
     val device: QoSDevice,
     val media: QoSMedia,
-    val operatingSystem: QoSOS = QoSOS(
+    @SerialName("os") val operatingSystem: QoSOS = QoSOS(
         name = PLATFORM_NAME,
         version = OPERATING_SYSTEM_VERSION,
     ),
@@ -37,10 +40,10 @@ data class QoSSession(
         platform = PLATFORM_NAME,
         version = PLAYER_VERSION,
     ),
-    val qoeTimings: QoETimings = QoETimings(),
-    val qosTimings: QoSTimings = QoSTimings(),
+    @SerialName("qoe_timings") val qoeTimings: QoETimings = QoETimings(),
+    @SerialName("qos_timings") val qosTimings: QoSTimings = QoSTimings(),
     val screen: QoSScreen,
-) {
+) : QoSMessageData {
     constructor(
         context: Context,
         media: QoSMedia,
@@ -66,8 +69,8 @@ data class QoSSession(
     private companion object {
         private val OPERATING_SYSTEM_VERSION = Build.VERSION.RELEASE
         private const val PHONE_TABLET_WIDTH_THRESHOLD = 600
-        private const val PLATFORM_NAME = "android"
-        private const val PLAYER_NAME = "pillarbox"
+        private const val PLATFORM_NAME = "Android"
+        private const val PLAYER_NAME = "Pillarbox"
         private const val PLAYER_VERSION = BuildConfig.VERSION_NAME
 
         @SuppressLint("HardwareIds")
@@ -82,7 +85,7 @@ data class QoSSession(
             return Build.MANUFACTURER + " " + Build.MODEL
         }
 
-        private fun Context.getDeviceType(): DeviceType {
+        private fun Context.getDeviceType(): DeviceType? {
             val configuration = resources.configuration
             return when (configuration.uiMode and Configuration.UI_MODE_TYPE_MASK) {
                 Configuration.UI_MODE_TYPE_CAR -> DeviceType.CAR
@@ -98,7 +101,7 @@ data class QoSSession(
                 }
 
                 Configuration.UI_MODE_TYPE_TELEVISION -> DeviceType.TV
-                else -> DeviceType.UNKNOWN
+                else -> null
             }
         }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSStall.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSStall.kt
@@ -4,12 +4,15 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
+import kotlinx.serialization.Serializable
+
 /**
  * Information about stalls.
  *
  * @property count The number of stalls that have occurred, not as a result of a seek.
  * @property duration The total duration of the stalls, in milliseconds.
  */
+@Serializable
 data class QoSStall(
     val count: Int,
     val duration: Long,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSTimings.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/qos/models/QoSTimings.kt
@@ -4,19 +4,20 @@
  */
 package ch.srgssr.pillarbox.player.qos.models
 
-import kotlin.time.Duration
+import kotlinx.serialization.Serializable
 
 /**
  * Represents the timings until the current media started to play, during the preload phase.
  *
- * @property asset The time spent to load the asset.
- * @property drm The time spent to load the DRM.
- * @property metadata The time spent to load the media source.
- * @property token The time spent to load the token.
+ * @property asset The time spent to load the asset, in milliseconds.
+ * @property drm The time spent to load the DRM, in milliseconds.
+ * @property metadata The time spent to load the media source, in milliseconds.
+ * @property token The time spent to load the token, in milliseconds.
  */
+@Serializable
 data class QoSTimings(
-    val asset: Duration? = null,
-    val drm: Duration? = null,
-    val metadata: Duration? = null,
-    val token: Duration? = null,
+    val asset: Long? = null,
+    val drm: Long? = null,
+    val metadata: Long? = null,
+    val token: Long? = null,
 )

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
@@ -167,6 +167,7 @@ class PlaybackSessionManagerTest {
         verifyOrder {
             sessionManagerListener.onSessionCreated(capture(sessionCreated))
             sessionManagerListener.onCurrentSessionChanged(null, captureNullable(newSession))
+            sessionManagerListener.onSessionDestroyed(capture(sessionDestroyed))
             sessionManagerListener.onCurrentSessionChanged(captureNullable(oldSession), null)
             sessionManagerListener.onSessionDestroyed(capture(sessionDestroyed))
         }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
@@ -167,7 +167,6 @@ class PlaybackSessionManagerTest {
         verifyOrder {
             sessionManagerListener.onSessionCreated(capture(sessionCreated))
             sessionManagerListener.onCurrentSessionChanged(null, captureNullable(newSession))
-            sessionManagerListener.onSessionDestroyed(capture(sessionDestroyed))
             sessionManagerListener.onCurrentSessionChanged(captureNullable(oldSession), null)
             sessionManagerListener.onSessionDestroyed(capture(sessionDestroyed))
         }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/QosCoordinatorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/QosCoordinatorTest.kt
@@ -63,10 +63,9 @@ class QosCoordinatorTest {
             player = player,
             metricsCollector = metricsCollector,
             sessionManager = player.sessionManager,
+            messageHandler = qosMessageHandler,
             coroutineContext = EmptyCoroutineContext,
-        ).apply {
-            messageHandler = qosMessageHandler
-        }
+        )
         player.prepare()
         player.play()
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/QosCoordinatorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/QosCoordinatorTest.kt
@@ -17,6 +17,7 @@ import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.SeekIncrement
 import ch.srgssr.pillarbox.player.analytics.metrics.MetricsCollector
 import ch.srgssr.pillarbox.player.qos.models.QoSMessage
+import ch.srgssr.pillarbox.player.qos.models.QoSMessage.EventName
 import ch.srgssr.pillarbox.player.qos.models.QoSTimings
 import ch.srgssr.pillarbox.player.source.PillarboxMediaSourceFactory
 import io.mockk.clearAllMocks
@@ -33,7 +34,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNotSame
 import kotlin.test.assertTrue
-import kotlin.time.Duration.Companion.ZERO
 
 @RunWith(AndroidJUnit4::class)
 class QosCoordinatorTest {
@@ -63,9 +63,10 @@ class QosCoordinatorTest {
             player = player,
             metricsCollector = metricsCollector,
             sessionManager = player.sessionManager,
-            messageHandler = qosMessageHandler,
             coroutineContext = EmptyCoroutineContext,
-        )
+        ).apply {
+            messageHandler = qosMessageHandler
+        }
         player.prepare()
         player.play()
     }
@@ -99,13 +100,13 @@ class QosCoordinatorTest {
         confirmVerified(qosMessageHandler)
 
         assertEquals(3, messages.size)
-        assertEquals(listOf("START", "HEARTBEAT", "STOP"), messages.map { it.eventName })
+        assertEquals(listOf(EventName.START, EventName.HEARTBEAT, EventName.STOP), messages.map { it.eventName })
         assertEquals(1, messages.distinctBy { it.sessionId }.count())
 
         assertEquals(QoSTimings(), qosTimings)
         assertNotNull(qoeTimings)
         assertNotNull(qoeTimings.total)
-        assertTrue(qoeTimings.total != ZERO)
+        assertTrue(qoeTimings.total != 0L)
     }
 
     @Test
@@ -141,7 +142,10 @@ class QosCoordinatorTest {
         confirmVerified(qosMessageHandler)
 
         assertEquals(6, messages.size)
-        assertEquals(listOf("START", "HEARTBEAT", "STOP", "START", "HEARTBEAT", "STOP"), messages.map { it.eventName })
+        assertEquals(
+            listOf(EventName.START, EventName.HEARTBEAT, EventName.STOP, EventName.START, EventName.HEARTBEAT, EventName.STOP),
+            messages.map { it.eventName },
+        )
         assertEquals(2, messages.distinctBy { it.sessionId }.count())
 
         assertNotSame(qosTimings1, qosTimings2)
@@ -150,12 +154,12 @@ class QosCoordinatorTest {
         assertEquals(QoSTimings(), qosTimings1)
         assertNotNull(qoeTimings1)
         assertNotNull(qoeTimings1.total)
-        assertTrue(qoeTimings1.total != ZERO)
+        assertTrue(qoeTimings1.total != 0L)
 
         assertEquals(QoSTimings(), qosTimings2)
         assertNotNull(qoeTimings2)
         assertNotNull(qoeTimings2.total)
-        assertTrue(qoeTimings2.total != ZERO)
+        assertTrue(qoeTimings2.total != 0L)
     }
 
     @Test
@@ -180,7 +184,7 @@ class QosCoordinatorTest {
         confirmVerified(qosMessageHandler)
 
         assertEquals(2, messages.size)
-        assertEquals(listOf("START", "ERROR"), messages.map { it.eventName })
+        assertEquals(listOf(EventName.START, EventName.ERROR), messages.map { it.eventName })
         assertEquals(1, messages.distinctBy { it.sessionId }.count())
     }
 

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/models/QoSErrorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/models/QoSErrorTest.kt
@@ -37,7 +37,6 @@ class QoSErrorTest {
 
     @Test
     fun `throwableConstructor with empty exception`() {
-        val player = createPlayer()
         val throwable = IllegalStateException()
         val qosError = QoSError(
             throwable = throwable,
@@ -62,7 +61,6 @@ class QoSErrorTest {
 
     @Test
     fun `throwableConstructor with detailed exception`() {
-        val player = createPlayer()
         val cause = NullPointerException("Expected 'foo' to be not null")
         val throwable = RuntimeException("Something bad happened", cause)
         val qosError = QoSError(
@@ -93,13 +91,5 @@ class QoSErrorTest {
         private val DURATION = 10.minutes.inWholeMilliseconds
         private val CURRENT_POSITION = 30.seconds.inWholeMilliseconds
         private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8"
-
-        private fun createPlayer(): Player {
-            return mockk {
-                every { duration } returns DURATION
-                every { currentPosition } returns CURRENT_POSITION
-                every { currentTimeline } returns Timeline.EMPTY
-            }
-        }
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/models/QoSErrorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/models/QoSErrorTest.kt
@@ -37,6 +37,7 @@ class QoSErrorTest {
 
     @Test
     fun `throwableConstructor with empty exception`() {
+        val player = createPlayer()
         val throwable = IllegalStateException()
         val qosError = QoSError(
             throwable = throwable,
@@ -61,6 +62,7 @@ class QoSErrorTest {
 
     @Test
     fun `throwableConstructor with detailed exception`() {
+        val player = createPlayer()
         val cause = NullPointerException("Expected 'foo' to be not null")
         val throwable = RuntimeException("Something bad happened", cause)
         val qosError = QoSError(
@@ -91,5 +93,13 @@ class QoSErrorTest {
         private val DURATION = 10.minutes.inWholeMilliseconds
         private val CURRENT_POSITION = 30.seconds.inWholeMilliseconds
         private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8"
+
+        private fun createPlayer(): Player {
+            return mockk {
+                every { duration } returns DURATION
+                every { currentPosition } returns CURRENT_POSITION
+                every { currentTimeline } returns Timeline.EMPTY
+            }
+        }
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/models/QoSSessionTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/qos/models/QoSSessionTest.kt
@@ -11,6 +11,7 @@ import org.junit.runner.RunWith
 import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @RunWith(AndroidJUnit4::class)
 class QoSSessionTest {
@@ -204,7 +205,7 @@ class QoSSessionTest {
 
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
-        assertEquals(QoSDevice.DeviceType.UNKNOWN, qosSession.device.type)
+        assertNull(qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
@@ -240,10 +241,10 @@ class QoSSessionTest {
         private const val ASSET_URL = "https://rts-vod-amd.akamaized.net/ww/12345/3037738d-fe91-32e3-93f2-4dbb62a0f9bd/master.m3u8"
         private const val MEDIA_ID = "urn:rts:video:12345"
         private const val METADATA_URL = "https://il-stage.srgssr.ch/integrationlayer/2.1/mediaComposition/byUrn/urn:rts:video:12345?vector=APPPLAY"
-        private const val OPERATING_SYSTEM_NAME = "android"
+        private const val OPERATING_SYSTEM_NAME = "Android"
         private const val ORIGIN = "ch.srgssr.pillarbox.player.test"
-        private const val PLAYER_NAME = "pillarbox"
-        private const val PLAYER_PLATFORM = "android"
+        private const val PLAYER_NAME = "Pillarbox"
+        private const val PLAYER_PLATFORM = "Android"
         private const val PLAYER_VERSION = "Local"
         private const val SCREEN_HEIGHT = 470
         private const val SCREEN_WIDTH = 320


### PR DESCRIPTION
# Pull request

## Description

This PR exposes a new field in `PillarboxExoPlayer` to allow the integrator to customize what to do with QoS events.

## Changes made

- Add `PillarboxExoPlayer.qosMessageHandler` to allow integrator to decide what to do with QoS events. For now, it logs the events in Logcat in release or sends them to `httpbin.org` in debug.
- Create a new `PillarboxHttpClient` in `pillarbox-player`.
- Deprecate the existing `DefaultHttpClient` class in `pillarbox-core-business` in favor of `PillarboxHttpClient`.
- Add an enum for the event name in `QoSMessage`.
- Add the `QoSMessagedata` interface for the data in `QoSMessage`.
- Provide three implementations of `QoSMessageHandler`: `NoOpQoSMessageHandler`, `LogcatQoSMessageHandler` and `RemoteQoSMessageHandler`.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.