### PR TITLE
Add shuffle support to `CastPlayer`

### DIFF
--- a/pillarbox-cast/build.gradle.kts
+++ b/pillarbox-cast/build.gradle.kts
@@ -10,10 +10,12 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":pillarbox-player"))
+    api(project(":pillarbox-player"))
+    implementation(libs.androidx.annotation)
     implementation(platform(libs.androidx.compose.bom))
     api(libs.androidx.compose.runtime)
     api(libs.androidx.compose.ui)
     api(libs.androidx.media3.cast)
+    api(libs.androidx.media3.common)
     implementation(libs.guava)
 }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -13,6 +13,7 @@ import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
+import androidx.media3.common.Player.RepeatMode
 import androidx.media3.common.util.Clock
 import androidx.media3.common.util.ListenerSet
 import ch.srgssr.pillarbox.player.PillarboxPlayer
@@ -84,6 +85,14 @@ class PillarboxCastPlayer(
             override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {
                 notifyOnAvailableCommandsChange()
             }
+
+            override fun onRepeatModeChanged(@RepeatMode repeatMode: Int) {
+                setRepeatMode(repeatMode)
+            }
+
+            override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
+                setShuffleModeEnabled(shuffleModeEnabled)
+            }
         })
     }
 
@@ -136,6 +145,19 @@ class PillarboxCastPlayer(
         return availableCommands.contains(command)
     }
 
+    @RepeatMode
+    override fun getRepeatMode(): Int {
+        return if (shuffleModeEnabled) repeatModeWhileShuffled else castPlayer.repeatMode
+    }
+
+    override fun setRepeatMode(@RepeatMode repeatMode: Int) {
+        if (shuffleModeEnabled) {
+            repeatModeWhileShuffled = repeatMode
+        } else if (repeatMode != castPlayer.repeatMode) {
+            castPlayer.repeatMode = repeatMode
+        }
+    }
+
     override fun getShuffleModeEnabled(): Boolean {
         return shuffleModeEnabled
     }
@@ -153,7 +175,7 @@ class PillarboxCastPlayer(
                 remoteMediaClient?.queueShuffle(null)
                 repeatModeWhileShuffled = castPlayer.repeatMode
             } else {
-                remoteMediaClient?.queueSetRepeatMode(repeatModeWhileShuffled, null)
+                castPlayer.repeatMode = repeatModeWhileShuffled
                 repeatModeWhileShuffled = Player.REPEAT_MODE_OFF
             }
         }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -17,6 +17,7 @@ import androidx.media3.common.util.Clock
 import androidx.media3.common.util.ListenerSet
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import com.google.android.gms.cast.MediaQueueItem
+import com.google.android.gms.cast.MediaStatus
 import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.SessionManagerListener
@@ -122,11 +123,11 @@ class PillarboxCastPlayer(
     }
 
     override fun getAvailableCommands(): Player.Commands {
+        val isShuffleAvailable = remoteMediaClient?.mediaStatus?.isMediaCommandSupported(MediaStatus.COMMAND_QUEUE_SHUFFLE) == true
+
         return castPlayer.availableCommands
             .buildUpon()
-            .apply {
-                add(Player.COMMAND_SET_SHUFFLE_MODE)
-            }
+            .addIf(Player.COMMAND_SET_SHUFFLE_MODE, isShuffleAvailable)
             .build()
     }
 

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -4,7 +4,6 @@
  */
 package ch.srgssr.pillarbox.cast
 
-import android.os.Looper
 import androidx.media3.cast.CastPlayer
 import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.Player
