### PR TITLE
Fix Dokka jar generation for release

### DIFF
--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
@@ -27,9 +27,10 @@ class PillarboxAndroidLibraryPublishingPlugin : Plugin<Project> {
         pluginManager.apply("com.android.library")
         pluginManager.apply("org.gradle.maven-publish")
         pluginManager.apply("org.jetbrains.dokka")
+        pluginManager.apply("org.jetbrains.dokka-javadoc")
 
         val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
-            val dokkaHtmlTask = tasks.named("dokkaHtml")
+            val dokkaHtmlTask = tasks.named("dokkaGeneratePublicationHtml")
 
             dependsOn(dokkaHtmlTask)
             from(dokkaHtmlTask.map { it.outputs })
@@ -37,7 +38,7 @@ class PillarboxAndroidLibraryPublishingPlugin : Plugin<Project> {
         }
 
         val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
-            val dokkaJavadocTask = tasks.named("dokkaJavadoc")
+            val dokkaJavadocTask = tasks.named("dokkaGeneratePublicationJavadoc")
 
             dependsOn(dokkaJavadocTask)
             from(dokkaJavadocTask.map { it.outputs })

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,7 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.dependency.analysis.gradle.plugin)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.dokka.javadoc)
     alias(libs.plugins.kotlinx.kover)
     alias(libs.plugins.pillarbox.detekt)
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,8 @@ android.useAndroidX=true
 kotlin.code.style=official
 
 org.gradle.caching=true
-org.gradle.configuration-cache=true
+# Disable configuration cache until Dokka supports it: https://github.com/Kotlin/dokka/issues/1217
+org.gradle.configuration-cache=false
 
 # Print dependency analysis report to the console
 dependency.analysis.print.build.health=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -145,6 +145,7 @@ android-library = { id = "com.android.library", version.ref = "android-gradle-pl
 dependency-analysis-gradle-plugin = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis-gradle-plugin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokka-javadoc = { id = "org.jetbrains.dokka-javadoc", version.ref = "dokka" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }


### PR DESCRIPTION
# Pull request

## Description

During the migration to Dokka 2, the `release.yml` workflow was not updated to use the new task names. This PR fixes that.
Also, it appears that Dokka 2 is not fully compatible with Gradle's Configuration Cache, so I've disabled it again. I'll investigate this further later and notify Dokka if necessary.

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).