### PR TITLE
Update to Gradle 8.10.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
----
 name: 🐞 Bug report
 description: File a bug report
-labels: ["bug", "triage"]
+labels: [ "bug", "triage" ]
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,2 +1,1 @@
----
 blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
----
 name: 💡 Feature request
 description: Request a feature or submit an idea you have.
-labels: ["enhancement", "triage"]
+labels: [ "enhancement", "triage" ]
 body:
   - type: textarea
     id: use_case

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,4 +1,3 @@
----
 name: 💭 Question
 description: Ask us for guidance or help.
 labels: ["question", "triage"]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-> Describe enhancements with sufficient details (e.g. implementation considerations, design choices, etc.). For bug reports please mention the issue number that was fixed. If no matching bug report exists you should [open one](https://github.com/SRGSSR/pillarbox-android/issues/new?assignees=&labels=bug%2Ctriage&template=bug_report.yml) first.
+> Describe your changes with sufficient details (e.g., implementation considerations, design choices, etc.). For bug reports, please mention the issue number that was fixed. If no matching bug report exists, you should [open one](https://github.com/SRGSSR/pillarbox-android/issues/new?template=bug_report.yml) first.
 
 ## Changes made
 
@@ -10,9 +10,7 @@
 
 ## Checklist
 
-- [ ] Your branch has been rebased onto the `main` branch.
 - [ ] APIs have been properly documented (if relevant).
 - [ ] The documentation has been updated (if relevant).
 - [ ] New unit tests have been written (if relevant).
 - [ ] The demo has been updated (if relevant).
-- [ ] All pull request status checks pass.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,13 @@
 
 version: 2
 
+registries:
+  srgdataprovider-android:
+    type: maven-repository
+    url: https://maven.pkg.github.com/SRGSSR/srgdataprovider-android
+    username: token
+    password: ${{ secrets.DEPENDABOT_PACKAGE_SECRET }}
+
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -17,10 +24,15 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    registries:
+      - "srgdataprovider-android"
     groups:
       androidx:
         patterns:
           - "androidx.*"
+      srgssr:
+        patterns:
+          - "ch.srg*"
     ignore:
       - dependency-name: "com.comscore:*"
       - dependency-name: "com.tagcommander.lib:*"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,9 +7,15 @@ pluginManagement {
     includeBuild("build-logic")
 
     repositories {
-        gradlePluginPortal()
-        google()
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
+            }
+        }
         mavenCentral()
+        gradlePluginPortal()
     }
 }
 
@@ -23,18 +29,22 @@ dependencyResolutionManagement {
             .orElse(providers.environmentVariable("GITHUB_TOKEN"))
             .get()
 
-        google()
-        mavenCentral()
-        maven("https://maven.pkg.github.com/SRGSSR/pillarbox-android") {
-            credentials {
-                username = gitHubUsername
-                password = gitHubKey
+        google {
+            content {
+                includeGroupByRegex("com\\.android.*")
+                includeGroupByRegex("com\\.google.*")
+                includeGroupByRegex("androidx.*")
             }
         }
+        mavenCentral()
         maven("https://maven.pkg.github.com/SRGSSR/srgdataprovider-android") {
             credentials {
                 username = gitHubUsername
                 password = gitHubKey
+            }
+
+            content {
+                includeGroupByRegex("ch\\.srg.*")
             }
         }
     }


### PR DESCRIPTION
# Pull request

## Description

Update to Gradle 8.10.2. The release notes are available [here](https://github.com/gradle/gradle/releases/tag/v8.10.2).

## Changes made

- Update to Gradle 8.10.2.
- Update the PR template to remove automatic checks: branch is up to date, checks pass.
- Add support for private repositories to Dependabot.
- Indicate which dependencies come from which repositories in `settings.gradle.kts`.

## Checklist

- [x] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [x] All pull request status checks pass.