### PR TITLE
Add Google's Maven repository to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,11 @@
 version: 2
 
 registries:
+  google-maven:
+    type: maven-repository
+    url: https://maven.google.com
+    username: "" # Required by Dependabot
+    password: "" # Required by Dependabot
   srgdataprovider-android:
     type: maven-repository
     url: https://maven.pkg.github.com/SRGSSR/srgdataprovider-android
@@ -25,6 +30,7 @@ updates:
     schedule:
       interval: "weekly"
     registries:
+      - "google-maven"
       - "srgdataprovider-android"
     groups:
       androidx:


### PR DESCRIPTION
# Pull request

## Description

In https://github.com/SRGSSR/pillarbox-android/pull/735, we added support for the `https://maven.pkg.github.com/SRGSSR/srgdataprovider-android` repository to Dependabot. Since then, we didn't receive updates for Android dependencies.
This PR adds Google's Maven repository to Dependabot configuration, so we can receive Android updates again.

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
