### PR TITLE
Make some symbols `internal`/`private`

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxBuilder.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxBuilder.kt
@@ -199,7 +199,7 @@ abstract class PillarboxBuilder {
      *
      * @return A new instance of [PillarboxExoPlayer].
      */
-    fun create(context: Context): PillarboxExoPlayer {
+    internal fun create(context: Context): PillarboxExoPlayer {
         return PillarboxExoPlayer(
             context = context,
             coroutineContext = coroutineContext,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/timeRange/TimeRange.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/timeRange/TimeRange.kt
@@ -43,7 +43,7 @@ sealed interface TimeRange {
 /**
  * @return the first not `null` [TimeRange] at [position].
  */
-internal fun <T : TimeRange> List<T>.firstOrNullAtPosition(position: Long): T? {
+fun <T : TimeRange> List<T>.firstOrNullAtPosition(position: Long): T? {
     return if (position == C.TIME_UNSET) {
         null
     } else {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/timeRange/TimeRange.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/asset/timeRange/TimeRange.kt
@@ -43,7 +43,7 @@ sealed interface TimeRange {
 /**
  * @return the first not `null` [TimeRange] at [position].
  */
-fun <T : TimeRange> List<T>.firstOrNullAtPosition(position: Long): T? {
+internal fun <T : TimeRange> List<T>.firstOrNullAtPosition(position: Long): T? {
     return if (position == C.TIME_UNSET) {
         null
     } else {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/MonitoringMessageHandler.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/MonitoringMessageHandler.kt
@@ -50,7 +50,7 @@ interface MonitoringMessageHandlerFactory<Config> {
  * @param Config The config used to create a new [MonitoringMessageHandler].
  */
 @PillarboxDsl
-class MonitoringConfigFactory<Config>
+class MonitoringConfigFactory<Config> internal constructor()
 
 /**
  * Represents a specific type of [MonitoringMessageHandler].


### PR DESCRIPTION
# Pull request

## Description

This PR changes the visibility of some symbols in `pillarbox-player` so they are not exposed unnecessarily to integrators.
This will also help limit the amount of data that we show to integrators in the documentation.

## Changes made

- Make `PillarboxBuilder.create()` internal: this method creates a `PillarboxExoPlayer`, whose constructor is already internal. Everything needed by this method can be customized via methods on `PillarboxBuilder`.
- Make `PillarboxAnalyticsListener` and `PlaybackSessionManager.Listener` implementations inner classes in `MetricsCollector`: there's no need to expose these, since they are only needed inside of `MetricsCollector`.
- ~Make `List<TimeRange>.firstOrNullAtPosition(position: Long)` internal: seems rather specific to our needs. But I'm open to reverting this.~
- Make `MonitoringConfigFactory`'s constructor internal: it is only necessary inside `PillarboxBuilder` to create the DSL structure.

## Open points

There are other symbols that may be removed/internalized. Tell me what you think about them:
- [`Format.selectionString()`](https://github.com/SRGSSR/pillarbox-android/blob/3f6e6e130df0842c4b874bbc6e24bd02588fc968/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt#L53): seems more like a debug method. I think we can remove it.
- [`Format.roleString()`](https://github.com/SRGSSR/pillarbox-android/blob/3f6e6e130df0842c4b874bbc6e24bd02588fc968/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Format.kt#L71): same as above.
- [`BitrateUtil`](https://github.com/SRGSSR/pillarbox-android/blob/3f6e6e130df0842c4b874bbc6e24bd02588fc968/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/BitrateUtil.kt): only used in the demo. I suggest moving it there.
- [`StringUtil`](https://github.com/SRGSSR/pillarbox-android/blob/3f6e6e130df0842c4b874bbc6e24bd02588fc968/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/StringUtil.kt): seems more like a debug class. Maybe we can internalize it or remove it.
- [pillarbox-ui] [`KeepScreenOn`](https://github.com/SRGSSR/pillarbox-android/blob/3f6e6e130df0842c4b874bbc6e24bd02588fc968/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/widget/KeepScreenOn.kt): only used in the demo. What about moving it there?

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).