### PR TITLE
Add User Story template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,19 @@
 name: 🐞 Bug report
 description: File a bug report
 labels: [ "bug", "triage" ]
+projects: [ "SRGSSR/9" ]
 body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: >
+        Please search to see if an
+        [issue](https://github.com/SRGSSR/pillarbox-android/issues?q=is%3Aissue)
+        already exists for the bug you encountered.
+      options:
+        - label: >
+            I have searched existing issues and found no similar bug report.
+          required: true
   - type: textarea
     id: description
     attributes:
@@ -53,14 +65,3 @@ body:
     attributes:
       label: Code sample
       description: Attach a code sample reproducing the issue if possible.
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this?
-      description: >
-        Please search to see if an
-        [issue](https://github.com/SRGSSR/pillarbox-android/issues?q=is%3Aissue)
-        already exists for the bug you encountered.
-      options:
-        - label: >
-            I have searched existing issues and found no similar bug report.
-          required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: 🐞 Bug report
 description: File a bug report
 labels: [ "bug", "triage" ]
 projects: [ "SRGSSR/9" ]
+type: Bug
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: 💡 Feature request
 description: Request a feature or submit an idea you have.
 labels: [ "enhancement", "triage" ]
 projects: [ "SRGSSR/9" ]
+type: Enhancement
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,21 @@
 name: 💡 Feature request
 description: Request a feature or submit an idea you have.
 labels: [ "enhancement", "triage" ]
+projects: [ "SRGSSR/9" ]
 body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing similar feature request?
+      options:
+        - label: >
+            I have searched existing
+            [features](https://github.com/SRGSSR/pillarbox-android/issues?q=is%3Aissue+label%3Aenhancement+)
+            and found no similar request.
+          required: true
+        - label: >
+            I have browsed the available API and found no way to achieve
+            the use case I described.
+          required: true
   - type: textarea
     id: use_case
     attributes:
@@ -27,16 +41,3 @@ body:
       label: Alternatives considered
       description: >
         Describe any alternative solutions you might consider applicable.
-  - type: checkboxes
-    attributes:
-      label: Is there an existing similar feature request?
-      options:
-        - label: >
-            I have searched existing
-            [features](https://github.com/SRGSSR/pillarbox-android/issues?q=is%3Aissue+label%3Aenhancement+)
-            and found no similar request.
-          required: true
-        - label: >
-            I have browsed the available API and found no way to achieve
-            the use case I described.
-          required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,14 +1,8 @@
 name: 💭 Question
 description: Ask us for guidance or help.
-labels: ["question", "triage"]
+labels: [ "question", "triage" ]
+projects: [ "SRGSSR/9" ]
 body:
-  - type: textarea
-    id: description
-    attributes:
-      label: Detailed question
-      description: Please develop your question in further detail.
-    validations:
-      required: true
   - type: checkboxes
     attributes:
       label: Can your answer be found elsewhere?
@@ -22,3 +16,10 @@ body:
             I have browsed the available documentation and found no answer
             to my question.
           required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Detailed question
+      description: Please develop your question in further detail.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,6 +1,7 @@
 name: 📙 Story
 description: Describe requirements.
 projects: [ "SRGSSR/9" ]
+type: Task
 body:
   - type: textarea
     id: description

--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,25 @@
+name: 📙 Story
+description: Describe requirements.
+projects: [ "SRGSSR/9" ]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      value: "**As a developer** "
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance criteria
+      value: "- "
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true


### PR DESCRIPTION
# Pull request

## Description

This PR adds a new issue template to create a User Story. This comes from the `pillarbox-apple`.
I've also updated the other templates based on what is in `pillarbox-apple`.

Thanks @waliid @defagos ❤️ 

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).