### PR TITLE
830 reduce flakiness of some tests

### DIFF
--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
@@ -9,8 +9,8 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.comscore.Analytics
+import io.mockk.clearAllMocks
 import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import kotlin.test.AfterTest
@@ -37,7 +37,7 @@ class SRGAnalyticsSingletonTest {
 
     @AfterTest
     fun tearDown() {
-        unmockkAll()
+        clearAllMocks()
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsTest.kt
@@ -10,9 +10,11 @@ import ch.srgssr.pillarbox.analytics.commandersact.CommandersActPageView
 import ch.srgssr.pillarbox.analytics.comscore.ComScore
 import ch.srgssr.pillarbox.analytics.comscore.ComScorePageView
 import io.mockk.Called
+import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.mockk
 import io.mockk.verify
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 
@@ -29,6 +31,11 @@ class SRGAnalyticsTest {
             comScore = comScore,
             commandersAct = commandersAct,
         )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
@@ -10,11 +10,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.analytics.AnalyticsConfig
 import com.comscore.Analytics
 import com.comscore.PublisherConfiguration
+import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
@@ -44,7 +44,7 @@ class ComScoreSrgTest {
 
     @AfterTest
     fun tearDown() {
-        unmockkAll()
+        clearAllMocks()
     }
 
     @Test(expected = IllegalArgumentException::class)

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/PillarboxTestPlayer.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/PillarboxTestPlayer.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.core.business
+
+import android.content.Context
+import androidx.media3.common.C
+import androidx.media3.exoplayer.DefaultLoadControl
+import androidx.media3.test.utils.FakeClock
+import androidx.test.core.app.ApplicationProvider
+import ch.srgssr.pillarbox.player.PillarboxDsl
+import ch.srgssr.pillarbox.player.PillarboxExoPlayer
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Pillarbox ExoPlayer
+ *
+ * @param context The [Context], by default [ApplicationProvider.getApplicationContext]
+ * @param block The block to further configure the [PillarboxExoPlayer].
+ * @return [PillarboxExoPlayer] configured for tests.
+ */
+@PillarboxDsl
+fun PillarboxExoPlayer(context: Context = ApplicationProvider.getApplicationContext(), block: SRG.Builder.() -> Unit = {}): PillarboxExoPlayer {
+    return PillarboxExoPlayer(context, SRG) {
+        loadControl(DefaultLoadControl())
+        clock(FakeClock(true))
+        coroutineContext(EmptyCoroutineContext)
+        block()
+    }.apply {
+        // FIXME Investigate why we need to disable the image track in tests
+        trackSelectionParameters = trackSelectionParameters.buildUpon()
+            .setTrackTypeDisabled(C.TRACK_TYPE_IMAGE, true)
+            .build()
+    }
+}

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/PillarboxTestPlayer.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/PillarboxTestPlayer.kt
@@ -26,6 +26,7 @@ fun PillarboxExoPlayer(context: Context = ApplicationProvider.getApplicationCont
         loadControl(DefaultLoadControl())
         clock(FakeClock(true))
         coroutineContext(EmptyCoroutineContext)
+        disableMonitoring()
         block()
     }.apply {
         // FIXME Investigate why we need to disable the image track in tests

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTrackerTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/SRGEventLoggerTrackerTest.kt
@@ -6,18 +6,31 @@ package ch.srgssr.pillarbox.core.business.tracker
 
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.verifySequence
 import org.junit.runner.RunWith
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 
 @RunWith(AndroidJUnit4::class)
 class SRGEventLoggerTrackerTest {
+    private lateinit var player: ExoPlayer
+
+    @BeforeTest
+    fun setUp() {
+        player = mockk(relaxed = true)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        clearAllMocks()
+    }
+
     @Test
     fun `event logger`() {
-        val player = mockk<ExoPlayer>(relaxed = true)
         val eventLogger = SRGEventLoggerTracker.Factory().create()
-
         eventLogger.start(player, Unit)
         eventLogger.stop(player)
 

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -942,7 +942,7 @@ class CommandersActTrackerIntegrationTest {
     }
 
     private companion object {
-        private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8"
+        private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8"
         private const val URN_AUDIO = "urn:rts:audio:13598743"
         private const val URN_LIVE_DVR_VIDEO = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_VIDEO
         private const val URN_NOT_LIVE_VIDEO = "urn:rsi:video:15916771"

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -80,9 +80,9 @@ class CommandersActTrackerIntegrationTest {
 
     @AfterTest
     fun tearDown() {
-        clearAllMocks()
         player.release()
         shadowOf(Looper.getMainLooper()).idle()
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -6,7 +6,6 @@ package ch.srgssr.pillarbox.core.business.tracker.commandersact
 
 import android.content.Context
 import android.os.Looper
-import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
@@ -42,7 +41,6 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.math.abs
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -70,21 +68,13 @@ class CommandersActTrackerIntegrationTest {
         testDispatcher = UnconfinedTestDispatcher()
 
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val mediaCompositionWithFallbackService = LocalMediaCompositionWithFallbackService(context)
-        player = PillarboxExoPlayer(context) {
+        player = PillarboxExoPlayer {
+            clock(clock)
             srgAssetLoader(context) {
-                mediaCompositionService(mediaCompositionWithFallbackService)
+                mediaCompositionService(LocalMediaCompositionWithFallbackService(context))
                 commanderActTrackerFactory(CommandersActTracker.Factory(commandersAct = commandersAct, coroutineContext = testDispatcher))
                 comscoreTrackerFactory(mockk(relaxed = true))
             }
-            clock(clock)
-            // Use other CoroutineContext to avoid infinite loop because Heartbeat is also running in Pillarbox.
-            coroutineContext(EmptyCoroutineContext)
-        }.apply {
-            // FIXME Investigate why we need to disable the image track in tests
-            trackSelectionParameters = trackSelectionParameters.buildUpon()
-                .setTrackTypeDisabled(C.TRACK_TYPE_IMAGE, true)
-                .build()
         }
     }
 

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
@@ -9,7 +9,6 @@ import android.os.Looper
 import android.view.SurfaceView
 import android.view.ViewGroup
 import androidx.core.view.updateLayoutParams
-import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.test.utils.FakeClock
@@ -33,7 +32,6 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
@@ -57,20 +55,13 @@ class ComScoreTrackerIntegrationTest {
             ComScoreTracker(streamingAnalytics)
         }
         val context = ApplicationProvider.getApplicationContext<Context>()
-        val mediaCompositionWithFallbackService = LocalMediaCompositionWithFallbackService(context)
-        player = PillarboxExoPlayer(context) {
+        player = PillarboxExoPlayer {
             clock(clock)
-            coroutineContext(EmptyCoroutineContext)
             srgAssetLoader(context) {
-                mediaCompositionService(mediaCompositionWithFallbackService)
+                mediaCompositionService(LocalMediaCompositionWithFallbackService(context))
                 comscoreTrackerFactory(comScoreFactory)
                 commanderActTrackerFactory(mockk(relaxed = true))
             }
-        }.apply {
-            // FIXME Investigate why we need to disable the image track in tests
-            trackSelectionParameters = trackSelectionParameters.buildUpon()
-                .setTrackTypeDisabled(C.TRACK_TYPE_IMAGE, true)
-                .build()
         }
     }
 

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
@@ -67,9 +67,9 @@ class ComScoreTrackerIntegrationTest {
 
     @AfterTest
     fun tearDown() {
-        clearAllMocks()
         player.release()
         shadowOf(Looper.getMainLooper()).idle()
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
@@ -682,7 +682,7 @@ class ComScoreTrackerIntegrationTest {
     // endregion
 
     private companion object {
-        private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8"
+        private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8"
         private const val URN_LIVE_DVR_VIDEO = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_VIDEO
         private const val URN_NOT_LIVE_VIDEO = "urn:rsi:video:15916771"
     }

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerTest.kt
@@ -11,11 +11,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.analytics.BuildConfig
 import com.comscore.Analytics
 import com.comscore.streaming.StreamingAnalytics
+import io.mockk.clearAllMocks
 import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import io.mockk.verify
 import org.junit.runner.RunWith
 import kotlin.test.AfterTest
@@ -33,7 +33,7 @@ class ComScoreTrackerTest {
 
     @AfterTest
     fun tearDown() {
-        unmockkAll()
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-demo-shared/build.gradle.kts
+++ b/pillarbox-demo-shared/build.gradle.kts
@@ -50,4 +50,5 @@ dependencies {
     debugImplementation(libs.androidx.compose.ui.tooling)
 
     testImplementation(libs.junit)
+    testImplementation(libs.kotlin.test)
 }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoItem.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/DemoItem.kt
@@ -119,7 +119,7 @@ sealed class DemoItem(
 
         val OnDemandHLS = URL(
             title = "VOD - HLS",
-            uri = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8",
+            uri = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8",
             description = "Sacha part à la rencontre d'univers atypiques",
             languageTag = "fr-CH",
         )

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/data/Playlist.kt
@@ -48,7 +48,7 @@ data class Playlist(val title: String, val items: List<DemoItem>, val languageTa
             items = listOf(
                 DemoItem.URL(
                     title = "Sacha part à la rencontre d'univers atypiques",
-                    uri = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8",
+                    uri = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8",
                     description = "VOD - HLS",
                     imageUri = "https://www.rts.ch/2024/06/13/11/34/14970435.image/16x9",
                     languageTag = "fr-CH",

--- a/pillarbox-demo-shared/src/test/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentTest.kt
+++ b/pillarbox-demo-shared/src/test/java/ch/srgssr/pillarbox/demo/shared/ui/integrationLayer/data/ContentTest.kt
@@ -9,10 +9,10 @@ import ch.srg.dataProvider.integrationlayer.data.remote.Media
 import ch.srg.dataProvider.integrationlayer.data.remote.MediaType
 import ch.srg.dataProvider.integrationlayer.data.remote.Type
 import ch.srg.dataProvider.integrationlayer.data.remote.Vendor
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import java.util.Date
 import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds

--- a/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/TestPillarboxRunHelper.kt
+++ b/pillarbox-player-testutils/src/main/java/ch/srgssr/pillarbox/player/test/utils/TestPillarboxRunHelper.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.player.test.utils
 
+import android.annotation.SuppressLint
 import android.os.Looper
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
@@ -26,25 +27,26 @@ object TestPillarboxRunHelper {
     }
 
     /**
-     * Runs tasks of the main Looper until [Player.Listener.onEvents] matches the
+     * Runs tasks of the main [Looper] until [Player.Listener.onEvents] matches the
      * expected state or a playback error occurs.
      *
-     * <p>If a playback error occurs it will be thrown wrapped in an {@link IllegalStateException}.
+     * <p>If a playback error occurs it will be thrown wrapped in an [IllegalStateException].
      *
      * @param player The [Player].
-     * @param expectedEvent The expected [Player.Event] if null wait until first [Player.Listener.onEvents].
+     * @param expectedEvents The expected [Player.Event]. If empty, waits until the first [Player.Listener.onEvents].
      * @throws TimeoutException If the [RobolectricUtil.DEFAULT_TIMEOUT_MS] is exceeded.
      */
     @Throws(TimeoutException::class)
-    fun runUntilEvent(player: Player, expectedEvent: @Player.Event Int? = null) {
+    fun runUntilEvents(player: Player, vararg expectedEvents: @Player.Event Int) {
         verifyMainTestThread(player)
         if (player is ExoPlayer) {
             verifyPlaybackThreadIsAlive(player)
         }
         val receivedCallback = AtomicBoolean(false)
         val listener: Player.Listener = object : Player.Listener {
+            @SuppressLint("WrongConstant")
             override fun onEvents(player: Player, events: Player.Events) {
-                if (expectedEvent?.let { events.contains(it) } != false) {
+                if (expectedEvents.isEmpty() || events.containsAny(*expectedEvents)) {
                     receivedCallback.set(true)
                 }
             }

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     androidTestImplementation(libs.androidx.test.monitor)
     androidTestRuntimeOnly(libs.androidx.test.runner)
     androidTestImplementation(libs.junit)
+    androidTestImplementation(libs.kotlin.test)
     androidTestRuntimeOnly(libs.kotlinx.coroutines.android)
     androidTestImplementation(libs.mockk)
 }

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/IsPlayingAllTypeOfContentTest.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/IsPlayingAllTypeOfContentTest.kt
@@ -11,11 +11,13 @@ import androidx.media3.common.Player
 import androidx.media3.common.util.ConditionVariable
 import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import ch.srgssr.pillarbox.player.utils.ContentUrls
-import org.junit.Assert
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 /**
  * Instrumented test, which will execute on an Android device.
@@ -50,10 +52,10 @@ class IsPlayingAllTypeOfContentTest {
             if (player.playerError != null) {
                 throw Exception(player.playerError)
             }
-            Assert.assertEquals(Player.STATE_READY, player.playbackState)
-            Assert.assertTrue(player.isPlaying)
-            Assert.assertNotNull(player.currentMediaItem)
-            Assert.assertEquals(player.currentMediaItem?.localConfiguration?.uri, Uri.parse(urlToTest))
+            assertEquals(Player.STATE_READY, player.playbackState)
+            assertTrue(player.isPlaying)
+            assertNotNull(player.currentMediaItem)
+            assertEquals(player.currentMediaItem?.localConfiguration?.uri, Uri.parse(urlToTest))
             player.release()
         }
     }

--- a/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/utils/ContentUrls.kt
+++ b/pillarbox-player/src/androidTest/java/ch/srgssr/pillarbox/player/utils/ContentUrls.kt
@@ -5,7 +5,8 @@
 package ch.srgssr.pillarbox.player.utils
 
 object ContentUrls {
-    const val VOD_HLS = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8"
+    const val VOD_HLS = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8"
+
     // From urn:swi:video:48940210
     const val VOD_MP4 = "https://cdn.prod.swi-services.ch/video-projects/141b30ce-3850-424b-9063-a20d5619d342/localised-videos/ENG/renditions/ENG.mp4"
     const val VOD_DASH_H264 = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd"

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerPlaybackSpeedTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerPlaybackSpeedTest.kt
@@ -22,7 +22,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 @RunWith(AndroidJUnit4::class)
-class TestPillarboxExoPlayerPlaybackSpeed {
+class PillarboxExoPlayerPlaybackSpeedTest {
     private lateinit var player: PillarboxExoPlayer
 
     @BeforeTest

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
@@ -227,7 +227,7 @@ class PlayerCallbackFlowTest {
     }
 
     private companion object {
-        private const val VOD = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8"
+        private const val VOD = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8"
         private const val LIVE = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0"
         private const val LIVE_DVR = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8"
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestIsPlaybackSpeedPossibleAtPosition.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestIsPlaybackSpeedPossibleAtPosition.kt
@@ -12,17 +12,17 @@ import ch.srgssr.pillarbox.player.test.utils.TestTimeline
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.After
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Test
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class TestIsPlaybackSpeedPossibleAtPosition {
 
-    @After
+    @AfterTest
     fun tearDown() {
         clearAllMocks()
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPillarboxExoPlayerPlaybackSpeed.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPillarboxExoPlayerPlaybackSpeed.kt
@@ -70,7 +70,7 @@ class TestPillarboxExoPlayerPlaybackSpeed {
 
         player.setPlaybackSpeed(2f)
         Assert.assertEquals(2f, player.getPlaybackSpeed())
-        TestPillarboxRunHelper.runUntilEvent(player, Player.EVENT_IS_LOADING_CHANGED)
+        TestPillarboxRunHelper.runUntilEvents(player, Player.EVENT_IS_LOADING_CHANGED)
         Assert.assertEquals(2f, player.getPlaybackSpeed())
     }
 
@@ -103,17 +103,17 @@ class TestPillarboxExoPlayerPlaybackSpeed {
 
         val speed = 2f
         player.setPlaybackSpeed(speed)
-        TestPillarboxRunHelper.runUntilEvent(player)
+        TestPillarboxRunHelper.runUntilEvents(player)
         Assert.assertEquals(speed, player.getPlaybackSpeed())
 
         player.setPlaybackSpeed(1f)
-        TestPillarboxRunHelper.runUntilEvent(player)
+        TestPillarboxRunHelper.runUntilEvents(player)
         Assert.assertEquals(1f, player.getPlaybackSpeed())
     }
 
-    companion object {
-        const val LIVE_DVR_URL = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8"
-        const val LIVE_ONLY_URL = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0"
-        const val VOD_URL = "https://rts-vod-amd.akamaized.net/ww/13317145/f1d49f18-f302-37ce-866c-1c1c9b76a824/master.m3u8"
+    private companion object {
+        private const val LIVE_DVR_URL = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8"
+        private const val LIVE_ONLY_URL = "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0"
+        private const val VOD_URL = "https://rts-vod-amd.akamaized.net/ww/13317145/f1d49f18-f302-37ce-866c-1c1c9b76a824/master.m3u8"
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPillarboxExoPlayerPlaybackSpeed.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPillarboxExoPlayerPlaybackSpeed.kt
@@ -4,15 +4,12 @@
  */
 package ch.srgssr.pillarbox.player
 
-import android.content.Context
 import android.os.Looper
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline.Window
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.extension.getPlaybackSpeed
 import ch.srgssr.pillarbox.player.test.utils.TestPillarboxRunHelper
@@ -22,7 +19,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-import kotlin.coroutines.EmptyCoroutineContext
 
 @RunWith(AndroidJUnit4::class)
 class TestPillarboxExoPlayerPlaybackSpeed {
@@ -30,11 +26,7 @@ class TestPillarboxExoPlayerPlaybackSpeed {
 
     @Before
     fun createPlayer() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        player = PillarboxExoPlayer(context) {
-            clock(FakeClock(true))
-            coroutineContext(EmptyCoroutineContext)
-        }
+        player = PillarboxExoPlayer()
     }
 
     @After

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPillarboxExoPlayerPlaybackSpeed.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPillarboxExoPlayerPlaybackSpeed.kt
@@ -13,23 +13,24 @@ import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.extension.getPlaybackSpeed
 import ch.srgssr.pillarbox.player.test.utils.TestPillarboxRunHelper
-import org.junit.After
-import org.junit.Assert
-import org.junit.Before
-import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 @RunWith(AndroidJUnit4::class)
 class TestPillarboxExoPlayerPlaybackSpeed {
     private lateinit var player: PillarboxExoPlayer
 
-    @Before
+    @BeforeTest
     fun createPlayer() {
         player = PillarboxExoPlayer()
     }
 
-    @After
+    @AfterTest
     fun releasePlayer() {
         player.release()
         shadowOf(Looper.getMainLooper()).idle()
@@ -43,15 +44,15 @@ class TestPillarboxExoPlayerPlaybackSpeed {
             play()
         }
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
-        Assert.assertEquals(Player.STATE_READY, player.playbackState)
+        assertEquals(Player.STATE_READY, player.playbackState)
 
         player.setPlaybackSpeed(2f)
-        Assert.assertEquals(1f, player.getPlaybackSpeed())
+        assertEquals(1f, player.getPlaybackSpeed())
 
         player.seekTo(0)
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
         player.setPlaybackSpeed(2f)
-        Assert.assertEquals(1f, player.getPlaybackSpeed())
+        assertEquals(1f, player.getPlaybackSpeed())
     }
 
     @Test
@@ -63,15 +64,15 @@ class TestPillarboxExoPlayerPlaybackSpeed {
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
         player.setPlaybackSpeed(2f)
-        Assert.assertEquals(1f, player.getPlaybackSpeed())
+        assertEquals(1f, player.getPlaybackSpeed())
 
         player.seekTo(0)
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
 
         player.setPlaybackSpeed(2f)
-        Assert.assertEquals(2f, player.getPlaybackSpeed())
+        assertEquals(2f, player.getPlaybackSpeed())
         TestPillarboxRunHelper.runUntilEvents(player, Player.EVENT_IS_LOADING_CHANGED)
-        Assert.assertEquals(2f, player.getPlaybackSpeed())
+        assertEquals(2f, player.getPlaybackSpeed())
     }
 
     @Test
@@ -82,16 +83,16 @@ class TestPillarboxExoPlayerPlaybackSpeed {
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
 
         val liveEdgePosition = player.currentTimeline.getWindow(0, Window()).defaultPositionMs
-        Assert.assertNotEquals(C.TIME_UNSET, liveEdgePosition)
+        assertNotEquals(C.TIME_UNSET, liveEdgePosition)
         player.seekTo(liveEdgePosition - 5_000)
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
 
         val speed = 2f
         player.setPlaybackSpeed(speed)
-        Assert.assertEquals(speed, player.getPlaybackSpeed())
+        assertEquals(speed, player.getPlaybackSpeed())
 
         TestPillarboxRunHelper.runUntilPlaybackParametersChanged(player)
-        Assert.assertEquals(1f, player.getPlaybackSpeed())
+        assertEquals(1f, player.getPlaybackSpeed())
     }
 
     @Test
@@ -104,11 +105,11 @@ class TestPillarboxExoPlayerPlaybackSpeed {
         val speed = 2f
         player.setPlaybackSpeed(speed)
         TestPillarboxRunHelper.runUntilEvents(player)
-        Assert.assertEquals(speed, player.getPlaybackSpeed())
+        assertEquals(speed, player.getPlaybackSpeed())
 
         player.setPlaybackSpeed(1f)
         TestPillarboxRunHelper.runUntilEvents(player)
-        Assert.assertEquals(1f, player.getPlaybackSpeed())
+        assertEquals(1f, player.getPlaybackSpeed())
     }
 
     private companion object {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
@@ -42,6 +42,7 @@ class MetricsCollectorTest {
         player = PillarboxExoPlayer()
         player.metricsCollector.addListener(metricsListener)
         player.prepare()
+        player.play()
 
         clearMocks(metricsListener)
     }
@@ -56,9 +57,8 @@ class MetricsCollectorTest {
     @Test
     fun `single item playback`() {
         player.setMediaItem(VOD1)
-        player.play()
-        TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
 
+        TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_ENDED)
 
         // Session is finished when starting another media or when there is no more current item
@@ -86,8 +86,8 @@ class MetricsCollectorTest {
     @Test
     fun `playback item transition`() {
         player.setMediaItems(listOf(VOD1, VOD2))
-        player.play()
 
+        TestPlayerRunHelper.playUntilStartOfMediaItem(player, 1)
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_ENDED)
 
         // To ensure that the final `onSessionFinished` is triggered.

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
@@ -49,9 +49,9 @@ class MetricsCollectorTest {
 
     @AfterTest
     fun tearDown() {
-        clearAllMocks()
         player.release()
         shadowOf(Looper.getMainLooper()).idle()
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
@@ -4,15 +4,13 @@
  */
 package ch.srgssr.pillarbox.player.analytics
 
-import android.content.Context
 import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
-import androidx.media3.test.utils.FakeClock
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import io.mockk.clearAllMocks
 import io.mockk.clearMocks
 import io.mockk.confirmVerified
@@ -32,23 +30,15 @@ import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class PlaybackSessionManagerTest {
-    private lateinit var clock: FakeClock
     private lateinit var player: ExoPlayer
     private lateinit var sessionManager: PlaybackSessionManager
     private lateinit var sessionManagerListener: PlaybackSessionManager.Listener
 
     @BeforeTest
     fun setUp() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-
-        clock = FakeClock(true)
         sessionManagerListener = mockk(relaxed = true)
-        player = ExoPlayer.Builder(context)
-            .setClock(clock)
-            .build()
-            .apply {
-                prepare()
-            }
+        player = PillarboxExoPlayer()
+        player.prepare()
 
         sessionManager = PlaybackSessionManager().apply {
             setPlayer(player)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
@@ -50,9 +50,9 @@ class PlaybackSessionManagerTest {
 
     @AfterTest
     fun tearDown() {
-        clearAllMocks()
         player.release()
         shadowOf(Looper.getMainLooper()).idle()
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/MonitoringTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/MonitoringTest.kt
@@ -48,9 +48,9 @@ class MonitoringTest {
 
     @AfterTest
     fun tearDown() {
-        clearAllMocks()
         player.release()
         shadowOf(Looper.getMainLooper()).idle()
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageDataTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageDataTest.kt
@@ -86,6 +86,6 @@ class ErrorMessageDataTest {
     private companion object {
         private val DURATION = 10.minutes.inWholeMilliseconds
         private val CURRENT_POSITION = 30.seconds.inWholeMilliseconds
-        private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/7510ee63-05a4-3d48-8d26-1f1b3a82f6be/master.m3u8"
+        private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8"
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/network/RequestSenderTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/network/RequestSenderTest.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.player.network
 
 import ch.srgssr.pillarbox.player.network.RequestSender.send
 import ch.srgssr.pillarbox.player.network.RequestSender.toJsonRequestBody
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.Serializable
@@ -36,6 +37,8 @@ class RequestSenderTest {
     @AfterTest
     fun tearDown() {
         buffer.close()
+
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapterTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/notification/PillarboxMediaDescriptionAdapterTest.kt
@@ -12,10 +12,12 @@ import androidx.media3.common.Player
 import androidx.media3.ui.PlayerNotificationManager.MediaDescriptionAdapter
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
+import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -33,6 +35,11 @@ class PillarboxMediaDescriptionAdapterTest {
         val context = ApplicationProvider.getApplicationContext<Context>()
         pendingIntent = mockk()
         mediaDescriptionAdapter = PillarboxMediaDescriptionAdapter(pendingIntent, context)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/session/PlayerSessionStateTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/session/PlayerSessionStateTest.kt
@@ -4,9 +4,7 @@
  */
 package ch.srgssr.pillarbox.player.session
 
-import android.content.Context
 import android.os.Bundle
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import org.junit.runner.RunWith
@@ -52,8 +50,7 @@ class PlayerSessionStateTest {
 
     @Test
     fun `to bundle`() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val player = PillarboxExoPlayer(context).apply {
+        val player = PillarboxExoPlayer().apply {
             smoothSeekingEnabled = false
             trackingEnabled = true
         }
@@ -68,8 +65,7 @@ class PlayerSessionStateTest {
 
     @Test
     fun `to bundle with extra data`() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val player = PillarboxExoPlayer(context).apply {
+        val player = PillarboxExoPlayer().apply {
             smoothSeekingEnabled = false
             trackingEnabled = true
         }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/MediaItemTrackerTest.kt
@@ -43,9 +43,9 @@ class MediaItemTrackerTest {
 
     @AfterTest
     fun releasePlayer() {
-        clearAllMocks()
         player.release()
         shadowOf(Looper.getMainLooper()).idle()
+        clearAllMocks()
     }
 
     @Test

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/PillarboxMediaMetaDataTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/PillarboxMediaMetaDataTrackerTest.kt
@@ -15,7 +15,7 @@ import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
 import ch.srgssr.pillarbox.player.extension.setChapters
 import io.mockk.clearAllMocks
-import io.mockk.spyk
+import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
 import org.junit.runner.RunWith
@@ -32,7 +32,7 @@ class PillarboxMediaMetaDataTrackerTest {
 
     @BeforeTest
     fun createPlayer() {
-        listener = spyk(object : PillarboxPlayer.Listener {})
+        listener = mockk(relaxed = true)
         player = PillarboxExoPlayer()
         player.addListener(listener)
         player.prepare()
@@ -112,18 +112,18 @@ class PillarboxMediaMetaDataTrackerTest {
         assertEquals(expectedChapters, receivedChapters)
     }
 
-    companion object {
+    private companion object {
         private const val URL = "https://rts-vod-amd.akamaized.net/ww/13317145/f1d49f18-f302-37ce-866c-1c1c9b76a824/master.m3u8"
-        const val ID_START_WITH_CHAPTER = "ID_START_WITH_CHAPTER"
-        const val ID_WITH_CHAPTER = "ID_WITH_CHAPTER"
-        const val NEAR_END_POSITION_MS = 15_000L // the video has 17 sec duration
+        private const val ID_START_WITH_CHAPTER = "ID_START_WITH_CHAPTER"
+        private const val ID_WITH_CHAPTER = "ID_WITH_CHAPTER"
+        private const val NEAR_END_POSITION_MS = 15_000L // the video has 17 sec duration
 
-        val CHAPTER_1 = Chapter(id = "Chapter1", 0, 5_000L, MediaMetadata.EMPTY)
-        val CHAPTER_2 = Chapter(id = "Chapter2", 5_000L, NEAR_END_POSITION_MS, MediaMetadata.EMPTY)
-        val CHAPTER_3 = Chapter(id = "Chapter3", 2_000L, 5_000L, MediaMetadata.EMPTY)
-        val CHAPTER_4 = Chapter(id = "Chapter4", 10_000L, NEAR_END_POSITION_MS, MediaMetadata.EMPTY)
+        private val CHAPTER_1 = Chapter(id = "Chapter1", 0, 5_000L, MediaMetadata.EMPTY)
+        private val CHAPTER_2 = Chapter(id = "Chapter2", 5_000L, NEAR_END_POSITION_MS, MediaMetadata.EMPTY)
+        private val CHAPTER_3 = Chapter(id = "Chapter3", 2_000L, 5_000L, MediaMetadata.EMPTY)
+        private val CHAPTER_4 = Chapter(id = "Chapter4", 10_000L, NEAR_END_POSITION_MS, MediaMetadata.EMPTY)
 
-        val MEDIA_ITEM = MediaItem.Builder()
+        private val MEDIA_ITEM = MediaItem.Builder()
             .setMediaId(ID_START_WITH_CHAPTER)
             .setUri(URL)
             .setMediaMetadata(
@@ -132,7 +132,7 @@ class PillarboxMediaMetaDataTrackerTest {
                     .build()
             )
             .build()
-        val MEDIA_ITEM_WITH_CHAPTER = MediaItem.Builder()
+        private val MEDIA_ITEM_WITH_CHAPTER = MediaItem.Builder()
             .setMediaId(ID_WITH_CHAPTER)
             .setUri(URL)
             .setMediaMetadata(
@@ -141,7 +141,7 @@ class PillarboxMediaMetaDataTrackerTest {
                     .build()
             )
             .build()
-        val NO_CHAPTER_MEDIA_ITEM = MediaItem.Builder()
+        private val NO_CHAPTER_MEDIA_ITEM = MediaItem.Builder()
             .setMediaId("NoChapter")
             .setUri(URL)
             .build()

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/utils/HeartbeatTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/utils/HeartbeatTest.kt
@@ -4,11 +4,9 @@
  */
 package ch.srgssr.pillarbox.player.utils
 
-import android.content.Context
 import android.os.Looper
-import androidx.media3.exoplayer.ExoPlayer
-import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -308,8 +306,7 @@ class HeartbeatTest {
 
     @Test
     fun `verify player is accessible from the task`() {
-        val context = ApplicationProvider.getApplicationContext<Context>()
-        val player = ExoPlayer.Builder(context).build()
+        val player = PillarboxExoPlayer()
         runTest(testDispatcher) {
             var taskCalled = false
 


### PR DESCRIPTION
# Pull request

## Description

This PR attempts to mitigate flakiness of some tests.

- For the `TimeoutException` mentioned in #830, I expect that they will be fixed with #831.
- For the `MockKException`, the issue probably comes from an other test than `CommandersActTrackerIntegrationTest`, because `CommandersActTrackerIntegrationTest` doesn't use a mocked player.
- For the `AssertionError`, I'll continue the investigation and try to submit a fix in a dedicated PR.

## Changes made

- Add some missing `clearAllMocks()` calls.
- Create a SRG `PillarboxExoPlayer` configured for tests.
- Continue migration from jUnit to Kotlin Test where possible.
- Make `TestPillarboxRunHelper.runUntilEvents()` support multiple events.
- Avoid sending networks requests:
  - Monitoring has been disabled in tests.
  - `RequestSenderTest` now uses a mocked `OkHttpClient` instead of using HttpBin.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).