### PR TITLE
891 add dsl for pillarboxcastplayer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -99,6 +99,9 @@ implementation("ch.srgssr.pillarbox:pillarbox-cast:<pillarbox_version>")
 // Library to handle SRG SSR content through media URNs
 implementation("ch.srgssr.pillarbox:pillarbox-core-business:<pillarbox_version>")
 
+// Library to handle SRG SSR Cast receiver with SRG SSR content.
+implementation("ch.srgssr.pillarbox:pillarbox-core-business-cast:<pillarbox_version>")
+
 // Library to display the video surface
 implementation("ch.srgssr.pillarbox:pillarbox-ui:<pillarbox_version>") 
 ```
@@ -126,6 +129,7 @@ To start using Pillarbox in your project, you can check each module's documentat
 - [`pillarbox-analytics`](https://github.com/SRGSSR/pillarbox-android/blob/main/pillarbox-analytics/docs/README.md)
 - [`pillarbox-cast`](https://github.com/SRGSSR/pillarbox-android/blob/main/pillarbox-cast/docs/README.md)
 - [`pillarbox-core-business`](https://github.com/SRGSSR/pillarbox-android/blob/main/pillarbox-core-business/docs/README.md)
+- [`pillarbox-core-business-cast`](https://github.com/SRGSSR/pillarbox-android/blob/main/pillarbox-core-business-cast/docs/README.md)
 - [`pillarbox-player`](https://github.com/SRGSSR/pillarbox-android/blob/main/pillarbox-player/docs/README.md)
 - [`pillarbox-ui`](https://github.com/SRGSSR/pillarbox-android/blob/main/pillarbox-ui/docs/README.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -99,7 +99,7 @@ implementation("ch.srgssr.pillarbox:pillarbox-cast:<pillarbox_version>")
 // Library to handle SRG SSR content through media URNs
 implementation("ch.srgssr.pillarbox:pillarbox-core-business:<pillarbox_version>")
 
-// Library to handle SRG SSR Cast receiver with SRG SSR content.
+// Library to handle SRG SSR Cast receiver with SRG SSR content
 implementation("ch.srgssr.pillarbox:pillarbox-core-business-cast:<pillarbox_version>")
 
 // Library to display the video surface

--- a/pillarbox-cast/docs/README.md
+++ b/pillarbox-cast/docs/README.md
@@ -16,17 +16,10 @@ implementations are based on the [PillarboxPlayer][ch.srgssr.pillarbox.player.Pi
 
 ## Getting started
 
-### Get the `CastContext` instance
-
-```kotlin
-val castContext = context.getCastContext()
-```
-
 ### Create the player
 
 ```kotlin
