### PR TITLE
Create a workflow to deploy the Dokka documentation

### DIFF
--- a/.github/workflows/deploy_dokka_documentation.yml
+++ b/.github/workflows/deploy_dokka_documentation.yml
@@ -1,0 +1,46 @@
+name: Deploy Dokka documentation
+
+on:
+  push:
+    branches:
+      - main
+  # TODO Remove before merging
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  deploy-dokka-documentation:
+    name: Deploy Dokka documentation
+    runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+      - name: Copy CI gradle.properties
+        run: mkdir -p ~/.gradle; cp .github/gradle-ci.properties ~/.gradle/gradle.properties
+      - name: Build Dokka documentation
+        run: ./gradlew :dokkaGenerate
+      - name: Deploy Dokka documentation
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          branch: gh-pages
+          folder: build/dokka/html
+          single-commit: true
+          target-folder: api

--- a/.github/workflows/deploy_dokka_documentation.yml
+++ b/.github/workflows/deploy_dokka_documentation.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  # TODO Remove before merging
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
@@ -103,7 +103,8 @@ class PillarboxAndroidLibraryPublishingPlugin : Plugin<Project> {
             pluginsConfiguration.getByName<DokkaHtmlPluginParameters>("html") {
                 customStyleSheets.from(rootProject.projectDir.resolve("dokka/styles/pillarbox.css"))
                 footerMessage.set("© SRG SSR")
-                homepageLink.set("https://srgssr.github.io/pillarbox-android")
+                // TODO Enable this once we have some content there
+                // homepageLink.set("https://srgssr.github.io/pillarbox-android")
                 templatesDir.set(rootProject.projectDir.resolve("dokka/templates"))
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,8 @@ dokka {
         customAssets.from("dokka/images/logo-icon.svg") // TODO Use Pillarbox logo
         customStyleSheets.from("dokka/styles/pillarbox.css")
         footerMessage.set("© SRG SSR")
-        homepageLink.set("https://srgssr.github.io/pillarbox-android")
+        // TODO Enable this once we have some content there
+        // homepageLink.set("https://srgssr.github.io/pillarbox-android")
         templatesDir.set(file("dokka/templates"))
     }
 }


### PR DESCRIPTION
# Pull request

## Description

Create a new workflow to generate and deploy the Dokka documentation.

Merging this will unblock https://github.com/SRGSSR/pillarbox-android/pull/770#discussion_r1820759938, as we will be able to put actual links in the Readme file.

## Changes made

- Add a new workflow.
- Push the documentation to the [`gh-pages`](https://github.com/SRGSSR/pillarbox-android/tree/gh-pages), in the `api` folder.
- The Dokka documentation is available at: https://srgssr.github.io/pillarbox-android/api/
- Disable link to the project's website, since there is no website yet.

> [!NOTE]
> For now, it is triggered on every push on `main`. Once the whole documentation is complete, I suggest triggering it only for each new release (or merging it with the `release.yml` workflow).

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).