### PR TITLE
Update to Gradle 8.11

### DIFF
--- a/build-logic/plugins/build.gradle.kts
+++ b/build-logic/plugins/build.gradle.kts
@@ -3,6 +3,7 @@
  * License information is available from the LICENSE file.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
@@ -18,8 +19,8 @@ java {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.majorVersion
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,31 +12,40 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+# https://docs.gradle.org/current/userguide/performance.html#increase_the_heap_size
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# https://docs.gradle.org/current/userguide/performance.html#parallel_execution
 org.gradle.parallel=true
 
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
-# https://developer.android.com/topic/libraries/support-library/androidx-rn
+# https://developer.android.com/jetpack/androidx#using_androidx_libraries_in_your_project
 android.useAndroidX=true
 
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
+# Gradle's Build Cache
+# https://docs.gradle.org/current/userguide/performance.html#enable_the_build_cache
 org.gradle.caching=true
+
+# Gradle's Configuration Cache
+# https://docs.gradle.org/current/userguide/performance.html#enable_configuration_cache
 # Disable configuration cache until Dokka supports it: https://github.com/Kotlin/dokka/issues/1217
 org.gradle.configuration-cache=false
+org.gradle.configuration-cache.parallel=true
 
 # Print dependency analysis report to the console
 dependency.analysis.print.build.health=true
 
-# Let Detekt use Gradle's Worker API (https://detekt.dev/docs/gettingstarted/gradle/#options-for-detekt-gradle-properties)
+# Let Detekt use Gradle's Worker API
+# https://detekt.dev/docs/gettingstarted/gradle/#options-for-detekt-gradle-properties
 detekt.use.worker.api=true
 
-# Use Dokka 2 Gradle Plugin: https://kotlinlang.org/docs/dokka-migration.html#migrate-your-project
+# Use Dokka 2 Gradle Plugin
+# https://kotlinlang.org/docs/dokka-migration.html#migrate-your-project
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Pull request

## Description

Update Gradle to version 8.11. See the [release notes](https://docs.gradle.org/8.11/release-notes.html) for more information.

## Changes made

- Update to Gradle 8.11.
- Fix a deprecation warning: migrate from `KotlinCompile.kotlinOptions` to `KotlinCompile.compilerOptions`.
- Enable Gradle's Configuration Cache parallel mode.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).