@@ -29,7 +28,7 @@ class PillarboxCastPlayer(
     castContext: CastContext,
     private val castPlayer: CastPlayer = CastPlayer(castContext),
 ) : PillarboxPlayer, Player by castPlayer {
-    private val listeners = ListenerSet<Player.Listener>(Looper.getMainLooper(), Clock.DEFAULT) { listener, flags ->
+    private val listeners = ListenerSet<Player.Listener>(castPlayer.applicationLooper, Clock.DEFAULT) { listener, flags ->
         listener.onEvents(this, Player.Events(flags))
     }
     private val remoteClientCallback = RemoteClientCallback()
@@ -107,6 +106,10 @@ class PillarboxCastPlayer(
             .build()
     }
 
+    override fun isCommandAvailable(command: Int): Boolean {
+        return availableCommands.contains(command)
+    }
+
     private var shuffleModeEnabled = true
 
     override fun getShuffleModeEnabled(): Boolean {
@@ -143,34 +146,34 @@ class PillarboxCastPlayer(
     }
 
     private inner class SessionListener : SessionManagerListener<CastSession> {
-        override fun onSessionEnded(p0: CastSession, p1: Int) {
+        override fun onSessionEnded(session: CastSession, p1: Int) {
             remoteMediaClient = null
         }
 
-        override fun onSessionEnding(p0: CastSession) {
+        override fun onSessionEnding(session: CastSession) {
         }
 
-        override fun onSessionResumeFailed(p0: CastSession, p1: Int) {
+        override fun onSessionResumeFailed(session: CastSession, p1: Int) {
         }
 
-        override fun onSessionResumed(p0: CastSession, p1: Boolean) {
-            remoteMediaClient = p0.remoteMediaClient
+        override fun onSessionResumed(session: CastSession, p1: Boolean) {
+            remoteMediaClient = session.remoteMediaClient
         }
 
-        override fun onSessionResuming(p0: CastSession, p1: String) {
+        override fun onSessionResuming(session: CastSession, p1: String) {
         }
 
-        override fun onSessionStartFailed(p0: CastSession, p1: Int) {
+        override fun onSessionStartFailed(session: CastSession, p1: Int) {
         }
 
-        override fun onSessionStarted(p0: CastSession, p1: String) {
-            remoteMediaClient = p0.remoteMediaClient
+        override fun onSessionStarted(session: CastSession, p1: String) {
+            remoteMediaClient = session.remoteMediaClient
         }
 
-        override fun onSessionStarting(p0: CastSession) {
+        override fun onSessionStarting(session: CastSession) {
         }
 
-        override fun onSessionSuspended(p0: CastSession, p1: Int) {
+        override fun onSessionSuspended(session: CastSession, p1: Int) {
             remoteMediaClient = null
         }
     }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -4,12 +4,18 @@
  */
 package ch.srgssr.pillarbox.cast
 
+import android.os.Looper
 import androidx.media3.cast.CastPlayer
 import androidx.media3.cast.SessionAvailabilityListener
-import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.Player
+import androidx.media3.common.util.Clock
+import androidx.media3.common.util.ListenerSet
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import com.google.android.gms.cast.MediaQueueItem
 import com.google.android.gms.cast.framework.CastContext
+import com.google.android.gms.cast.framework.CastSession
+import com.google.android.gms.cast.framework.SessionManagerListener
+import com.google.android.gms.cast.framework.media.RemoteMediaClient
 
 /**
  * A [PillarboxPlayer] implementation that forwards calls to a [CastPlayer].
@@ -18,18 +24,43 @@ import com.google.android.gms.cast.framework.CastContext
  *
  * @param castPlayer The underlying [CastPlayer] instance to which method calls will be forwarded.
  */
-class PillarboxCastPlayer(private val castPlayer: CastPlayer) : PillarboxPlayer, ForwardingPlayer(castPlayer) {
-    override var smoothSeekingEnabled: Boolean = false
+// TODO Add all the arguments from the CastPlayer constructor
+class PillarboxCastPlayer(
+    castContext: CastContext,
+    private val castPlayer: CastPlayer = CastPlayer(castContext),
+) : PillarboxPlayer, Player by castPlayer {
+    private val listeners = ListenerSet<Player.Listener>(Looper.getMainLooper(), Clock.DEFAULT) { listener, flags ->
+        listener.onEvents(this, Player.Events(flags))
+    }
+    private val remoteClientCallback = RemoteClientCallback()
+    private val sessionManagerListener = SessionListener()
+
+    private var remoteMediaClient: RemoteMediaClient? = null
         set(value) {
-            field = false
+            if (field != value) {
+                field?.unregisterCallback(remoteClientCallback)
+                value?.registerCallback(remoteClientCallback)
+                field = value
+            }
         }
+
+    override var smoothSeekingEnabled: Boolean = false
+        set(value) {}
 
     override var trackingEnabled: Boolean = false
-        set(value) {
-            field = false
-        }
+        set(value) {}
 
-    constructor(context: CastContext) : this(CastPlayer(context))
+    init {
+        remoteMediaClient = castContext.sessionManager.currentCastSession?.remoteMediaClient
+
+        castContext.sessionManager.addSessionManagerListener(sessionManagerListener, CastSession::class.java)
+
+        castPlayer.addListener(object : Player.Listener {
+            override fun onAvailableCommandsChanged(availableCommands: Player.Commands) {
+                notifyOnAvailableCommandsChange()
+            }
+        })
+    }
 
     /**
      * Returns the item that corresponds to the period with the given id, or `null` if no media queue or period with id [periodId] exist.
@@ -55,5 +86,92 @@ class PillarboxCastPlayer(private val castPlayer: CastPlayer) : PillarboxPlayer,
      */
     fun setSessionAvailabilityListener(listener: SessionAvailabilityListener?) {
         castPlayer.setSessionAvailabilityListener(listener)
+    }
+
+    override fun addListener(listener: Player.Listener) {
+        castPlayer.addListener(listener)
+        listeners.add(listener)
+    }
+
+    override fun removeListener(listener: Player.Listener) {
+        castPlayer.removeListener(listener)
+        listeners.remove(listener)
+    }
+
+    override fun getAvailableCommands(): Player.Commands {
+        return castPlayer.availableCommands
+            .buildUpon()
+            .apply {
+                add(Player.COMMAND_SET_SHUFFLE_MODE)
+            }
+            .build()
+    }
+
+    private var shuffleModeEnabled = true
+
+    override fun getShuffleModeEnabled(): Boolean {
+        return shuffleModeEnabled
+    }
+
+    override fun setShuffleModeEnabled(shuffleModeEnabled: Boolean) {
+        this.shuffleModeEnabled = shuffleModeEnabled
+
+        listeners.queueEvent(Player.EVENT_SHUFFLE_MODE_ENABLED_CHANGED) {
+            it.onShuffleModeEnabledChanged(shuffleModeEnabled)
+        }
+        listeners.flushEvents()
+
+        // TODO Toggle the shuffle mode, keep the current repeat mode, listen to the PendingResult
+        // remoteMediaClient?.queueSetRepeatMode(MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE, null)
+    }
+
+    private fun notifyOnAvailableCommandsChange() {
+        listeners.queueEvent(Player.EVENT_AVAILABLE_COMMANDS_CHANGED) {
+            it.onAvailableCommandsChanged(availableCommands)
+        }
+        listeners.flushEvents()
+    }
+
+    private inner class RemoteClientCallback : RemoteMediaClient.Callback() {
+        override fun onStatusUpdated() {
+            notifyOnAvailableCommandsChange()
+        }
+
+        override fun onQueueStatusUpdated() {
+            notifyOnAvailableCommandsChange()
+        }
+    }
+
+    private inner class SessionListener : SessionManagerListener<CastSession> {
+        override fun onSessionEnded(p0: CastSession, p1: Int) {
+            remoteMediaClient = null
+        }
+
+        override fun onSessionEnding(p0: CastSession) {
+        }
+
+        override fun onSessionResumeFailed(p0: CastSession, p1: Int) {
+        }
+
+        override fun onSessionResumed(p0: CastSession, p1: Boolean) {
+            remoteMediaClient = p0.remoteMediaClient
+        }
+
+        override fun onSessionResuming(p0: CastSession, p1: String) {
+        }
+
+        override fun onSessionStartFailed(p0: CastSession, p1: Int) {
+        }
+
+        override fun onSessionStarted(p0: CastSession, p1: String) {
+            remoteMediaClient = p0.remoteMediaClient
+        }
+
+        override fun onSessionStarting(p0: CastSession) {
+        }
+
+        override fun onSessionSuspended(p0: CastSession, p1: Int) {
+            remoteMediaClient = null
+        }
     }
 }

--- a/pillarbox-demo-cast/build.gradle.kts
+++ b/pillarbox-demo-cast/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":pillarbox-demo-shared"))
     implementation(project(":pillarbox-cast"))
+    implementation(project(":pillarbox-demo-shared"))
     implementation(project(":pillarbox-ui"))
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
@@ -22,5 +22,8 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.ui.unit)
     implementation(libs.androidx.fragment)
+    implementation(libs.androidx.media3.cast)
+    implementation(libs.androidx.media3.common)
+    implementation(libs.androidx.media3.ui)
     implementation(libs.kotlin.stdlib)
 }

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : FragmentActivity() {
 
         setContent {
             val player = remember {
-                PillarboxCastPlayer(getCastContext()).apply {
+                PillarboxCastPlayer(getCastContext(), this).apply {
                     val mediaItem = MediaItem.Builder()
                         .setMimeType(MimeTypes.VIDEO_MP4)
                         .setUri("https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd")

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
@@ -43,7 +43,7 @@ class MainActivity : FragmentActivity() {
 
                     setSessionAvailabilityListener(object : SessionAvailabilityListener {
                         override fun onCastSessionAvailable() {
-                            setMediaItem(mediaItem)
+                            setMediaItems(listOf(mediaItem, mediaItem, mediaItem, mediaItem, mediaItem, mediaItem, mediaItem))
                         }
 
                         override fun onCastSessionUnavailable() {

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainActivity.kt
@@ -36,14 +36,21 @@ class MainActivity : FragmentActivity() {
         setContent {
             val player = remember {
                 PillarboxCastPlayer(getCastContext(), this).apply {
-                    val mediaItem = MediaItem.Builder()
-                        .setMimeType(MimeTypes.VIDEO_MP4)
-                        .setUri("https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd")
-                        .build()
+                    @Suppress("MaximumLineLength", "MaxLineLength")
+                    val mediaItems = listOf(
+                        "https://cdn.prod.swi-services.ch/video-projects/94f5f5d1-5d53-4336-afda-9198462c45d9/localised-videos/ENG/renditions/ENG.mp4",
+                        "https://bitmovin-a.akamaihd.net/content/MI201109210084_1/MI201109210084_mpeg-4_hd_high_1080p25_10mbits.mp4",
+                        "https://demo.unified-streaming.com/k8s/features/stable/video/tears-of-steel/tears-of-steel.mp4/.mpd",
+                    ).map {
+                        MediaItem.Builder()
+                            .setMimeType(MimeTypes.VIDEO_MP4)
+                            .setUri(it)
+                            .build()
+                    }
 
                     setSessionAvailabilityListener(object : SessionAvailabilityListener {
                         override fun onCastSessionAvailable() {
-                            setMediaItems(listOf(mediaItem, mediaItem, mediaItem, mediaItem, mediaItem, mediaItem, mediaItem))
+                            setMediaItems(mediaItems)
                         }
 
                         override fun onCastSessionUnavailable() {
@@ -65,6 +72,7 @@ class MainActivity : FragmentActivity() {
                         modifier = Modifier
                             .padding(innerPadding)
                             .fillMaxSize(),
+                        showShuffleButton = true,
                     )
                 }
             }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerView.kt
@@ -28,6 +28,8 @@ import androidx.media3.ui.PlayerView.ShowBuffering
  * @param controllerAutoShow Whether the controls should be shown automatically when the playback starts, pauses, ends or fails.
  * @param showNextButton Whether to display the "next" button in the controller.
  * @param showPreviousButton Whether to display the "previous" button in the controller.
+ * @param showShuffleButton Whether to display the "shuffle" button in the controller.
+ * @param showSubtitleButton Whether to display the "subtitles" button in the controller.
  * @param showBuffering Specifies when to display the buffering indicator.
  * @param resizeMode Specifies how the video content should be resized to fit the [PlayerView].
  * @param errorMessageProvider An optional [ErrorMessageProvider] to customize error messages displayed during playback failures.
@@ -40,6 +42,8 @@ import androidx.media3.ui.PlayerView.ShowBuffering
  * @see PlayerView.setControllerAutoShow
  * @see PlayerView.setShowNextButton
  * @see PlayerView.setShowPreviousButton
+ * @see PlayerView.setShowShuffleButton
+ * @see PlayerView.setShowSubtitleButton
  * @see PlayerView.setShowBuffering
  * @see PlayerView.setResizeMode
  * @see PlayerView.setErrorMessageProvider
@@ -56,6 +60,8 @@ fun ExoPlayerView(
     controllerAutoShow: Boolean = true,
     showNextButton: Boolean = true,
     showPreviousButton: Boolean = true,
+    showShuffleButton: Boolean = false,
+    showSubtitleButton: Boolean = false,
     showBuffering: @ShowBuffering Int = PlayerView.SHOW_BUFFERING_NEVER,
     resizeMode: @AspectRatioFrameLayout.ResizeMode Int = AspectRatioFrameLayout.RESIZE_MODE_FIT,
     errorMessageProvider: ErrorMessageProvider<PlaybackException>? = null,
@@ -71,8 +77,6 @@ fun ExoPlayerView(
             view.resizeMode = resizeMode
             view.setShowBuffering(showBuffering)
             view.setErrorMessageProvider(errorMessageProvider)
-            view.setShowShuffleButton(true)
-            view.setShowSubtitleButton(true)
             view.controllerAutoShow = controllerAutoShow
             view.useController = useController
             view.setFullscreenButtonClickListener(fullScreenListener)
@@ -83,6 +87,8 @@ fun ExoPlayerView(
             view.setControllerVisibilityListener(controllerVisibilityListener)
             view.setShowNextButton(showNextButton)
             view.setShowPreviousButton(showPreviousButton)
+            view.setShowShuffleButton(showShuffleButton)
+            view.setShowSubtitleButton(showSubtitleButton)
             view.setShutterBackgroundColor(shutterBackgroundColor)
             view.player = player
         },

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerView.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/exoplayer/ExoPlayerView.kt
@@ -71,6 +71,8 @@ fun ExoPlayerView(
             view.resizeMode = resizeMode
             view.setShowBuffering(showBuffering)
             view.setErrorMessageProvider(errorMessageProvider)
+            view.setShowShuffleButton(true)
+            view.setShowSubtitleButton(true)
             view.controllerAutoShow = controllerAutoShow
             view.useController = useController
             view.setFullscreenButtonClickListener(fullScreenListener)


### PR DESCRIPTION
# Pull request

## Description

This PR adds support for shuffle mode with a `CastPlayer`. This fixes #869.

## Changes made

- Update `PillarboxCastPlayer` to be able to customize the default internal `CastPlayer`.
- Make `PillarboxCastPlayer` override shuffle/repeat mode methods.
- Add `showShuffleButton` and `showSubtitleButton` arguments to `ExoPlayerView`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).