### PR TITLE
Network stack okhttp

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 androidx-media3-cast = { group = "androidx.media3", name = "media3-cast", version.ref = "androidx-media3" }
 androidx-media3-common = { group = "androidx.media3", name = "media3-common", version.ref = "androidx-media3" }
 androidx-media3-datasource = { group = "androidx.media3", name = "media3-datasource", version.ref = "androidx-media3" }
+androidx-media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "androidx-media3" }
 androidx-media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "androidx-media3" }
 androidx-media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "androidx-media3" }
 androidx-media3-dash = { group = "androidx.media3", name = "media3-exoplayer-dash", version.ref = "androidx-media3" }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/SRGAssetLoaderConfig.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/SRGAssetLoaderConfig.kt
@@ -9,6 +9,7 @@ import androidx.annotation.VisibleForTesting
 import androidx.media3.common.MediaMetadata
 import androidx.media3.datasource.DataSource.Factory
 import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.okhttp.OkHttpDataSource
 import ch.srgssr.pillarbox.analytics.SRGAnalytics
 import ch.srgssr.pillarbox.core.business.akamai.AkamaiTokenProvider
 import ch.srgssr.pillarbox.core.business.integrationlayer.ResourceSelector
@@ -20,6 +21,7 @@ import ch.srgssr.pillarbox.core.business.integrationlayer.service.MediaCompositi
 import ch.srgssr.pillarbox.core.business.tracker.commandersact.CommandersActTracker
 import ch.srgssr.pillarbox.core.business.tracker.comscore.ComScoreTracker
 import ch.srgssr.pillarbox.player.PillarboxDsl
+import ch.srgssr.pillarbox.player.network.PillarboxOkHttp
 import ch.srgssr.pillarbox.player.tracker.MediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MutableMediaItemTrackerData
 import io.ktor.client.HttpClient
@@ -31,7 +33,7 @@ import kotlinx.coroutines.Dispatchers
  */
 @PillarboxDsl
 class SRGAssetLoaderConfig internal constructor(context: Context) {
-    private var dataSourceFactory: Factory = DefaultDataSource.Factory(context)
+    private var dataSourceFactory: Factory = DefaultDataSource.Factory(context, OkHttpDataSource.Factory(PillarboxOkHttp()))
     private var mediaCompositionService: MediaCompositionService = HttpMediaCompositionService()
     private var akamaiTokenProvider = AkamaiTokenProvider()
     private var mediaItemTrackerDataConfig: (MutableMediaItemTrackerData.(Resource, Chapter, MediaComposition) -> Unit)? = null

--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -79,6 +79,8 @@ dependencies {
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)
     implementation(libs.androidx.media3.ui)
+    implementation(libs.androidx.media3.datasource.okhttp)
+    implementation(libs.ktor.client.okhttp)
     implementation(libs.androidx.navigation.common)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.navigation.runtime)

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     api(libs.androidx.media3.common)
     implementation(libs.androidx.media3.dash)
     implementation(libs.androidx.media3.datasource)
+    api(libs.androidx.media3.datasource.okhttp)
     api(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.hls)
     api(libs.androidx.media3.session)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/network/PillarboxHttpClient.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/network/PillarboxHttpClient.kt
@@ -5,7 +5,6 @@
 package ch.srgssr.pillarbox.player.network
 
 import androidx.annotation.VisibleForTesting
-import ch.srgssr.pillarbox.player.BuildConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.cache.HttpCache
@@ -14,8 +13,6 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.ClassDiscriminatorMode
 import kotlinx.serialization.json.Json
-import okhttp3.logging.HttpLoggingInterceptor
-import okhttp3.logging.HttpLoggingInterceptor.Level
 
 /**
  * Provide a Ktor [HttpClient] instance tailored for Pillarbox's needs.
@@ -39,13 +36,7 @@ object PillarboxHttpClient {
             expectSuccess = true
 
             engine {
-                addInterceptor(
-                    HttpLoggingInterceptor().apply {
-                        val logLevel = if (BuildConfig.DEBUG) Level.BODY else Level.NONE
-
-                        setLevel(logLevel)
-                    }
-                )
+                preconfigured = PillarboxOkHttp()
             }
 
             install(HttpCache)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/network/PillarboxOkHttp.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/network/PillarboxOkHttp.kt
@@ -10,7 +10,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import okhttp3.logging.HttpLoggingInterceptor.Level
 
 /**
- * Provide a Ktor [OkHttpClient] instance tailored for Pillarbox's needs.
+ * Provide a [OkHttpClient] instance tailored for Pillarbox's needs.
  */
 object PillarboxOkHttp {
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/network/PillarboxOkHttp.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/network/PillarboxOkHttp.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.network
+
+import ch.srgssr.pillarbox.player.BuildConfig
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import okhttp3.logging.HttpLoggingInterceptor.Level
+
+/**
+ * Provide a Ktor [OkHttpClient] instance tailored for Pillarbox's needs.
+ */
+object PillarboxOkHttp {
+
+    private val okHttpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    val logLevel = if (BuildConfig.DEBUG) Level.BASIC else Level.NONE
+                    setLevel(logLevel)
+                }
+            )
+            .build()
+    }
+
+    /**
+     * Returns the [OkHttpClient] tailored for Pillarbox's needs.
+     *
+     * @return A [OkHttpClient] instance.
+     */
+    operator fun invoke(): OkHttpClient {
+        return okHttpClient
+    }
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSourceFactory.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaSourceFactory.kt
@@ -6,12 +6,15 @@ package ch.srgssr.pillarbox.player.source
 
 import android.content.Context
 import androidx.media3.common.MediaItem
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.okhttp.OkHttpDataSource
 import androidx.media3.exoplayer.drm.DrmSessionManagerProvider
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.MediaSource
 import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
 import ch.srgssr.pillarbox.player.asset.AssetLoader
 import ch.srgssr.pillarbox.player.asset.UrlAssetLoader
+import ch.srgssr.pillarbox.player.network.PillarboxOkHttp
 import kotlin.time.TimeSource
 
 /**
@@ -28,7 +31,14 @@ class PillarboxMediaSourceFactory(
     /**
      * Default asset loader used when no other AssetLoader has been found.
      */
-    val defaultAssetLoader = UrlAssetLoader(DefaultMediaSourceFactory(context))
+    val defaultAssetLoader = UrlAssetLoader(
+        DefaultMediaSourceFactory(
+            DefaultDataSource.Factory(
+                context,
+                OkHttpDataSource.Factory(PillarboxOkHttp())
+            )
+        )
+    )
 
     /**
      * Minimal duration in milliseconds to consider a live with seek capabilities.


### PR DESCRIPTION
# Pull request

## Description

This PR include Media3 OkHttp DataSource and use it by default.

## Changes made

- Default DataSource.Factory is `OkHttpDataSource.Factory` with `PillarboxOkHttpClient`

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
