### PR TITLE
Don't force PillarboxExoPlayer instance in Services

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
@@ -8,6 +8,7 @@ import android.app.PendingIntent
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaSession
@@ -35,7 +36,9 @@ class DemoMediaLibraryService : PillarboxMediaLibraryService() {
     override fun onCreate() {
         super.onCreate()
         demoBrowser = DemoBrowser()
-        val player = PlayerModule.provideDefaultPlayer(this)
+        val player = PlayerModule.provideDefaultPlayer(this).apply {
+            setWakeMode(C.WAKE_MODE_NETWORK)
+        }
         setPlayer(player = player, callback = DemoCallback(), sessionId = "AndroidAutoSession")
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
@@ -9,7 +9,6 @@ import android.content.Intent
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSession.ControllerInfo
-import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.extension.setHandleAudioFocus
 import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
@@ -18,7 +17,7 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  * `PillarboxMediaLibraryService` implementation of [MediaLibraryService].
  * It is the recommended way to make background playback for Android and sharing content with Android Auto.
  *
- * It handles only one [MediaSession] with one [PillarboxExoPlayer].
+ * It handles only one [MediaSession] with one [PillarboxPlayer].
  *
  * Usage:
  * Add these permissions inside your manifest:

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
@@ -6,12 +6,11 @@ package ch.srgssr.pillarbox.player.session
 
 import android.app.PendingIntent
 import android.content.Intent
-import androidx.media3.common.C
-import androidx.media3.common.Player
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSession.ControllerInfo
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
+import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.extension.setHandleAudioFocus
 import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
 
@@ -57,7 +56,6 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  * ```
  */
 abstract class PillarboxMediaLibraryService : MediaLibraryService() {
-    private var player: Player? = null
     private var mediaSession: PillarboxMediaLibrarySession? = null
 
     /**
@@ -67,18 +65,16 @@ abstract class PillarboxMediaLibraryService : MediaLibraryService() {
 
     /**
      * Set player to use with this Service.
-     * @param player [PillarboxExoPlayer] to link to this service.
+     * @param player [PillarboxPlayer] to link to this service.
      * @param callback The [PillarboxMediaLibrarySession.Callback]
      * @param sessionId The ID. Must be unique among all sessions per package.
      */
     fun setPlayer(
-        player: PillarboxExoPlayer,
+        player: PillarboxPlayer,
         callback: PillarboxMediaLibrarySession.Callback,
         sessionId: String? = null,
     ) {
-        if (this.player == null) {
-            this.player = player
-            player.setWakeMode(C.WAKE_MODE_NETWORK)
+        if (this.mediaSession == null) {
             player.setHandleAudioFocus(true)
             mediaSession = PillarboxMediaLibrarySession.Builder(this, player, callback).apply {
                 sessionActivity()?.let {
@@ -88,6 +84,8 @@ abstract class PillarboxMediaLibraryService : MediaLibraryService() {
                     setId(it)
                 }
             }.build()
+        } else {
+            mediaSession?.player = player
         }
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
@@ -6,11 +6,10 @@ package ch.srgssr.pillarbox.player.session
 
 import android.app.PendingIntent
 import android.content.Intent
-import androidx.media3.common.C
-import androidx.media3.common.Player
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
+import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.extension.setHandleAudioFocus
 import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
 
@@ -53,7 +52,6 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  */
 @Suppress("MemberVisibilityCanBePrivate")
 abstract class PillarboxMediaSessionService : MediaSessionService() {
-    private var player: Player? = null
     private var mediaSession: PillarboxMediaSession? = null
 
     /**
@@ -63,18 +61,16 @@ abstract class PillarboxMediaSessionService : MediaSessionService() {
 
     /**
      * Set player to use with this Service.
-     * @param player [PillarboxExoPlayer] to link to this service.
+     * @param player [PillarboxPlayer] to link to this service.
      * @param mediaSessionCallback The [PillarboxMediaSession.Callback]
      * @param sessionId The ID. Must be unique among all sessions per package.
      */
     fun setPlayer(
-        player: PillarboxExoPlayer,
+        player: PillarboxPlayer,
         mediaSessionCallback: PillarboxMediaSession.Callback = PillarboxMediaSession.Callback.Default,
         sessionId: String? = null,
     ) {
-        if (this.player == null) {
-            this.player = player
-            player.setWakeMode(C.WAKE_MODE_NETWORK)
+        if (this.mediaSession == null) {
             player.setHandleAudioFocus(true)
             mediaSession = PillarboxMediaSession.Builder(this, player).apply {
                 sessionActivity()?.let {
@@ -85,6 +81,8 @@ abstract class PillarboxMediaSessionService : MediaSessionService() {
                     setId(it)
                 }
             }.build()
+        } else {
+            mediaSession?.player = player
         }
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
@@ -8,7 +8,6 @@ import android.app.PendingIntent
 import android.content.Intent
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
-import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.extension.setHandleAudioFocus
 import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
@@ -17,7 +16,7 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  * `PillarboxMediaSessionService` implementation of [MediaSessionService].
  * It is the recommended way to make background playback for Android.
  *
- * It handles only one [MediaSession] with one [PillarboxExoPlayer].
+ * It handles only one [MediaSession] with one [PillarboxPlayer].
  *
  * Usage:
  * Add these permissions inside your manifest:

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
@@ -173,9 +173,10 @@ class PlayerCallbackFlowTest {
         TestPillarboxRunHelper.runUntilEvents(player, Player.EVENT_TIMELINE_CHANGED, Player.EVENT_PLAYBACK_STATE_CHANGED)
 
         player.getCurrentDefaultPositionAsFlow().test {
+            val duration = player.duration.milliseconds.inWholeHours
             val currentDefaultPositionInHours = awaitItem().milliseconds.inWholeHours
 
-            assertTrue(currentDefaultPositionInHours in 5..6)
+            assertTrue(currentDefaultPositionInHours in duration - 1..duration + 1)
             ensureAllEventsConsumed()
         }
     }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to allow any instance of `PillarboxPlayer` to be set in `PillarboxMediaSessionService` and `PillarboxMediaLiabraryService` like it is already done for sessions.

## Changes made

- `PillarboxMediaSessionService.setPlayer` takes a `PillarboxPlayer` instead of a `PillarboxExoPlayer`.
- `PillarboxMediaLiabraryService.setPlayer` takes a `PillarboxPlayer` instead of a `PillarboxExoPlayer`.
- Given player doesn't call anymore `setWakeMode(C.WAKE_MODE_NETWORK)`. This have to be done by the user.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
