### PR TITLE
Add emoji for debug and nigthly build

### DIFF
--- a/pillarbox-demo/src/debug/res/values/strings.xml
+++ b/pillarbox-demo/src/debug/res/values/strings.xml
@@ -3,5 +3,5 @@
   ~ License information is available from the LICENSE file.
   -->
 <resources>
-    <string name="app_name">🐛Pillarbox Demo</string>
+    <string name="app_name">🐛 Pillarbox Demo</string>
 </resources>

--- a/pillarbox-demo/src/debug/res/values/strings.xml
+++ b/pillarbox-demo/src/debug/res/values/strings.xml
@@ -3,5 +3,5 @@
   ~ License information is available from the LICENSE file.
   -->
 <resources>
-    <string name="app_name">Pillarbox Demo Debug</string>
+    <string name="app_name">🐛Pillarbox Demo</string>
 </resources>

--- a/pillarbox-demo/src/nightly/res/values/strings.xml
+++ b/pillarbox-demo/src/nightly/res/values/strings.xml
@@ -3,5 +3,5 @@
   ~ License information is available from the LICENSE file.
   -->
 <resources>
-    <string name="app_name">🌙Pillarbox Demo Nightly</string>
+    <string name="app_name">🌙 Pillarbox Demo Nightly</string>
 </resources>

--- a/pillarbox-demo/src/nightly/res/values/strings.xml
+++ b/pillarbox-demo/src/nightly/res/values/strings.xml
@@ -3,5 +3,5 @@
   ~ License information is available from the LICENSE file.
   -->
 <resources>
-    <string name="app_name">Pillarbox Demo Nightly</string>
+    <string name="app_name">🌙Pillarbox Demo Nightly</string>
 </resources>

--- a/pillarbox-demo/src/nightly/res/values/strings.xml
+++ b/pillarbox-demo/src/nightly/res/values/strings.xml
@@ -3,5 +3,5 @@
   ~ License information is available from the LICENSE file.
   -->
 <resources>
-    <string name="app_name">🌙 Pillarbox Demo Nightly</string>
+    <string name="app_name">🌙 Pillarbox Demo</string>
 </resources>


### PR DESCRIPTION
# Pull request

## Description

Add prefix emoji to differentiate builds.

- `🐛 Pillarbox Demo Debug`
- `🌙 Pillarbox Demo Nightly`

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
