### PR TITLE
Add surface type to PlayerSurface

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/OptimizedStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/OptimizedStory.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.ScaleMode
 import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
+import ch.srgssr.pillarbox.ui.widget.player.SurfaceType
 
 /**
  * Optimized story trying to reproduce story-like TikTok or Instagram.
@@ -78,6 +79,8 @@ fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
                 PlayerSurface(
                     modifier = Modifier.fillMaxHeight(),
                     scaleMode = ScaleMode.Crop,
+                    // Using Texture instead of Surface because on Android34 animations are not working well due to the hack.
+                    surfaceType = SurfaceType.Texture,
                     player = player,
                 )
             }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/OptimizedStory.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/OptimizedStory.kt
@@ -79,7 +79,8 @@ fun OptimizedStory(storyViewModel: StoryViewModel = viewModel()) {
                 PlayerSurface(
                     modifier = Modifier.fillMaxHeight(),
                     scaleMode = ScaleMode.Crop,
-                    // Using Texture instead of Surface because on Android34 animations are not working well due to the hack.
+                    // Using Texture instead of Surface because on Android API 34 animations are not working well due to the hack
+                    // See PlayerSurfaceView in AndroidPlayerSurfaceView
                     surfaceType = SurfaceType.Texture,
                     player = player,
                 )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
@@ -14,7 +14,9 @@ import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.core.business.SRGMediaItemBuilder
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
-import ch.srgssr.pillarbox.ui.widget.player.SphericalSurface
+import ch.srgssr.pillarbox.ui.ScaleMode
+import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
+import ch.srgssr.pillarbox.ui.widget.player.SurfaceType
 
 /**
  * Showcase how to display a spherical surface to play 360° video.
@@ -43,5 +45,10 @@ fun SphericalSurfaceShowcase() {
         }
     }
 
-    SphericalSurface(player = player, modifier = Modifier.fillMaxSize())
+    PlayerSurface(
+        player = player,
+        modifier = Modifier.fillMaxSize(),
+        surfaceType = SurfaceType.Spherical,
+        scaleMode = ScaleMode.Fill,
+    )
 }

--- a/pillarbox-ui/docs/README.md
+++ b/pillarbox-ui/docs/README.md
@@ -114,7 +114,7 @@ fun MyPlayerView(player: Player) {
         Text(text = "Duration = $duration ms", modifier = Modifier.align(Alignment.TopEnd))
         
         val isPlaying = player.isPlayingAsState()
-        Button(modifier = Modifier = Modififer.align(Alignement.Center), onClick = { togglePlayingBack() }){
+        Button(modifier = Modififer.align(Alignement.Center), onClick = { togglePlayingBack() }){
             Text(text = if(isPlaying) "Pause" else "Play")
         }
     }

--- a/pillarbox-ui/docs/README.md
+++ b/pillarbox-ui/docs/README.md
@@ -34,7 +34,7 @@ fun SimplePlayer(player: Player){
 
 ### Create a simple player with controls and subtitles
 
-In this example we are drawing controls and subtitles on top of the player surface. To add subtitles use `ExoPlayerSubtitleView` and for controls
+In this example, we are drawing controls and subtitles on top of the player surface. To add subtitles use `ExoPlayerSubtitleView` and for controls
 you can use the Exoplayer version, `ExoPlayerControlView`.
 
 ```kotlin
@@ -52,7 +52,8 @@ fun MyPlayer(player: Player) {
             modifier = Modifier,
             player = player,
             scaleMode = ScaleMode.Fit,
-            defaultAspectRatio = defaultAspectRatio
+            defaultAspectRatio = defaultAspectRatio,
+            surfaceType = SurfaceType.Surface, // By default
         )
         ExoPlayerControlView(modifier = Modifier.matchParentSize(), player = player)
         ExoPlayerSubtitleView(modifier = Modifier.matchParentSize(), player = player)
@@ -67,6 +68,21 @@ In this example we use `ScaleMode.Fit` to fit the content to the parent containe
 - `ScaleMode.Fit` : Fit player content to the parent container and keep aspect ratio.
 - `ScaleMode.Fill` : Fill player content to the parent container.
 - `ScaleMode.Crop` : Crop player content inside the parent container and keep aspect ratio. Content outside the parent container will be clipped.
+
+## Surface types
+
+PlayerSurface allows choosing between multiple surface types:
+
+ - `SurfaceType.Surface` : The player is linked to a `SurfaceView` the default option.
+   This option is the more optimized version and allows to play 
+   any content including DRM protected content.
+ - `SurfaceType.Texture`: The player is linked to a `TextureView`.
+   This surface maybe interesting when dealing with animation and surface type has 
+   issue.
+ - `SurfaceType.Spherical` : The player is linked to a `SphericalGLSurfaceView`. This surface type is suited when playing 360° video content.
+
+The two last surface types are not suited when playing DRM protected content.
+
 
 ### Listen to player states
 

--- a/pillarbox-ui/docs/README.md
+++ b/pillarbox-ui/docs/README.md
@@ -25,7 +25,7 @@ More information can be found on the [top level README](../docs/README.md)
 
 ```kotlin
 @Composable
-fun SimplePlayer(player: Player){
+fun SimplePlayer(player: Player) {
     Box(modifier = Modifier) {
         PlayerSurface(player = player)
     }
@@ -69,20 +69,18 @@ In this example we use `ScaleMode.Fit` to fit the content to the parent containe
 - `ScaleMode.Fill` : Fill player content to the parent container.
 - `ScaleMode.Crop` : Crop player content inside the parent container and keep aspect ratio. Content outside the parent container will be clipped.
 
-## Surface types
+### Surface types
 
-PlayerSurface allows choosing between multiple surface types:
+`PlayerSurface` allows choosing between multiple types of surface:
 
- - `SurfaceType.Surface` : The player is linked to a `SurfaceView` the default option.
-   This option is the more optimized version and allows to play 
-   any content including DRM protected content.
- - `SurfaceType.Texture`: The player is linked to a `TextureView`.
-   This surface maybe interesting when dealing with animation and surface type has 
-   issue.
- - `SurfaceType.Spherical` : The player is linked to a `SphericalGLSurfaceView`. This surface type is suited when playing 360° video content.
+- `SurfaceType.Surface` (default): the player is linked to a `SurfaceView`. This option is the most optimized version, and supports playing any
+  content including DRM protected content.
+- `SurfaceType.Texture`: the player is linked to a `TextureView`. This option may be interesting when dealing with animation, and the `Surface`
+  option doesn't work as expected.
+- `SurfaceType.Spherical`: the player is linked to a `SphericalGLSurfaceView`. This surface type is suited when playing 360° video content.
 
-The two last surface types are not suited when playing DRM protected content.
-
+> [!NOTE]
+> The last two surface types are not suited when playing DRM protected content.
 
 ### Listen to player states
 
@@ -109,13 +107,13 @@ fun MyPlayerView(player: Player) {
         // Displays current position periodically
         val currentPosition = player.currentPositionAsState()
         Text(text = "Position = $currentPosition ms", modifier = Modifier.align(Alignment.TopStart))
-        
+
         val duration = player.durationAsState()
         Text(text = "Duration = $duration ms", modifier = Modifier.align(Alignment.TopEnd))
-        
+
         val isPlaying = player.isPlayingAsState()
-        Button(modifier = Modififer.align(Alignement.Center), onClick = { togglePlayingBack() }){
-            Text(text = if(isPlaying) "Pause" else "Play")
+        Button(modifier = Modififer.align(Alignement.Center), onClick = { togglePlayingBack() }) {
+            Text(text = if (isPlaying) "Pause" else "Play")
         }
     }
 }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerSurfaceView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerSurfaceView.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.ui.widget.player
+
+import android.content.Context
+import android.graphics.Canvas
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.view.SurfaceControl
+import android.view.SurfaceView
+import android.window.SurfaceSyncGroup
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.Player
+
+/**
+ * Render the [player] content on a [SurfaceView].
+ *
+ * @param player The player to render on the SurfaceView.
+ * @param modifier The modifier to be applied to the layout.
+ */
+@Composable
+internal fun AndroidPlayerSurfaceView(player: Player, modifier: Modifier = Modifier) {
+    AndroidView(
+        /*
+         * On some devices (Pixel 2 XL Android 11),
+         * the "black" background of the SurfaceView shows outside its bound.
+         */
+        modifier = modifier.clipToBounds(),
+        factory = { context ->
+            PlayerSurfaceView(context)
+        },
+        update = { view ->
+            view.player = player
+        },
+        onRelease = { view ->
+            view.player = null
+        },
+        onReset = { view ->
+            // onReset is called before `update` when the composable is reused with a different context.
+            view.player = null
+        }
+    )
+}
+
+/**
+ * Player surface view
+ */
+private class PlayerSurfaceView(context: Context) : SurfaceView(context) {
+    private val playerListener = PlayerListener()
+    private val surfaceSyncGroupV34 = when {
+        isInEditMode -> null
+        needSurfaceSyncWorkaround() -> SurfaceSyncGroupCompatV34()
+        else -> null
+    }
+
+    /**
+     * Player if null is passed just clear surface
+     */
+    var player: Player? = null
+        set(value) {
+            if (field != value) {
+                field?.clearVideoSurfaceView(this)
+                field?.removeListener(playerListener)
+                value?.setVideoSurfaceView(this)
+                value?.addListener(playerListener)
+            }
+            field = value
+        }
+
+    override fun dispatchDraw(canvas: Canvas) {
+        super.dispatchDraw(canvas)
+
+        if (needSurfaceSyncWorkaround()) {
+            surfaceSyncGroupV34?.maybeMarkSyncReadyAndClear()
+        }
+    }
+
+    // Workaround for a surface sync issue on API 34: https://github.com/androidx/media/issues/1237
+    // Imported from https://github.com/androidx/media/commit/30cb76269a67e09f6e1662ea9ead6aac70667028
+    private fun needSurfaceSyncWorkaround(): Boolean {
+        return Build.VERSION.SDK_INT == Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+    }
+
+    private inner class PlayerListener : Player.Listener {
+        private val mainLooperHandler = Handler(Looper.getMainLooper())
+
+        override fun onSurfaceSizeChanged(width: Int, height: Int) {
+            if (needSurfaceSyncWorkaround()) {
+                surfaceSyncGroupV34?.postRegister(mainLooperHandler, this@PlayerSurfaceView)
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+    private class SurfaceSyncGroupCompatV34 {
+        private var surfaceSyncGroup: SurfaceSyncGroup? = null
+
+        fun postRegister(
+            mainLooperHandler: Handler,
+            surfaceView: SurfaceView,
+        ) {
+            mainLooperHandler.post {
+                // The SurfaceView isn't attached to a window, so don't apply the workaround.
+                val rootSurfaceControl = surfaceView.getRootSurfaceControl() ?: return@post
+
+                surfaceSyncGroup = SurfaceSyncGroup("exo-sync-b-334901521")
+                surfaceSyncGroup?.add(rootSurfaceControl) {}
+                surfaceView.invalidate()
+                rootSurfaceControl.applyTransactionOnDraw(SurfaceControl.Transaction())
+            }
+        }
+
+        fun maybeMarkSyncReadyAndClear() {
+            surfaceSyncGroup?.markSyncReady()
+            surfaceSyncGroup = null
+        }
+    }
+}

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerTextureView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerTextureView.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.ui.widget.player
+
+import android.content.Context
+import android.view.TextureView
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.Player
+
+/**
+ * Render the [player] content on a [TextureView]. Do not work with DRM content!
+ *
+ * @param player The player to render on the TextureView.
+ * @param modifier The modifier to be applied to the layout.
+ */
+@Composable
+internal fun AndroidPlayerTextureView(player: Player, modifier: Modifier = Modifier) {
+    AndroidView(
+        /*
+         * On some devices (Pixel 2 XL Android 11),
+         * the "black" background of the SurfaceView shows outside its bound.
+         */
+        modifier = modifier.clipToBounds(),
+        factory = { context ->
+            PlayerTextureView(context)
+        },
+        update = { view ->
+            view.player = player
+        },
+        onRelease = { view ->
+            view.player = null
+        },
+        onReset = { view ->
+            // onReset is called before `update` when the composable is reused with a different context.
+            view.player = null
+        }
+    )
+}
+
+private class PlayerTextureView(context: Context) : TextureView(context) {
+    /**
+     * Player if null is passed just clear surface
+     */
+    var player: Player? = null
+        set(value) {
+            if (field != value) {
+                field?.clearVideoTextureView(this)
+                value?.setVideoTextureView(this)
+            }
+            field = value
+        }
+}

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerTextureView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidPlayerTextureView.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.Player
 
 /**
- * Render the [player] content on a [TextureView]. Do not work with DRM content!
+ * Render the [player] content on a [TextureView]. Does not work with DRM content!
  *
  * @param player The player to render on the TextureView.
  * @param modifier The modifier to be applied to the layout.

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidSphericalSurfaceView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/AndroidSphericalSurfaceView.kt
@@ -17,7 +17,7 @@ import androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
  * @param modifier The modifier to be applied to the layout.
  */
 @Composable
-fun SphericalSurface(player: Player, modifier: Modifier = Modifier) {
+internal fun AndroidSphericalSurfaceView(player: Player, modifier: Modifier = Modifier) {
     AndroidView(
         modifier = modifier,
         factory = { context ->

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
@@ -4,15 +4,8 @@
  */
 package ch.srgssr.pillarbox.ui.widget.player
 
-import android.content.Context
-import android.graphics.Canvas
-import android.os.Build
-import android.os.Handler
-import android.os.Looper
-import android.view.SurfaceControl
 import android.view.SurfaceView
-import android.window.SurfaceSyncGroup
-import androidx.annotation.RequiresApi
+import android.view.TextureView
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -32,8 +25,8 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.Player
+import androidx.media3.exoplayer.video.spherical.SphericalGLSurfaceView
 import ch.srgssr.pillarbox.player.tracks.videoTracks
 import ch.srgssr.pillarbox.ui.ScaleMode
 import ch.srgssr.pillarbox.ui.exoplayer.ExoPlayerSubtitleView
@@ -48,9 +41,11 @@ import ch.srgssr.pillarbox.ui.extension.getAspectRatioAsState
  * @param contentAlignment The "letterboxing" content alignment inside the parent. Only used when the aspect ratio is strictly positive.
  * @param defaultAspectRatio The aspect ratio to use while video is loading or for audio content.
  * @param displayDebugView When `true`, displays debug information on top of the surface. Only used when the aspect ratio is strictly positive.
+ * @param surfaceType Surface type to use. When playing DRM content, don't use [SurfaceType.Texture] or [SurfaceType.Spherical].
  * @param surfaceContent The Composable content to display on top of the [SurfaceView]. By default, render the subtitles. Only used when the aspect
  * ratio is strictly positive.
  */
+@Suppress("CyclomaticComplexMethod")
 @Composable
 fun PlayerSurface(
     player: Player,
@@ -59,6 +54,7 @@ fun PlayerSurface(
     contentAlignment: Alignment = Alignment.Center,
     defaultAspectRatio: Float? = null,
     displayDebugView: Boolean = false,
+    surfaceType: SurfaceType = SurfaceType.Surface,
     surfaceContent: @Composable (BoxScope.() -> Unit)? = { ExoPlayerSubtitleView(player = player) },
 ) {
     var lastKnownVideoAspectRatio by remember { mutableFloatStateOf(defaultAspectRatio ?: 1f) }
@@ -100,7 +96,11 @@ fun PlayerSurface(
             }
         }
 
-        AndroidPlayerSurfaceView(modifier = videoSurfaceModifier, player = player)
+        when (surfaceType) {
+            SurfaceType.Surface -> AndroidPlayerSurfaceView(modifier = videoSurfaceModifier, player = player)
+            SurfaceType.Texture -> AndroidPlayerTextureView(modifier = videoSurfaceModifier, player = player)
+            SurfaceType.Spherical -> AndroidSphericalSurfaceView(modifier = videoSurfaceModifier, player = player)
+        }
 
         surfaceContent?.let {
             val overlayModifier = if (scaleMode != ScaleMode.Crop) {
@@ -129,6 +129,26 @@ fun PlayerSurface(
 }
 
 /**
+ * Surface type
+ */
+enum class SurfaceType {
+    /**
+     * Render into a [SurfaceView].
+     */
+    Surface,
+
+    /**
+     * Render into a [TextureView], not compatible with DRM content.
+     */
+    Texture,
+
+    /**
+     * Render into a [SphericalGLSurfaceView] useful for 360° content.
+     */
+    Spherical,
+}
+
+/**
  * Debug player view
  *
  * @param modifier The modifier to use to layout.
@@ -152,110 +172,5 @@ private fun DebugPlayerView(modifier: Modifier) {
             color = Color.Magenta,
             style = Stroke(width = 4f),
         )
-    }
-}
-
-/**
- * Render the [player] content on a [SurfaceView].
- *
- * @param player The player to render on the SurfaceView.
- * @param modifier The modifier to be applied to the layout.
- */
-@Composable
-private fun AndroidPlayerSurfaceView(player: Player, modifier: Modifier = Modifier) {
-    AndroidView(
-        /*
-         * On some devices (Pixel 2 XL Android 11),
-         * the "black" background of the SurfaceView shows outside its bound.
-         */
-        modifier = modifier.clipToBounds(),
-        factory = { context ->
-            PlayerSurfaceView(context)
-        },
-        update = { view ->
-            view.player = player
-        },
-        onRelease = { view ->
-            view.player = null
-        },
-        onReset = { view ->
-            // onReset is called before `update` when the composable is reused with a different context.
-            view.player = null
-        }
-    )
-}
-
-/**
- * Player surface view
- */
-private class PlayerSurfaceView(context: Context) : SurfaceView(context) {
-    private val playerListener = PlayerListener()
-    private val surfaceSyncGroupV34 = when {
-        isInEditMode -> null
-        needSurfaceSyncWorkaround() -> SurfaceSyncGroupCompatV34()
-        else -> null
-    }
-
-    /**
-     * Player if null is passed just clear surface
-     */
-    var player: Player? = null
-        set(value) {
-            if (field != value) {
-                field?.clearVideoSurfaceView(this)
-                field?.removeListener(playerListener)
-                value?.setVideoSurfaceView(this)
-                value?.addListener(playerListener)
-            }
-            field = value
-        }
-
-    override fun dispatchDraw(canvas: Canvas) {
-        super.dispatchDraw(canvas)
-
-        if (needSurfaceSyncWorkaround()) {
-            surfaceSyncGroupV34?.maybeMarkSyncReadyAndClear()
-        }
-    }
-
-    // Workaround for a surface sync issue on API 34: https://github.com/androidx/media/issues/1237
-    // Imported from https://github.com/androidx/media/commit/30cb76269a67e09f6e1662ea9ead6aac70667028
-    private fun needSurfaceSyncWorkaround(): Boolean {
-        return Build.VERSION.SDK_INT == Build.VERSION_CODES.UPSIDE_DOWN_CAKE
-    }
-
-    private inner class PlayerListener : Player.Listener {
-        private val mainLooperHandler = Handler(Looper.getMainLooper())
-
-        override fun onSurfaceSizeChanged(width: Int, height: Int) {
-            if (needSurfaceSyncWorkaround()) {
-                surfaceSyncGroupV34?.postRegister(mainLooperHandler, this@PlayerSurfaceView)
-            }
-        }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-    private class SurfaceSyncGroupCompatV34 {
-        private var surfaceSyncGroup: SurfaceSyncGroup? = null
-
-        fun postRegister(
-            mainLooperHandler: Handler,
-            surfaceView: SurfaceView,
-        ) {
-            mainLooperHandler.post {
-                // The SurfaceView isn't attached to a window, so don't apply the workaround.
-                val rootSurfaceControl = surfaceView.getRootSurfaceControl() ?: return@post
-
-                surfaceSyncGroup = SurfaceSyncGroup("exo-sync-b-334901521")
-                surfaceSyncGroup?.add(rootSurfaceControl) {}
-                surfaceView.invalidate()
-                rootSurfaceControl.applyTransactionOnDraw(SurfaceControl.Transaction())
-            }
-        }
-
-        fun maybeMarkSyncReadyAndClear() {
-            surfaceSyncGroup?.markSyncReady()
-            surfaceSyncGroup = null
-        }
     }
 }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/player/PlayerSurface.kt
@@ -41,7 +41,7 @@ import ch.srgssr.pillarbox.ui.extension.getAspectRatioAsState
  * @param contentAlignment The "letterboxing" content alignment inside the parent. Only used when the aspect ratio is strictly positive.
  * @param defaultAspectRatio The aspect ratio to use while video is loading or for audio content.
  * @param displayDebugView When `true`, displays debug information on top of the surface. Only used when the aspect ratio is strictly positive.
- * @param surfaceType Surface type to use. When playing DRM content, don't use [SurfaceType.Texture] or [SurfaceType.Spherical].
+ * @param surfaceType Surface type to use. When playing DRM content, only [SurfaceType.Surface] is supported.
  * @param surfaceContent The Composable content to display on top of the [SurfaceView]. By default, render the subtitles. Only used when the aspect
  * ratio is strictly positive.
  */


### PR DESCRIPTION
# Pull request

## Description

This PR add options to `PlayerSurface` to choose on which kind of surface the player render in. Media3 Exoplayer can be rendered into `SurfaceView`, `TextureView` and `SphericalGLSurfaceView`.

Texture view can be use in some cases where there is no DRM protected content and SurfaceView have issues with UI animations (Pagers).

Currently there an issue with `SurfaceView` on pixels Android 34 when used in compose. We apply the same hack/fix than Media3. #515 

## Changes made

- `PlayerSurface` have a new parameters to choose witch surface type to render in.
- Add `SurfaceType.Surface`, `SurfaceType.Texture` and `SurfaceType.Spherical`.

## Checklist

- [ ] Your branch has been rebased onto the `main` branch.
- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
- [ ] All pull request status checks pass.