-val castContext = context.getCastContext()
-val player = PillarboxCastPlayer(castContext = castContext)
+val player = PillarboxCastPlayer(context, Default)
 player.setSessionAvailabilityListener(object : SessionAvailabilityListener {
     override fun onCastSessionAvailable() {
         // The cast session is connected.
@@ -42,6 +35,30 @@ player.setSessionAvailabilityListener(object : SessionAvailabilityListener {
 })
 // When the player is not needed anymore.
 player.release()
+```
+`SessionAvailabilityListener` can also be created this way
+
+```kotlin
+val player = PillarboxCastPlayer(context, Default) {
+    onCastSessionAvailable {
+        // The cast session is connected.
+        setMediaItems(mediaItems)
+        play()
+        prepare()
+    }
+
+    onCastSessionUnavailable {
+        // The cast session has been disconnected.
+    }
+}
+```
+
+### Configure [MediaItemConverter][androidx.media3.cast.MediaItemConverter]
+
+```kotlin
+val player = PillarboxCastPlayer(context, Default) {
+    mediaItemConverter(DefaultMediaItemConverter()) // By default
+}
 ```
 
 ### Display a Cast button
@@ -60,10 +77,10 @@ When switching to remote playback, the local playback has to be stop manually an
 remote player.
 
 ```kotlin
-val localPlayer = PillarboxExoPlayer(context)
-val castContext = context.getCastContext()
-val remotePlayer = PillarboxCastPlayer(castContext = castContext)
+val localPlayer = PillarboxExoPlayer(context, Default)
+val remotePlayer = PillarboxCastPlayer(context, Default)
 var currentPlayer: PillarboxPlayer = if (remotePlayer.isCastSessionAvailable()) remotePlayer else localPlayer
+
 player.setSessionAvailabilityListener(object : SessionAvailabilityListener {
     override fun onCastSessionAvailable() {
         setCurrentPlayer(remotePlayer)
@@ -73,6 +90,8 @@ player.setSessionAvailabilityListener(object : SessionAvailabilityListener {
         setCurrentPlayer(localPlayer)
     }
 })
+
+PlayerView(currentPlayer)
 ```
 
 ## Additional resources
@@ -83,3 +102,4 @@ player.setSessionAvailabilityListener(object : SessionAvailabilityListener {
 [ch.srgssr.pillarbox.player.PillarboxExoPlayer]: https://android.pillarbox.ch/api/pillarbox-player/ch.srgssr.pillarbox.player/-pillarbox-exo-player.html
 [ch.srgssr.pillarbox.cast.PillarboxCastPlayer]: https://android.pillarbox.ch/api/ch.srgssr.pillarbox.cast/-pillarbox-cast-player/index.html
 [androidx.media3.cast.CastPlayer]: https://developer.android.com/reference/androidx/media3/cast/CastPlayer
+[androidx.media3.cast.MediaItemConverter]: https://developer.android.com/reference/androidx/media3/cast/MediaItemConverter

--- a/pillarbox-cast/docs/README.md
+++ b/pillarbox-cast/docs/README.md
@@ -36,7 +36,8 @@ player.setSessionAvailabilityListener(object : SessionAvailabilityListener {
 // When the player is not needed anymore.
 player.release()
 ```
-`SessionAvailabilityListener` can also be created this way
+
+The `SessionAvailabilityListener` can also be created this way:
 
 ```kotlin
 val player = PillarboxCastPlayer(context, Default) {

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/DefaultCastTrackSelector.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/DefaultCastTrackSelector.kt
@@ -12,7 +12,7 @@ import androidx.media3.common.Tracks
  * Default cast track selector
  * Support only [TrackSelectionOverride] from [TrackSelectionParameters.overrides].
  */
-class DefaultCastTrackSelector : CastTrackSelector {
+object DefaultCastTrackSelector : CastTrackSelector {
 
     override fun getActiveMediaTracks(
         parameters: TrackSelectionParameters,

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -8,7 +8,6 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.annotation.IntRange
 import androidx.media3.cast.CastPlayer
-import androidx.media3.cast.DefaultMediaItemConverter
 import androidx.media3.cast.MediaItemConverter
 import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.C
@@ -74,10 +73,11 @@ fun <Builder : PillarboxCastPlayerBuilder> PillarboxCastPlayer(
  * @param trackSelector The [CastTrackSelector] to use when selecting tracks from [TrackSelectionParameters].
  * @param castPlayer The underlying [CastPlayer] instance to which method calls will be forwarded.
  */
+@Suppress("LongParameterList")
 class PillarboxCastPlayer internal constructor(
     private val castContext: CastContext,
-    context: Context? = null,
-    mediaItemConverter: MediaItemConverter = DefaultMediaItemConverter(),
+    context: Context?,
+    mediaItemConverter: MediaItemConverter,
     @IntRange(from = 1) seekBackIncrementMs: Long,
     @IntRange(from = 1) seekForwardIncrementMs: Long,
     @IntRange(from = 0) maxSeekToPreviousPositionMs: Long,

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -32,6 +32,23 @@ import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.SessionManagerListener
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
 
+/**
+ * Create a new instance of [PillarboxCastPlayer].
+ *
+ * **Usage**
+ * ```kotlin
+ * val player = PillarboxCastPlayer(context, Default) {
+ *      mediaItemConverter(MyMediaItemConverter())
+ * }
+ * ```
+ *
+ * @param Builder The type of the [PillarboxCastPlayerBuilder].
+ * @param context The [Context].
+ * @param type The [CastPlayerConfig].
+ * @param builder The builder.
+ *
+ * @return A new instance of [PillarboxCastPlayer].
+ */
 @PillarboxDsl
 fun <Builder : PillarboxCastPlayerBuilder> PillarboxCastPlayer(
     context: Context,
@@ -54,8 +71,8 @@ fun <Builder : PillarboxCastPlayerBuilder> PillarboxCastPlayer(
  * @param seekBackIncrementMs The [seekBack] increment, in milliseconds.
  * @param seekForwardIncrementMs The [seekForward] increment, in milliseconds.
  * @param maxSeekToPreviousPositionMs The maximum position for which [seekToPrevious] seeks to the previous [MediaItem], in milliseconds.
- * @param castPlayer The underlying [CastPlayer] instance to which method calls will be forwarded.
  * @param trackSelector The [CastTrackSelector] to use when selecting tracks from [TrackSelectionParameters].
+ * @param castPlayer The underlying [CastPlayer] instance to which method calls will be forwarded.
  */
 class PillarboxCastPlayer internal constructor(
     private val castContext: CastContext,

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.cast
+
+import android.content.Context
+import androidx.annotation.IntRange
+import androidx.media3.cast.DefaultMediaItemConverter
+import androidx.media3.cast.MediaItemConverter
+import androidx.media3.cast.SessionAvailabilityListener
+import androidx.media3.common.C
+import ch.srgssr.pillarbox.player.PillarboxBuilder
+import ch.srgssr.pillarbox.player.PillarboxDsl
+
+@PillarboxDsl
+abstract class PillarboxCastPlayerBuilder {
+    private var mediaItemConverter: MediaItemConverter = DefaultMediaItemConverter()
+    private var seekBackIncrementMs: Long = C.DEFAULT_SEEK_BACK_INCREMENT_MS
+    private var seekForwardIncrementMs: Long = C.DEFAULT_SEEK_FORWARD_INCREMENT_MS
+    private var maxSeekToPreviousPositionMs: Long = C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS
+    private var trackSelector: CastTrackSelector = DefaultCastTrackSelector
+    private var onCastSessionAvailable: (PillarboxCastPlayer.() -> Unit)? = null
+    private var onCastSessionUnAvailable: (PillarboxCastPlayer.() -> Unit)? = null
+
+    fun seekBackIncrementMs(@IntRange(from = 1) seekBackIncrementMs: Long) {
+        this.seekBackIncrementMs = seekBackIncrementMs
+    }
+
+    fun seekForwardIncrementMs(@IntRange(from = 1) seekForwardIncrementMs: Long) {
+        this.seekForwardIncrementMs = seekBackIncrementMs
+    }
+
+    fun maxSeekToPreviousPositionMs(@IntRange(from = 0) maxSeekToPreviousPositionMs: Long) {
+        this.maxSeekToPreviousPositionMs = maxSeekToPreviousPositionMs
+    }
+
+    fun trackSelector(trackSelector: CastTrackSelector) {
+        this.trackSelector = trackSelector
+    }
+
+    fun onCastSessionAvailable(onCastSessionAvailable: PillarboxCastPlayer.() -> Unit) {
+        this.onCastSessionAvailable = onCastSessionAvailable
+    }
+
+    fun onCastSessionUnavailable(onCastSessionUnAvailable: PillarboxCastPlayer.() -> Unit) {
+        this.onCastSessionAvailable = onCastSessionUnAvailable
+    }
+
+    internal fun create(context: Context): PillarboxCastPlayer {
+        return PillarboxCastPlayer(
+            context.getCastContext(),
+            context,
+            mediaItemConverter,
+            seekBackIncrementMs,
+            seekForwardIncrementMs,
+            maxSeekToPreviousPositionMs,
+            trackSelector,
+        ).apply {
+            setSessionAvailabilityListener(object : SessionAvailabilityListener {
+                override fun onCastSessionAvailable() {
+                    onCastSessionAvailable?.invoke(this@apply)
+                }
+
+                override fun onCastSessionUnavailable() {
+                    onCastSessionUnAvailable?.invoke(this@apply)
+                }
+            })
+        }
+    }
+}
+
+/**
+ * Defines a factory for creating instances of [PillarboxBuilder].
+ *
+ * @param Builder The type of [PillarboxBuilder] that this factory creates.
+ */
+interface CastPlayerConfig<Builder : PillarboxCastPlayerBuilder> {
+    /**
+     * Creates a new instance of the [Builder] class.
+     *
+     * @return A new instance of the [Builder].
+     */
+    fun create(): Builder
+}
+
+/**
+ * Default configuration for creating a [PillarboxCastPlayer].
+ */
+object Default : CastPlayerConfig<Default.Builder> {
+    override fun create(): Builder {
+        return Builder
+    }
+
+    /**
+     * A builder class for creating and configuring a [PillarboxCastPlayer].
+     */
+    object Builder : PillarboxCastPlayerBuilder()
+}

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -17,7 +17,7 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * A builder class for creating instances of [PillarboxCastPlayer].
  *
- * This builder provides a fluent API for configuring various aspects of the player, seek increments, item converters, ...
+ * This builder provides a fluent API for configuring various aspects of the player, such as seek increments, item converters, ...
  */
 @PillarboxDsl
 abstract class PillarboxCastPlayerBuilder {
@@ -65,8 +65,7 @@ abstract class PillarboxCastPlayerBuilder {
     /**
      * On cast session available
      *
-     * @param onCastSessionAvailable The method to call when [SessionAvailabilityListener.onCastSessionAvailable].
-     * @receiver
+     * @param onCastSessionAvailable The method to invoke when [SessionAvailabilityListener.onCastSessionAvailable] is called.
      */
     fun onCastSessionAvailable(onCastSessionAvailable: PillarboxCastPlayer.() -> Unit) {
         this.onCastSessionAvailable = onCastSessionAvailable
@@ -75,8 +74,7 @@ abstract class PillarboxCastPlayerBuilder {
     /**
      * On cast session unavailable
      *
-     * @param onCastSessionUnavailable The method to call when [SessionAvailabilityListener.onCastSessionUnavailable]
-     * @receiver
+     * @param onCastSessionUnavailable The method to invoke when [SessionAvailabilityListener.onCastSessionUnavailable] is called.
      */
     fun onCastSessionUnavailable(onCastSessionUnavailable: PillarboxCastPlayer.() -> Unit) {
         this.onCastSessionUnavailable = onCastSessionUnavailable
@@ -85,7 +83,7 @@ abstract class PillarboxCastPlayerBuilder {
     /**
      * Media item converter
      *
-     * @param mediaItemConverter the [MediaItemConverter] to use.
+     * @param mediaItemConverter The [MediaItemConverter] to use.
      */
     fun mediaItemConverter(mediaItemConverter: MediaItemConverter) {
         this.mediaItemConverter = mediaItemConverter

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -47,6 +47,10 @@ abstract class PillarboxCastPlayerBuilder {
         this.onCastSessionAvailable = onCastSessionUnAvailable
     }
 
+    fun mediaItemConverter(mediaItemConverter: MediaItemConverter) {
+        this.mediaItemConverter = mediaItemConverter
+    }
+
     internal fun create(context: Context): PillarboxCastPlayer {
         return PillarboxCastPlayer(
             context.getCastContext(),

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -5,48 +5,88 @@
 package ch.srgssr.pillarbox.cast
 
 import android.content.Context
-import androidx.annotation.IntRange
 import androidx.media3.cast.DefaultMediaItemConverter
 import androidx.media3.cast.MediaItemConverter
 import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.C
-import ch.srgssr.pillarbox.player.PillarboxBuilder
+import androidx.media3.common.MediaItem
 import ch.srgssr.pillarbox.player.PillarboxDsl
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
+/**
+ * A builder class for creating instances of [PillarboxCastPlayer].
+ *
+ * This builder provides a fluent API for configuring various aspects of the player, seek increments, item converters, ...
+ */
 @PillarboxDsl
 abstract class PillarboxCastPlayerBuilder {
     private var mediaItemConverter: MediaItemConverter = DefaultMediaItemConverter()
-    private var seekBackIncrementMs: Long = C.DEFAULT_SEEK_BACK_INCREMENT_MS
-    private var seekForwardIncrementMs: Long = C.DEFAULT_SEEK_FORWARD_INCREMENT_MS
-    private var maxSeekToPreviousPositionMs: Long = C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS
+    private var seekBackIncrement: Duration = C.DEFAULT_SEEK_BACK_INCREMENT_MS.milliseconds
+    private var seekForwardIncrement: Duration = C.DEFAULT_SEEK_FORWARD_INCREMENT_MS.milliseconds
+    private var maxSeekToPreviousPosition: Duration = C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS.milliseconds
     private var trackSelector: CastTrackSelector = DefaultCastTrackSelector
     private var onCastSessionAvailable: (PillarboxCastPlayer.() -> Unit)? = null
     private var onCastSessionUnAvailable: (PillarboxCastPlayer.() -> Unit)? = null
 
-    fun seekBackIncrementMs(@IntRange(from = 1) seekBackIncrementMs: Long) {
-        this.seekBackIncrementMs = seekBackIncrementMs
+    /**
+     * @param seekBackIncrement The [PillarboxCastPlayer.seekBack] increment.
+     */
+    fun seekBackIncrement(seekBackIncrement: Duration) {
+        check(seekBackIncrement > Duration.ZERO)
+        this.seekBackIncrement = seekBackIncrement
     }
 
-    fun seekForwardIncrementMs(@IntRange(from = 1) seekForwardIncrementMs: Long) {
-        this.seekForwardIncrementMs = seekBackIncrementMs
+    /**
+     * @param seekForwardIncrement The [PillarboxCastPlayer.seekForward] increment.
+     */
+    fun seekForwardIncrement(seekForwardIncrement: Duration) {
+        check(seekForwardIncrement > Duration.ZERO)
+        this.seekForwardIncrement = seekForwardIncrement
     }
 
-    fun maxSeekToPreviousPositionMs(@IntRange(from = 0) maxSeekToPreviousPositionMs: Long) {
-        this.maxSeekToPreviousPositionMs = maxSeekToPreviousPositionMs
+    /**
+     * @param maxSeekToPreviousPosition The maximum position for which [PillarboxCastPlayer.seekToPrevious] seeks to the previous [MediaItem].
+     */
+    fun maxSeekToPreviousPosition(maxSeekToPreviousPosition: Duration) {
+        check(maxSeekToPreviousPosition >= Duration.ZERO)
+        this.maxSeekToPreviousPosition = maxSeekToPreviousPosition
     }
 
+    /**
+     * Track selector
+     *
+     * @param trackSelector The [CastTrackSelector] to use.
+     */
     fun trackSelector(trackSelector: CastTrackSelector) {
         this.trackSelector = trackSelector
     }
 
+    /**
+     * On cast session available
+     *
+     * @param onCastSessionAvailable The method to call when [SessionAvailabilityListener.onCastSessionAvailable].
+     * @receiver
+     */
     fun onCastSessionAvailable(onCastSessionAvailable: PillarboxCastPlayer.() -> Unit) {
         this.onCastSessionAvailable = onCastSessionAvailable
     }
 
+    /**
+     * On cast session unavailable
+     *
+     * @param onCastSessionUnAvailable The method to call when [SessionAvailabilityListener.onCastSessionUnavailable]
+     * @receiver
+     */
     fun onCastSessionUnavailable(onCastSessionUnAvailable: PillarboxCastPlayer.() -> Unit) {
         this.onCastSessionAvailable = onCastSessionUnAvailable
     }
 
+    /**
+     * Media item converter
+     *
+     * @param mediaItemConverter the [MediaItemConverter] to use.
+     */
     fun mediaItemConverter(mediaItemConverter: MediaItemConverter) {
         this.mediaItemConverter = mediaItemConverter
     }
@@ -56,9 +96,9 @@ abstract class PillarboxCastPlayerBuilder {
             context.getCastContext(),
             context,
             mediaItemConverter,
-            seekBackIncrementMs,
-            seekForwardIncrementMs,
-            maxSeekToPreviousPositionMs,
+            seekBackIncrement.inWholeMilliseconds,
+            seekForwardIncrement.inWholeMilliseconds,
+            maxSeekToPreviousPosition.inWholeMilliseconds,
             trackSelector,
         ).apply {
             setSessionAvailabilityListener(object : SessionAvailabilityListener {
@@ -75,9 +115,9 @@ abstract class PillarboxCastPlayerBuilder {
 }
 
 /**
- * Defines a factory for creating instances of [PillarboxBuilder].
+ * Defines a factory for creating instances of [PillarboxCastPlayerBuilder].
  *
- * @param Builder The type of [PillarboxBuilder] that this factory creates.
+ * @param Builder The type of [PillarboxCastPlayerBuilder] that this factory creates.
  */
 interface CastPlayerConfig<Builder : PillarboxCastPlayerBuilder> {
     /**

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -101,6 +101,7 @@ abstract class PillarboxCastPlayerBuilder {
             maxSeekToPreviousPosition.inWholeMilliseconds,
             trackSelector,
         ).apply {
+            if (onCastSessionAvailable == null && onCastSessionAvailable == null) return@apply
             setSessionAvailabilityListener(object : SessionAvailabilityListener {
                 override fun onCastSessionAvailable() {
                     onCastSessionAvailable?.invoke(this@apply)

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -27,7 +27,7 @@ abstract class PillarboxCastPlayerBuilder {
     private var maxSeekToPreviousPosition: Duration = C.DEFAULT_MAX_SEEK_TO_PREVIOUS_POSITION_MS.milliseconds
     private var trackSelector: CastTrackSelector = DefaultCastTrackSelector
     private var onCastSessionAvailable: (PillarboxCastPlayer.() -> Unit)? = null
-    private var onCastSessionUnAvailable: (PillarboxCastPlayer.() -> Unit)? = null
+    private var onCastSessionUnavailable: (PillarboxCastPlayer.() -> Unit)? = null
 
     /**
      * @param seekBackIncrement The [PillarboxCastPlayer.seekBack] increment.
@@ -75,11 +75,11 @@ abstract class PillarboxCastPlayerBuilder {
     /**
      * On cast session unavailable
      *
-     * @param onCastSessionUnAvailable The method to call when [SessionAvailabilityListener.onCastSessionUnavailable]
+     * @param onCastSessionUnavailable The method to call when [SessionAvailabilityListener.onCastSessionUnavailable]
      * @receiver
      */
-    fun onCastSessionUnavailable(onCastSessionUnAvailable: PillarboxCastPlayer.() -> Unit) {
-        this.onCastSessionAvailable = onCastSessionUnAvailable
+    fun onCastSessionUnavailable(onCastSessionUnavailable: PillarboxCastPlayer.() -> Unit) {
+        this.onCastSessionUnavailable = onCastSessionUnavailable
     }
 
     /**
@@ -101,14 +101,14 @@ abstract class PillarboxCastPlayerBuilder {
             maxSeekToPreviousPosition.inWholeMilliseconds,
             trackSelector,
         ).apply {
-            if (onCastSessionAvailable == null && onCastSessionAvailable == null) return@apply
+            if (onCastSessionAvailable == null && onCastSessionUnavailable == null) return@apply
             setSessionAvailabilityListener(object : SessionAvailabilityListener {
                 override fun onCastSessionAvailable() {
                     onCastSessionAvailable?.invoke(this@apply)
                 }
 
                 override fun onCastSessionUnavailable() {
-                    onCastSessionUnAvailable?.invoke(this@apply)
+                    onCastSessionUnavailable?.invoke(this@apply)
                 }
             })
         }

--- a/pillarbox-core-business-cast/docs/README.md
+++ b/pillarbox-core-business-cast/docs/README.md
@@ -15,7 +15,7 @@ The main goal of this module is to be able to connect to a SRG SSR receiver with
 ## Getting started
 
 ```kotlin
-val player = PillarboxCastPlayer(context) // ch.srgssr.pillarbox.core.business.cast.PillarboxCastPlayer
+val player = PillarboxCastPlayer(context)
 ```
 
 [ch.srgssr.pillarbox.cast.PillarboxCastPlayer]: https://android.pillarbox.ch/api/pillarbox-cast/ch.srgssr.pillarbox.cast/-pillarbox-cast-player/index.html

--- a/pillarbox-core-business-cast/docs/README.md
+++ b/pillarbox-core-business-cast/docs/README.md
@@ -15,8 +15,7 @@ The main goal of this module is to be able to connect to a SRG SSR receiver with
 ## Getting started
 
 ```kotlin
-val castContext = context.getCastContext()
-val player = PillarboxCastPlayer(castContext = castContext, mediaItemConverter = SRGMediaItemConverter())
+val player = PillarboxCastPlayer(context) // ch.srgssr.pillarbox.core.business.cast.PillarboxCastPlayer
 ```
 
 [ch.srgssr.pillarbox.cast.PillarboxCastPlayer]: https://android.pillarbox.ch/api/pillarbox-cast/ch.srgssr.pillarbox.cast/-pillarbox-cast-player/index.html

--- a/pillarbox-core-business-cast/src/main/java/ch/srgssr/pillarbox/core/business/cast/PillarboxSRG.kt
+++ b/pillarbox-core-business-cast/src/main/java/ch/srgssr/pillarbox/core/business/cast/PillarboxSRG.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.core.business.cast
+
+import android.content.Context
+import ch.srgssr.pillarbox.cast.CastPlayerConfig
+import ch.srgssr.pillarbox.cast.PillarboxCastPlayer
+import ch.srgssr.pillarbox.cast.PillarboxCastPlayerBuilder
+import ch.srgssr.pillarbox.player.PillarboxDsl
+
+/**
+ * Creates a [PillarboxCastPlayer] instance configured for the SRG SSR.
+ *
+ * **Basic usage**
+ *
+ * ```kotlin
+ * val srgCastPlayer = PillarboxCastPlayer(context)
+ * ```
+ *
+ * This creates a player with the default SRG SSR configuration:
+ * - SRG cast MediaItemConverter: integrates an [SRGMediaItemConverter] for handling SRG-specific media item to cast item. If not explicitly
+ * configured, a default instance is created.
+ *
+ * **Custom configuration**
+ *
+ * ```kotlin
+ * val customSrgCastPlayer = PillarboxCastPlayer(context) {
+ *     mediaItemConverter(SRGMediaItemConverter())
+ *     onCastSessionAvailable(context) {
+ *          setMediaItems(listItems)
+ *          play()
+ *     }
+ *     onCastSessionUnavailable {
+ *          goBackToLocalPlayerBack()
+ *     }
+ * }
+ * ```
+ *
+ * The same can be achieved by using [PillarboxCastPlayer.setSessionAvailabilityListener].
+ *
+ * @param context The [Context] of the application.
+ * @param builder An optional lambda with a receiver of type [SRG.Builder] allowing customization of the player's configuration.
+ *
+ * @return A configured [PillarboxCastPlayer] instance ready for playback.
+ */
+@PillarboxDsl
+fun PillarboxCastPlayer(
+    context: Context,
+    builder: SRG.Builder.() -> Unit = {},
+): PillarboxCastPlayer {
+    return PillarboxCastPlayer(context, SRG, builder)
+}
+
+/**
+ * Builder for creating an SRG-flavored Pillarbox cast player.
+ */
+object SRG : CastPlayerConfig<SRG.Builder> {
+
+    override fun create(): Builder {
+        return Builder
+    }
+
+    /**
+     * A builder class for creating and configuring a [PillarboxCastPlayer].
+     */
+    object Builder : PillarboxCastPlayerBuilder() {
+        init {
+            mediaItemConverter(SRGMediaItemConverter())
+        }
+    }
+}

--- a/pillarbox-core-business-cast/src/main/java/ch/srgssr/pillarbox/core/business/cast/PillarboxSRG.kt
+++ b/pillarbox-core-business-cast/src/main/java/ch/srgssr/pillarbox/core/business/cast/PillarboxSRG.kt
@@ -5,6 +5,7 @@
 package ch.srgssr.pillarbox.core.business.cast
 
 import android.content.Context
+import androidx.media3.cast.MediaItemConverter
 import ch.srgssr.pillarbox.cast.CastPlayerConfig
 import ch.srgssr.pillarbox.cast.PillarboxCastPlayer
 import ch.srgssr.pillarbox.cast.PillarboxCastPlayerBuilder
@@ -20,15 +21,15 @@ import ch.srgssr.pillarbox.player.PillarboxDsl
  * ```
  *
  * This creates a player with the default SRG SSR configuration:
- * - SRG cast MediaItemConverter: integrates an [SRGMediaItemConverter] for handling SRG-specific media item to cast item. If not explicitly
- * configured, a default instance is created.
+ * - SRG Cast [MediaItemConverter]: integrates an [SRGMediaItemConverter] for handling SRG-specific media item to Cast item conversion. If not
+ * explicitly configured, a default instance is created.
  *
  * **Custom configuration**
  *
  * ```kotlin
  * val customSrgCastPlayer = PillarboxCastPlayer(context) {
  *     mediaItemConverter(SRGMediaItemConverter())
- *     onCastSessionAvailable(context) {
+ *     onCastSessionAvailable {
  *          setMediaItems(listItems)
  *          play()
  *     }

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainViewModel.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainViewModel.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Timeline
+import ch.srgssr.pillarbox.cast.Default
 import ch.srgssr.pillarbox.cast.PillarboxCastPlayer
 import ch.srgssr.pillarbox.cast.getCastContext
 import ch.srgssr.pillarbox.cast.isConnected
@@ -29,11 +30,9 @@ import ch.srgssr.pillarbox.player.extension.getCurrentMediaItems
  * @param application The application context.
  */
 class MainViewModel(application: Application) : AndroidViewModel(application), SessionAvailabilityListener {
-    private val castPlayer: PillarboxCastPlayer = PillarboxCastPlayer(
-        castContext = application.getCastContext(),
-        context = application,
-        mediaItemConverter = SRGMediaItemConverter()
-    )
+    private val castPlayer: PillarboxCastPlayer = PillarboxCastPlayer(application, Default) {
+        mediaItemConverter(SRGMediaItemConverter())
+    }
     private val localPlayer = PillarboxExoPlayer(application)
     private var _currentPlayer: PillarboxPlayer by mutableStateOf(if (application.getCastContext().isConnected()) castPlayer else localPlayer)
 

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainViewModel.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/MainViewModel.kt
@@ -12,12 +12,11 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.media3.cast.SessionAvailabilityListener
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Timeline
-import ch.srgssr.pillarbox.cast.Default
 import ch.srgssr.pillarbox.cast.PillarboxCastPlayer
 import ch.srgssr.pillarbox.cast.getCastContext
 import ch.srgssr.pillarbox.cast.isConnected
 import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
-import ch.srgssr.pillarbox.core.business.cast.SRGMediaItemConverter
+import ch.srgssr.pillarbox.core.business.cast.PillarboxCastPlayer
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.extension.getCurrentMediaItems
@@ -30,9 +29,7 @@ import ch.srgssr.pillarbox.player.extension.getCurrentMediaItems
  * @param application The application context.
  */
 class MainViewModel(application: Application) : AndroidViewModel(application), SessionAvailabilityListener {
-    private val castPlayer: PillarboxCastPlayer = PillarboxCastPlayer(application, Default) {
-        mediaItemConverter(SRGMediaItemConverter())
-    }
+    private val castPlayer: PillarboxCastPlayer = PillarboxCastPlayer(application)
     private val localPlayer = PillarboxExoPlayer(application)
     private var _currentPlayer: PillarboxPlayer by mutableStateOf(if (application.getCastContext().isConnected()) castPlayer else localPlayer)
 


### PR DESCRIPTION
# Pull request

## Description

Introduce same dsl pattern as it has been done with `PillarboxExoPlayer` that can configure each aspect of a `PillarboxCastPlayer`.

### Samples

```kotlin
import ch.srgssr.pillarbox.cast.PillarboxCastPlayer

val castPlayer = PillarboxCastPlayer(context, Default) {
      mediaItemConverter(MyMediaItemConverter())
      seekBackIncrement(10.seconds)
      seekForwardIncrement(10.seconds)
      ....
}
```

```kotlin
import ch.srgssr.pillarbox.core.business.cast.PillarboxCastPlayer

val castPlayer = PillarboxCastPlayer(context) // SRG Configured.
```


## Changes made
- Add a SRG PillarboxCastPlayer builder that configure everything for SRG SSR content and Letterbox receiver.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
