### PR TITLE
Improve Gradle scripts

### DIFF
--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidApplicationPlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidApplicationPlugin.kt
@@ -36,6 +36,7 @@ class PillarboxAndroidApplicationPlugin : Plugin<Project> {
 
             defaultConfig {
                 applicationId = namespace
+                resourceConfigurations += "en"
                 targetSdk = AppConfig.targetSdk
                 versionCode = VersionConfig().versionCode()
                 versionName = VersionConfig().versionName()
@@ -43,7 +44,7 @@ class PillarboxAndroidApplicationPlugin : Plugin<Project> {
             }
 
             signingConfigs {
-                create("release") {
+                register("release") {
                     val password = System.getenv("DEMO_KEY_PASSWORD") ?: extra.properties["pillarbox.keystore.password"] as String?
 
                     storeFile = file("./demo.keystore")
@@ -60,7 +61,7 @@ class PillarboxAndroidApplicationPlugin : Plugin<Project> {
                 }
 
                 release {
-                    signingConfig = signingConfigs.named("release").get()
+                    signingConfig = signingConfigs.getByName("release")
                     isMinifyEnabled = false
                     isDebuggable = true
 

--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -10,14 +10,16 @@ android {
     val versionDimension = "version"
     flavorDimensions += versionDimension
     productFlavors {
-        create("prod") {
+        register("prod") {
             dimension = versionDimension
         }
 
-        create("nightly") {
-            dimension = versionDimension
-            applicationIdSuffix = ".nightly"
-            versionNameSuffix = "-nightly"
+        if (System.getenv("CI") == "true") {
+            register("nightly") {
+                dimension = versionDimension
+                applicationIdSuffix = ".nightly"
+                versionNameSuffix = "-nightly"
+            }
         }
     }
 
@@ -28,15 +30,6 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
-        }
-    }
-
-    // Hide nightly flavors from BuildVariants in AndroidStudio
-    androidComponents {
-        beforeVariants { variant ->
-            val isCI = System.getenv("CI")?.toBooleanStrictOrNull() ?: false
-
-            variant.enable = isCI || variant.flavorName != "nightly"
         }
     }
 }


### PR DESCRIPTION
# Pull request

## Description

Small tweaks to Gradle scripts.

## Changes made

- Use Gradle lazy API. Replace calls to `create` by `register`. The former immediately creates and configures the object, the latter only does it when needed.
- Only keep English resources in demo applications, since they are not translated anyway. This should help reduce the size of the final application.
- Only creates the `nightly` flavor on CI.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).