### PR TITLE
Correctly forward MediaPeriod.Callback with PillarboxMediaPeriod.

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaPeriod.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/source/PillarboxMediaPeriod.kt
@@ -59,4 +59,19 @@ internal class PillarboxMediaPeriod(
     fun release(mediaSource: MediaSource) {
         mediaSource.releasePeriod(mediaPeriod)
     }
+
+    override fun prepare(callback: MediaPeriod.Callback, positionUs: Long) {
+        mediaPeriod.prepare(
+            object : MediaPeriod.Callback {
+                override fun onPrepared(mediaPeriod: MediaPeriod) {
+                    callback.onPrepared(this@PillarboxMediaPeriod)
+                }
+
+                override fun onContinueLoadingRequested(source: MediaPeriod) {
+                    callback.onContinueLoadingRequested(this@PillarboxMediaPeriod)
+                }
+            },
+            positionUs
+        )
+    }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxMediaPeriodTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxMediaPeriodTest.kt
@@ -19,7 +19,9 @@ import ch.srgssr.pillarbox.player.tracker.FakeMediaItemTracker
 import ch.srgssr.pillarbox.player.tracker.MediaItemTrackerData
 import ch.srgssr.pillarbox.player.tracker.MutableMediaItemTrackerData
 import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
 import io.mockk.mockk
+import io.mockk.verify
 import org.junit.runner.RunWith
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -95,6 +97,19 @@ class PillarboxMediaPeriodTest {
         val expectedTrackGroup = TrackGroupArray(TrackGroup(format), trackBlockedTimeRanges)
         mediaPeriod.prepare(mockk(relaxed = true), 0)
         assertEquals(expectedTrackGroup, mediaPeriod.trackGroups)
+    }
+
+    @Test
+    fun `test MediaPeriod Callback is forwarded`() {
+        val mediaPeriod = PillarboxMediaPeriod(mediaPeriod = mediaPeriod, emptyTrackerData, emptyList())
+        val callback = mockk<MediaPeriod.Callback>(relaxed = true)
+        mediaPeriod.prepare(callback, 0)
+
+        verify {
+            callback.onPrepared(mediaPeriod)
+        }
+
+        confirmVerified(callback)
     }
 
     private companion object {


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to improve `MediaPeriod.Callback` when using `PillarboxMediaPeriod`.

## Changes made

- Now MediaPeriod.Callback call it's callback with the right `MediaPeriod`type.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
