### PR TITLE
Let the user input any value for the media URL/URN

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/examples/InsertContentView.kt
@@ -89,7 +89,10 @@ private data class InsertContentData(
                 forceLocation = environmentConfig.location,
             )
 
-            else -> error("Invalid URI: $uri")
+            else -> DemoItem.URL(
+                title = uri,
+                uri = uri,
+            )
         }
     }
 }


### PR DESCRIPTION
# Pull request

## Description

Don't crash the demo app when entering a value that is neither a URL nor a URN in the input field in "Examples".

## Changes made

- In the event that the provided value is neither a value URL nor a valid URN, we now treat it as a URL, without the license URL. This aligns the behavior with what is done in the Apple and Web demos.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).