### PR TITLE
Add missing Detekt rules

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,6 +1,28 @@
 # Official doc at https://detekt.dev/docs/rules/style#libraryentitiesshouldnotbepublic
 
+comments:
+  AbsentOrWrongFileLicense:
+    active: true
+
+  DeprecatedBlockTag:
+    active: true
+
+  OutdatedDocumentation:
+    active: true
+
+  UndocumentedPublicClass:
+    active: true
+
+  UndocumentedPublicFunction:
+    active: true
+
+  UndocumentedPublicProperty:
+    active: true
+
 complexity:
+  ComplexInterface:
+    active: true
+
   LargeClass:
     active: false
 
@@ -12,10 +34,26 @@ complexity:
     ignoreAnnotated: [ 'Composable' ]
     ignoreDefaultParameters: true
 
+  NamedArguments:
+    active: true
+
+  NestedScopeFunctions:
+    active: true
+
+  ReplaceSafeCallChainWithRun:
+    active: true
+
+  StringLiteralDuplication:
+    active: true
+
   TooManyFunctions:
     ignoreAnnotatedFunctions: [ 'Composable', 'Preview', 'PreviewLightDark' ]
     ignoreOverridden: true
     ignorePrivate: true
+
+coroutines:
+  GlobalCoroutineUsage:
+    active: true
 
 empty-blocks:
   EmptyFunctionBlock:
@@ -28,10 +66,22 @@ formatting:
   CommentWrapping:
     active: false
 
+  FunctionReturnTypeSpacing:
+    maxLineLength: 150
+
   MaximumLineLength:
     maxLineLength: 150
 
+  ParameterListWrapping:
+    maxLineLength: 150
+
+  ParameterWrapping:
+    maxLineLength: 150
+
   PropertyWrapping:
+    maxLineLength: 150
+
+  Wrapping:
     maxLineLength: 150
 
 naming:
@@ -41,7 +91,20 @@ naming:
   TopLevelPropertyNaming:
     constantPattern: '[A-Z][A-Za-z0-9]*'
 
+potential-bugs:
+  DontDowncastCollectionTypes:
+    active: true
+
 style:
+  CascadingCallWrapping:
+    active: true
+
+  ClassOrdering:
+    active: true
+
+  CollapsibleIfStatements:
+    active: true
+
   MagicNumber:
     ignoreAnnotated: [ 'Composable' ]
     ignorePropertyDeclaration: true

--- a/config/detekt/license.template
+++ b/config/detekt/license.template
@@ -1,0 +1,4 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/IlHost.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/IlHost.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
 package ch.srgssr.pillarbox.core.business.integrationlayer.service
 
 import java.net.URL

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
 package ch.srgssr.pillarbox.demo.cast
 
 import android.os.Bundle

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/ui/theme/Theme.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/ui/theme/Theme.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
 package ch.srgssr.pillarbox.demo.cast.ui.theme
 
 import android.app.Activity

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/EventMessageData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/EventMessageData.kt
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */


### PR DESCRIPTION
# Pull request

## Description

Following the merge of #703, some Detekt rules (in particular about the documentation) are no longer enabled. I went through the old Detekt config file and added the missing rules.

## Changes made

- Re-enable rules for documentation.
- Re-enable rules for complexity.
- Re-enable rules for coroutines.
- Re-enable rules for naming.
- Re-enable rules for style.
- Adjust some formatting rules (was not done before).

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.