### PR TITLE
Make the slider interactive again

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/ResizablePlayerShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/ResizablePlayerShowcase.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.demo.ui.showcases.misc
 
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -159,6 +160,7 @@ private fun SliderWithLabel(
             activeTrackColorDisabled = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             inactiveTrackColorEnabled = MaterialTheme.colorScheme.surfaceVariant,
             inactiveTrackColorDisabled = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+            interactionSource = remember { MutableInteractionSource() },
             onValueChange = onValueChange,
         )
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SmoothSeekingShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SmoothSeekingShowcase.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.misc
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -91,7 +92,8 @@ fun SmoothSeekingShowcase() {
                     .padding(horizontal = MaterialTheme.paddings.small)
                     .align(Alignment.BottomCenter),
                 player = player,
-                progressTracker = rememberProgressTrackerState(player = player, smoothTracker = smoothSeekingEnabled)
+                progressTracker = rememberProgressTrackerState(player = player, smoothTracker = smoothSeekingEnabled),
+                interactionSource = remember { MutableInteractionSource() },
             )
         }
         Row(


### PR DESCRIPTION
# Pull request

## Description

This PR makes the slider interactive again in `ResizablePlayerShowcase` and `SmoothSeekingShowcase`. The issue was introduced in #698, where `interactionSource` was made optional to follow Android's recommendation. However, these two usages were not updated to provide a non-`null` argument.

Fixes #722

## Changes made

- Self-explanatory.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.