### PR TITLE
Add server picker in "Examples"

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
@@ -329,7 +329,7 @@ private fun InsertContentTextFieldEmptyPreview() {
     PillarboxTheme {
         InsertContentTextField(
             value = value,
-            label = "Label",
+            label = stringResource(R.string.enter_url_or_urn),
             onValueChange = setValue,
             onClearClick = { setValue("") },
         )
@@ -346,7 +346,7 @@ private fun InsertContentTextFieldValuePreview() {
     PillarboxTheme {
         InsertContentTextField(
             value = value,
-            label = "Label",
+            label = stringResource(R.string.enter_url_or_urn),
             onValueChange = setValue,
             onClearClick = { setValue("") },
         )
@@ -365,7 +365,7 @@ private fun InsertContentDropDownPreview() {
     PillarboxTheme {
         InsertContentDropDown(
             value = server,
-            label = "Label",
+            label = stringResource(R.string.enter_url_or_urn),
             entries = servers,
             onEntrySelected = setServer,
         )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
@@ -5,45 +5,73 @@
 package ch.srgssr.pillarbox.demo.ui.examples
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
-import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaUrn
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import ch.srgssr.pillarbox.core.business.integrationlayer.data.isValidMediaUrn
+import ch.srgssr.pillarbox.demo.EnvironmentConfig
 import ch.srgssr.pillarbox.demo.R
+import ch.srgssr.pillarbox.demo.getServers
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
+import java.net.MalformedURLException
+import java.net.URL
 
 private data class InsertContentData(
     val uri: String = "",
-    val licenseUrl: String = ""
+    val licenseUrl: String = "",
+    val environmentConfig: EnvironmentConfig? = null,
 ) {
+    val hasValidInput: Boolean
+        get() = uri.isNotBlank()
+
     val isValidUrl: Boolean
-        get() = uri.startsWith("http")
+        get() = try {
+            URL(uri)
+            true
+        } catch (_: MalformedURLException) {
+            false
+        }
+
+    val isValidUrn: Boolean
+        get() = uri.isValidMediaUrn()
 
     fun toDemoItem(): DemoItem {
         return when {
@@ -53,9 +81,12 @@ private data class InsertContentData(
                 licenseUri = licenseUrl,
             )
 
-            MediaUrn.isValid(uri) -> DemoItem.URN(
+            isValidUrn -> DemoItem.URN(
                 title = uri,
                 urn = uri,
+                host = checkNotNull(environmentConfig).host,
+                forceSAM = environmentConfig.forceSAM,
+                forceLocation = environmentConfig.location,
             )
 
             else -> error("Invalid URI: $uri")
@@ -74,10 +105,25 @@ fun InsertContentView(
     modifier: Modifier = Modifier,
     onPlayClick: (DemoItem) -> Unit
 ) {
-    var insertContentData by remember {
+    val (insertContentData, setInsertContentData) = remember {
         mutableStateOf(InsertContentData())
     }
 
+    InsertContentViewInternal(
+        insertContentData = insertContentData,
+        modifier = modifier,
+        setInsertContentData = setInsertContentData,
+        onPlayClick = onPlayClick,
+    )
+}
+
+@Composable
+private fun InsertContentViewInternal(
+    insertContentData: InsertContentData,
+    modifier: Modifier = Modifier,
+    setInsertContentData: (InsertContentData) -> Unit,
+    onPlayClick: (DemoItem) -> Unit,
+) {
     Column(
         modifier = modifier.padding(bottom = MaterialTheme.paddings.small),
         verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.small),
@@ -89,8 +135,8 @@ fun InsertContentView(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = MaterialTheme.paddings.mini),
-            onValueChange = { insertContentData = insertContentData.copy(uri = it) },
-            onClearClick = { insertContentData = InsertContentData() }
+            onValueChange = { setInsertContentData(insertContentData.copy(uri = it)) },
+            onClearClick = { setInsertContentData(InsertContentData()) },
         )
 
         AnimatedVisibility(visible = insertContentData.isValidUrl) {
@@ -100,12 +146,33 @@ fun InsertContentView(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = MaterialTheme.paddings.mini),
-                onValueChange = { insertContentData = insertContentData.copy(licenseUrl = it) },
-                onClearClick = { insertContentData = insertContentData.copy(licenseUrl = "") }
+                onValueChange = { setInsertContentData(insertContentData.copy(licenseUrl = it)) },
+                onClearClick = { setInsertContentData(insertContentData.copy(licenseUrl = "")) },
             )
         }
 
-        AnimatedVisibility(visible = insertContentData.uri.isNotBlank()) {
+        AnimatedVisibility(visible = insertContentData.isValidUrn) {
+            val context = LocalContext.current
+            val servers = remember { getServers(context) }
+
+            LaunchedEffect(servers) {
+                setInsertContentData(insertContentData.copy(environmentConfig = servers[0]))
+            }
+
+            if (insertContentData.environmentConfig != null) {
+                InsertContentDropDown(
+                    value = insertContentData.environmentConfig,
+                    label = stringResource(R.string.server),
+                    entries = servers,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = MaterialTheme.paddings.mini),
+                    onEntrySelected = { setInsertContentData(insertContentData.copy(environmentConfig = it)) },
+                )
+            }
+        }
+
+        AnimatedVisibility(visible = insertContentData.hasValidInput) {
             Button(onClick = { onPlayClick(insertContentData.toDemoItem()) }) {
                 Text(text = stringResource(R.string.play))
             }
@@ -146,23 +213,161 @@ private fun InsertContentTextField(
 }
 
 @Composable
-@Preview(showBackground = true)
-private fun InsertContentViewPreview() {
-    PillarboxTheme {
-        InsertContentView {
+private fun InsertContentDropDown(
+    value: EnvironmentConfig,
+    label: String,
+    entries: List<EnvironmentConfig>,
+    modifier: Modifier = Modifier,
+    onEntrySelected: (entry: EnvironmentConfig) -> Unit,
+) {
+    var showDropdownMenu by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        val interactionSource = remember { MutableInteractionSource() }
+        val isPressed by interactionSource.collectIsPressedAsState()
+
+        LaunchedEffect(isPressed) {
+            if (isPressed) {
+                showDropdownMenu = true
+            }
+        }
+
+        OutlinedTextField(
+            value = value.displayName,
+            onValueChange = {},
+            modifier = Modifier.fillMaxWidth(),
+            readOnly = true,
+            label = { Text(text = label) },
+            trailingIcon = {
+                val iconRotation by animateFloatAsState(
+                    targetValue = if (showDropdownMenu) -180f else 0f,
+                    label = "icon_rotation_animation",
+                )
+
+                Icon(
+                    imageVector = Icons.Default.ExpandMore,
+                    contentDescription = null,
+                    modifier = Modifier.rotate(iconRotation),
+                )
+            },
+            interactionSource = interactionSource,
+        )
+
+        DropdownMenu(
+            expanded = showDropdownMenu,
+            onDismissRequest = { showDropdownMenu = false },
+            offset = DpOffset(x = 0.dp, y = MaterialTheme.paddings.small),
+        ) {
+            entries.forEach { entry ->
+                DropdownMenuItem(
+                    text = { Text(text = entry.displayName) },
+                    onClick = {
+                        onEntrySelected(entry)
+                        showDropdownMenu = false
+                    },
+                )
+            }
         }
     }
 }
 
 @Composable
-@Preview(showBackground = true)
-private fun InsertContentTextFieldPreview() {
+@Preview(group = "InsertContentView", showBackground = true)
+private fun InsertContentViewEmptyPreview() {
+    val (insertContentData, setInsertContentData) = remember {
+        mutableStateOf(InsertContentData())
+    }
+
+    PillarboxTheme {
+        InsertContentViewInternal(
+            insertContentData = insertContentData,
+            setInsertContentData = setInsertContentData,
+            onPlayClick = {},
+        )
+    }
+}
+
+@Composable
+@Preview(group = "InsertContentView", showBackground = true)
+private fun InsertContentViewUrlPreview() {
+    val (insertContentData, setInsertContentData) = remember {
+        mutableStateOf(InsertContentData(uri = "https://www.example.com/", licenseUrl = "https://www.license.com/"))
+    }
+
+    PillarboxTheme {
+        InsertContentViewInternal(
+            insertContentData = insertContentData,
+            setInsertContentData = setInsertContentData,
+            onPlayClick = {},
+        )
+    }
+}
+
+@Composable
+@Preview(group = "InsertContentView", showBackground = true)
+private fun InsertContentViewUrnPreview() {
+    val (insertContentData, setInsertContentData) = remember {
+        mutableStateOf(InsertContentData(uri = "urn:rts:video:1234567"))
+    }
+
+    PillarboxTheme {
+        InsertContentViewInternal(
+            insertContentData = insertContentData,
+            setInsertContentData = setInsertContentData,
+            onPlayClick = {},
+        )
+    }
+}
+
+@Composable
+@Preview(group = "InsertContentTextField", showBackground = true)
+private fun InsertContentTextFieldEmptyPreview() {
+    val (value, setValue) = remember {
+        mutableStateOf("")
+    }
+
     PillarboxTheme {
         InsertContentTextField(
-            value = "Value",
+            value = value,
             label = "Label",
-            onValueChange = {},
-            onClearClick = {}
+            onValueChange = setValue,
+            onClearClick = { setValue("") },
+        )
+    }
+}
+
+@Composable
+@Preview(group = "InsertContentTextField", showBackground = true)
+private fun InsertContentTextFieldValuePreview() {
+    val (value, setValue) = remember {
+        mutableStateOf("Value")
+    }
+
+    PillarboxTheme {
+        InsertContentTextField(
+            value = value,
+            label = "Label",
+            onValueChange = setValue,
+            onClearClick = { setValue("") },
+        )
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+private fun InsertContentDropDownPreview() {
+    val context = LocalContext.current
+    val servers = getServers(context)
+    val (server, setServer) = remember {
+        mutableStateOf(servers[0])
+    }
+
+    PillarboxTheme {
+        InsertContentDropDown(
+            value = server,
+            label = "Label",
+            entries = servers,
+            onEntrySelected = setServer,
         )
     }
 }


### PR DESCRIPTION
# Pull request

## Description

When entering a URN in `Examples` in `pillarbox-demo`, it is now possible to select a specific backend configuration (IL/SAM, CH/WW).

## Changes made

- Expose the method to get the list of servers from `MainNavigation`.
- Add a server picker in `Examples`.

## Screenshot

![Screenshot 2024-10-15 at 11 27 37](https://github.com/user-attachments/assets/7e24685d-85c8-49e5-8dbc-563af0d48592)

![Screenshot 2024-10-15 at 11 28 57](https://github.com/user-attachments/assets/fe8f6370-8622-441f-a1b7-40095dd5dfa2)

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).