### PR TITLE
Remove `severity` from monitoring error

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
@@ -196,7 +196,6 @@ internal class Monitoring(
                 data = ErrorMessageData(
                     throwable = error.cause ?: error,
                     player = player,
-                    severity = ErrorMessageData.Severity.FATAL,
                     url = playbackMetrics?.url.toString(),
                 ),
             )

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageData.kt
@@ -6,7 +6,6 @@ package ch.srgssr.pillarbox.player.monitoring.models
 
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.player.extension.getPositionTimestamp
-import ch.srgssr.pillarbox.player.monitoring.models.ErrorMessageData.Severity
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -19,7 +18,6 @@ import kotlinx.serialization.Serializable
  * @property name The name of the error.
  * @property position The position of the player when the error occurred, in milliseconds, or `null` if not available.
  * @property positionTimestamp The current player timestamp, as retrieved from the playlist.
- * @property severity The severity of the error, either [FATAL][Severity.FATAL] or [WARNING][Severity.WARNING].
  * @property url The last loaded url.
  */
 @Serializable
@@ -30,24 +28,10 @@ data class ErrorMessageData(
     val name: String,
     val position: Long?,
     @SerialName("position_timestamp") val positionTimestamp: Long?,
-    val severity: Severity,
     val url: String,
 ) : MessageData {
-    /**
-     * Represents a [Player][androidx.media3.common.Player] error severity.
-     */
-    @Suppress("UndocumentedPublicProperty")
-    enum class Severity {
-        @SerialName("Fatal")
-        FATAL,
-
-        @SerialName("Warning")
-        WARNING,
-    }
-
     constructor(
         throwable: Throwable,
-        severity: Severity,
         player: Player,
         url: String,
     ) : this(
@@ -57,7 +41,6 @@ data class ErrorMessageData(
         name = throwable::class.simpleName.orEmpty(),
         position = player.currentPosition,
         positionTimestamp = player.getPositionTimestamp(),
-        severity = severity,
         url = url,
     )
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageDataTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageDataTest.kt
@@ -40,7 +40,6 @@ class ErrorMessageDataTest {
         val throwable = IllegalStateException()
         val qosErrorMessageData = ErrorMessageData(
             throwable = throwable,
-            severity = ErrorMessageData.Severity.WARNING,
             player = player,
             url = URL,
         )
@@ -55,7 +54,6 @@ class ErrorMessageDataTest {
         assertEquals("IllegalStateException", qosErrorMessageData.name)
         assertEquals(CURRENT_POSITION, qosErrorMessageData.position)
         assertNull(qosErrorMessageData.positionTimestamp)
-        assertEquals(ErrorMessageData.Severity.WARNING, qosErrorMessageData.severity)
         assertEquals(URL, qosErrorMessageData.url)
     }
 
@@ -65,7 +63,6 @@ class ErrorMessageDataTest {
         val throwable = RuntimeException("Something bad happened", cause)
         val qosErrorMessageData = ErrorMessageData(
             throwable = throwable,
-            severity = ErrorMessageData.Severity.FATAL,
             player = player,
             url = URL,
         )
@@ -83,7 +80,6 @@ class ErrorMessageDataTest {
         assertEquals("RuntimeException", qosErrorMessageData.name)
         assertEquals(CURRENT_POSITION, qosErrorMessageData.position)
         assertNull(qosErrorMessageData.positionTimestamp)
-        assertEquals(ErrorMessageData.Severity.FATAL, qosErrorMessageData.severity)
         assertEquals(URL, qosErrorMessageData.url)
     }
 


### PR DESCRIPTION
# Pull request

## Description

Remove the `severity` field from the monitoring `Error` message.

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).