### PR TITLE
Rename to PillarboxExoPlayer

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/PillarboxSRG.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/PillarboxSRG.kt
@@ -20,7 +20,7 @@ import kotlin.time.Duration.Companion.seconds
  * @param context The [Context].
  * @param builder The builder.
  * @receiver [SRG.Builder].
- * @return The configured [PillarboxExoplayer] for SRG SSR.
+ * @return The configured [PillarboxExoPlayer] for SRG SSR.
  */
 @PillarboxDsl
 fun PillarboxExoPlayer(

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/PillarboxSRG.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/PillarboxSRG.kt
@@ -22,15 +22,12 @@ import kotlin.time.Duration.Companion.seconds
  * @receiver [SRG.Builder].
  * @return The configured [PillarboxExoplayer] for SRG SSR.
  */
-@Suppress("FunctionName")
 @PillarboxDsl
-fun PillarboxExoplayer(
+fun PillarboxExoPlayer(
     context: Context,
     builder: SRG.Builder.() -> Unit = {},
 ): PillarboxExoPlayer {
-    return SRG.create()
-        .apply(builder)
-        .create(context)
+    return PillarboxExoPlayer(context, SRG, builder)
 }
 
 /**

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -22,7 +22,7 @@ import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType.Seek
 import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType.Stop
 import ch.srgssr.pillarbox.analytics.commandersact.MediaEventType.Uptime
 import ch.srgssr.pillarbox.analytics.commandersact.TCMediaEvent
-import ch.srgssr.pillarbox.core.business.PillarboxExoplayer
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.core.business.SRGMediaItem
 import ch.srgssr.pillarbox.core.business.utils.LocalMediaCompositionWithFallbackService
 import ch.srgssr.pillarbox.player.test.utils.TestPillarboxRunHelper
@@ -70,7 +70,7 @@ class CommandersActTrackerIntegrationTest {
 
         val context = ApplicationProvider.getApplicationContext<Context>()
         val mediaCompositionWithFallbackService = LocalMediaCompositionWithFallbackService(context)
-        player = PillarboxExoplayer(context) {
+        player = PillarboxExoPlayer(context) {
             srgAssetLoader(context) {
                 mediaCompositionService(mediaCompositionWithFallbackService)
                 commanderActTrackerFactory(CommandersActTracker.Factory(commandersAct = commandersAct, coroutineContext = testDispatcher))

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
@@ -17,7 +17,7 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import ch.srgssr.pillarbox.analytics.BuildConfig
-import ch.srgssr.pillarbox.core.business.PillarboxExoplayer
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.core.business.SRGMediaItem
 import ch.srgssr.pillarbox.core.business.utils.LocalMediaCompositionWithFallbackService
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
@@ -57,7 +57,7 @@ class ComScoreTrackerIntegrationTest {
         }
         val context = ApplicationProvider.getApplicationContext<Context>()
         val mediaCompositionWithFallbackService = LocalMediaCompositionWithFallbackService(context)
-        player = PillarboxExoplayer(context) {
+        player = PillarboxExoPlayer(context) {
             clock(clock)
             coroutineContext(EmptyCoroutineContext)
             srgAssetLoader(context) {

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import ch.srg.dataProvider.integrationlayer.dependencies.modules.IlServiceModule
 import ch.srg.dataProvider.integrationlayer.dependencies.modules.OkHttpModule
 import ch.srgssr.dataprovider.paging.DataProviderPaging
-import ch.srgssr.pillarbox.core.business.PillarboxExoplayer
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.core.business.integrationlayer.service.IlHost
 import ch.srgssr.pillarbox.demo.shared.source.BlockedTimeRangeAssetLoader
 import ch.srgssr.pillarbox.demo.shared.source.CustomAssetLoader
@@ -27,7 +27,7 @@ object PlayerModule {
      * Provide default player that allow to play urls and urns content from the SRG
      */
     fun provideDefaultPlayer(context: Context): PillarboxExoPlayer {
-        return PillarboxExoplayer(context = context) {
+        return PillarboxExoPlayer(context = context) {
             +CustomAssetLoader(context)
             +BlockedTimeRangeAssetLoader(context)
         }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/ChaptersShowcaseViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/ChaptersShowcaseViewModel.kt
@@ -8,7 +8,7 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.media3.common.Player
-import ch.srgssr.pillarbox.core.business.PillarboxExoplayer
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
 import ch.srgssr.pillarbox.player.currentMediaMetadataAsFlow
@@ -30,7 +30,7 @@ class ChaptersShowcaseViewModel(application: Application) : AndroidViewModel(app
     /**
      * Player
      */
-    val player: Player = PillarboxExoplayer(application)
+    val player: Player = PillarboxExoPlayer(application)
 
     /**
      * Progress tracker

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/StoryViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/layouts/StoryViewModel.kt
@@ -16,7 +16,7 @@ import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.source.preload.DefaultPreloadManager.Status
 import androidx.media3.exoplayer.source.preload.DefaultPreloadManager.Status.STAGE_LOADED_TO_POSITION_MS
 import androidx.media3.exoplayer.source.preload.TargetPreloadStatusControl
-import ch.srgssr.pillarbox.core.business.PillarboxExoplayer
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.core.business.source.SRGAssetLoader
 import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
@@ -61,7 +61,7 @@ class StoryViewModel(application: Application) : AndroidViewModel(application) {
 
     private val players = SparseArray<PillarboxExoPlayer>(PLAYERS_COUNT).apply {
         for (i in 0 until PLAYERS_COUNT) {
-            val player = PillarboxExoplayer(application) {
+            val player = PillarboxExoPlayer(application) {
                 playbackLooper(preloadManager.playbackLooper)
                 loadControl(loadControl)
             }.apply {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/ContentNotYetAvailableViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/ContentNotYetAvailableViewModel.kt
@@ -12,6 +12,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException
 import ch.srgssr.pillarbox.core.business.source.SRGAssetLoader
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
+import ch.srgssr.pillarbox.player.Default
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.asset.Asset
 import ch.srgssr.pillarbox.player.asset.AssetLoader
@@ -42,7 +43,7 @@ class ContentNotYetAvailableViewModel(application: Application) : AndroidViewMod
     /**
      * Player
      */
-    val player: PillarboxExoPlayer = PillarboxExoPlayer(application) {
+    val player: PillarboxExoPlayer = PillarboxExoPlayer(application, Default) {
         +AlwaysStartDateBlockedAssetLoader(application)
     }
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SmoothSeekingShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SmoothSeekingShowcase.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.media3.common.Player
-import ch.srgssr.pillarbox.core.business.PillarboxExoplayer
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.demo.R
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.ui.player.controls.PlayerPlaybackRow
@@ -47,7 +47,7 @@ import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 fun SmoothSeekingShowcase() {
     val context = LocalContext.current
     val player = remember {
-        PillarboxExoplayer(context).apply {
+        PillarboxExoPlayer(context).apply {
             addMediaItem(DemoItem.UnifiedStreamingOnDemand_Dash_TrickPlay.toMediaItem())
             addMediaItem(DemoItem.UnifiedStreamingOnDemandTrickplay.toMediaItem())
             addMediaItem(DemoItem.UnifiedStreamingOnDemand_Dash_FragmentedMP4.toMediaItem())

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/IsPlayingAllTypeOfContentTest.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/IsPlayingAllTypeOfContentTest.kt
@@ -34,7 +34,7 @@ class IsPlayingAllTypeOfContentTest {
         val atomicPlayer = AtomicReference<PillarboxExoPlayer>()
         val waitIsPlaying = WaitIsPlaying()
         getInstrumentation().runOnMainSync {
-            val player = PillarboxExoPlayer(appContext)
+            val player = PillarboxExoPlayer(appContext, Default)
             atomicPlayer.set(player)
             player.addMediaItem(MediaItem.fromUri(urlToTest))
             player.addListener(waitIsPlaying)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -34,21 +34,23 @@ import ch.srgssr.pillarbox.player.utils.PillarboxEventLogger
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext
-
 /**
  * Create a new instance of [PillarboxExoPlayer].
  *
+ * @param T The type of the [PillarboxBuilder].
  * @param context The [Context].
+ * @param type The [PlayerConfig].
  * @param builder The builder.
  *
  * @return A new instance of [PillarboxExoPlayer].
  */
 @PillarboxDsl
-fun PillarboxExoPlayer(
+fun <T : PillarboxBuilder> PillarboxExoPlayer(
     context: Context,
-    builder: Default.Builder.() -> Unit = {},
+    type: PlayerConfig<T>,
+    builder: T.() -> Unit = {},
 ): PillarboxExoPlayer {
-    return Default.create()
+    return type.create()
         .apply(builder)
         .create(context)
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -34,10 +34,11 @@ import ch.srgssr.pillarbox.player.utils.PillarboxEventLogger
 import kotlinx.coroutines.android.asCoroutineDispatcher
 import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.CoroutineContext
+
 /**
  * Create a new instance of [PillarboxExoPlayer].
  *
- * @param T The type of the [PillarboxBuilder].
+ * @param Builder The type of the [PillarboxBuilder].
  * @param context The [Context].
  * @param type The [PlayerConfig].
  * @param builder The builder.
@@ -45,10 +46,10 @@ import kotlin.coroutines.CoroutineContext
  * @return A new instance of [PillarboxExoPlayer].
  */
 @PillarboxDsl
-fun <T : PillarboxBuilder> PillarboxExoPlayer(
+fun <Builder : PillarboxBuilder> PillarboxExoPlayer(
     context: Context,
-    type: PlayerConfig<T>,
-    builder: T.() -> Unit = {},
+    type: PlayerConfig<Builder>,
+    builder: Builder.() -> Unit = {},
 ): PillarboxExoPlayer {
     return type.create()
         .apply(builder)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxTestPlayer.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxTestPlayer.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import android.content.Context
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.test.utils.FakeClock
+import androidx.test.core.app.ApplicationProvider
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Pillarbox exo player
+ *
+ * @param context the [Context] by default [ApplicationProvider.getApplicationContext]
+ * @param block The block to further configure the [PillarboxExoPlayer].
+ * @return [PillarboxExoPlayer] configured for tests.
+ */
+@PillarboxDsl
+fun PillarboxExoPlayer(context: Context = ApplicationProvider.getApplicationContext(), block: Default.Builder.() -> Unit = {}): PillarboxExoPlayer {
+    return PillarboxExoPlayer(context, Default) {
+        loadControl(DefaultLoadControl())
+        clock(FakeClock(true))
+        coroutineContext(EmptyCoroutineContext)
+        block()
+    }
+}

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxTestPlayer.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxTestPlayer.kt
@@ -11,9 +11,9 @@ import androidx.test.core.app.ApplicationProvider
 import kotlin.coroutines.EmptyCoroutineContext
 
 /**
- * Pillarbox exo player
+ * Pillarbox ExoPlayer
  *
- * @param context the [Context] by default [ApplicationProvider.getApplicationContext]
+ * @param context The [Context], by default [ApplicationProvider.getApplicationContext]
  * @param block The block to further configure the [PillarboxExoPlayer].
  * @return [PillarboxExoPlayer] configured for tests.
  */

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
@@ -4,22 +4,17 @@
  */
 package ch.srgssr.pillarbox.player
 
-import android.content.Context
 import android.os.Looper
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -33,13 +28,7 @@ class PlayerCallbackFlowTest {
 
     @BeforeTest
     fun setUp() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-
-        player = PillarboxExoPlayer(context) {
-            loadControl(DefaultLoadControl())
-            clock(FakeClock(true))
-            coroutineContext(EmptyCoroutineContext)
-        }.apply {
+        player = PillarboxExoPlayer().apply {
             prepare()
             play()
         }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
@@ -4,14 +4,10 @@
  */
 package ch.srgssr.pillarbox.player.analytics
 
-import android.content.Context
 import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.analytics.metrics.MetricsCollector
@@ -24,7 +20,6 @@ import io.mockk.slot
 import io.mockk.verify
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -43,13 +38,8 @@ class MetricsCollectorTest {
 
     @BeforeTest
     fun setUp() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         metricsListener = mockk(relaxed = true)
-        player = PillarboxExoPlayer(context) {
-            loadControl(DefaultLoadControl())
-            clock(FakeClock(true))
-            coroutineContext(EmptyCoroutineContext)
-        }
+        player = PillarboxExoPlayer()
         player.metricsCollector.addListener(metricsListener)
         player.prepare()
 

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/MonitoringTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/MonitoringTest.kt
@@ -4,13 +4,10 @@
  */
 package ch.srgssr.pillarbox.player.monitoring
 
-import android.content.Context
 import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.monitoring.models.Message
@@ -19,8 +16,6 @@ import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import kotlin.test.AfterTest
@@ -37,15 +32,12 @@ class MonitoringTest {
     private lateinit var monitoringMessageHandler: MonitoringMessageHandler
 
     @BeforeTest
-    @OptIn(ExperimentalCoroutinesApi::class)
     fun setUp() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         monitoringMessageHandler = mockk(relaxed = true)
-        player = PillarboxExoPlayer(context) {
-            clock(FakeClock(true))
-            coroutineContext(UnconfinedTestDispatcher())
+        player = PillarboxExoPlayer {
             monitoring = monitoringMessageHandler
         }
+
         player.prepare()
         player.play()
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/MonitoringTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/MonitoringTest.kt
@@ -16,6 +16,8 @@ import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import kotlin.test.AfterTest
@@ -31,11 +33,13 @@ class MonitoringTest {
     private lateinit var player: PillarboxExoPlayer
     private lateinit var monitoringMessageHandler: MonitoringMessageHandler
 
+    @OptIn(ExperimentalCoroutinesApi::class)
     @BeforeTest
     fun setUp() {
         monitoringMessageHandler = mockk(relaxed = true)
         player = PillarboxExoPlayer {
             monitoring = monitoringMessageHandler
+            coroutineContext(UnconfinedTestDispatcher())
         }
 
         player.prepare()

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/session/PlayerSessionStateTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/session/PlayerSessionStateTest.kt
@@ -40,8 +40,7 @@ class PlayerSessionStateTest {
 
     @Test
     fun `create with Pillarbox player`() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val player = PillarboxExoPlayer(context).apply {
+        val player = PillarboxExoPlayer().apply {
             smoothSeekingEnabled = false
             trackingEnabled = true
         }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/BlockedTimeRangeTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/BlockedTimeRangeTrackerTest.kt
@@ -8,9 +8,7 @@ import android.content.Context
 import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.DefaultLoadControl
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -25,7 +23,6 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -41,10 +38,7 @@ class BlockedTimeRangeTrackerTest {
     fun createPlayer() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         listener = spyk(object : PillarboxPlayer.Listener {})
-        player = PillarboxExoPlayer(context) {
-            loadControl(DefaultLoadControl())
-            clock(FakeClock(true))
-            coroutineContext(EmptyCoroutineContext)
+        player = PillarboxExoPlayer {
             +BlockedAssetLoader(context)
         }
         player.addListener(listener)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
@@ -8,8 +8,6 @@ import android.content.Context
 import android.os.Looper
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.RobolectricUtil
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
 import androidx.test.core.app.ApplicationProvider
@@ -39,9 +37,7 @@ class MediaItemTrackerTest {
     fun createPlayer() {
         val context = ApplicationProvider.getApplicationContext<Context>()
         fakeMediaItemTracker = spyk(FakeMediaItemTracker())
-        player = PillarboxExoPlayer(context) {
-            loadControl(DefaultLoadControl())
-            clock(FakeClock(true))
+        player = PillarboxExoPlayer {
             coroutineContext(EmptyCoroutineContext)
             +FakeAssetLoader(context, fakeMediaItemTracker)
         }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
@@ -21,7 +21,6 @@ import io.mockk.verifyAll
 import io.mockk.verifyOrder
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -38,7 +37,6 @@ class MediaItemTrackerTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         fakeMediaItemTracker = spyk(FakeMediaItemTracker())
         player = PillarboxExoPlayer {
-            coroutineContext(EmptyCoroutineContext)
             +FakeAssetLoader(context, fakeMediaItemTracker)
         }
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/PillarboxMediaMetaDataTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/PillarboxMediaMetaDataTrackerTest.kt
@@ -4,15 +4,11 @@
  */
 package ch.srgssr.pillarbox.player.tracker
 
-import android.content.Context
 import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.DefaultLoadControl
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.PillarboxPlayer
@@ -24,7 +20,6 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -37,13 +32,8 @@ class PillarboxMediaMetaDataTrackerTest {
 
     @BeforeTest
     fun createPlayer() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
         listener = spyk(object : PillarboxPlayer.Listener {})
-        player = PillarboxExoPlayer(context) {
-            loadControl(DefaultLoadControl())
-            clock(FakeClock(true))
-            coroutineContext(EmptyCoroutineContext)
-        }
+        player = PillarboxExoPlayer()
         player.addListener(listener)
         player.prepare()
         player.play()


### PR DESCRIPTION
# Pull request

## Description

This PR rename core-business module `PillarboxExoplayer` to `PillarboxExoPlayer`.

## Changes made

- Remove `PillarboxExoPlayer(context)` from player module, replaced by `PillarboxExoPlayer(context, Default)`

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
