### PR TITLE
Remove secrets from public workflow

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/dependency_graph.yml
+++ b/.github/workflows/dependency_graph.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,5 +28,3 @@ jobs:
           distribution: 'temurin'
       - name: Submit dependency graph
         uses: gradle/actions/dependency-submission@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -12,34 +12,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    env:
-      USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ github.token }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Java
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-      - name: Build modules
-        run: >
-          ./gradlew
-          :pillarbox-demo:assembleProdDebug
-          :pillarbox-demo-cast:assembleDebug
-          :pillarbox-demo-tv:assembleDebug
-          :pillarbox-player-testutils:assembleDebug
-
   android-lint:
     name: Android Lint
     runs-on: ubuntu-latest
-    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
@@ -70,7 +45,6 @@ jobs:
   detekt:
     name: Detekt
     runs-on: ubuntu-latest
-    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
@@ -96,7 +70,6 @@ jobs:
   dependency-analysis:
     name: Dependency Analysis
     runs-on: ubuntu-latest
-    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
@@ -116,7 +89,6 @@ jobs:
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: build
     permissions:
       pull-requests: write
     env:
@@ -158,7 +130,6 @@ jobs:
   android-tests:
     name: Android Tests
     runs-on: ubuntu-latest
-    needs: build
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -28,8 +28,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Build modules
         run: >
           ./gradlew
@@ -44,7 +42,7 @@ jobs:
     needs: build
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,8 +53,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Android Lint
         run: >
           ./gradlew
@@ -77,7 +73,7 @@ jobs:
     needs: build
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -88,8 +84,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Detekt
         run: ./gradlew detekt
       - name: Upload Detekt results
@@ -105,7 +99,7 @@ jobs:
     needs: build
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,8 +110,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Dependency Analysis
         run: ./gradlew buildHealth
 
@@ -129,7 +121,7 @@ jobs:
       pull-requests: write
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -140,8 +132,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Unit Tests
         run: >
           ./gradlew
@@ -157,7 +147,7 @@ jobs:
         uses: madrapps/jacoco-report@v1.7.1
         with:
           paths: ${{ github.workspace }}/**/build/reports/kover/**.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.token }}
           min-coverage-overall: 0
           min-coverage-changed-files: 0
           update-comment: true
@@ -171,7 +161,7 @@ jobs:
     needs: build
     env:
       USERNAME: ${{ github.actor }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
     strategy:
       matrix:
         api-level: [ 26 ]
@@ -191,8 +181,6 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
-        with:
-          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Android Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Pull request

## Description

This PR removes secrets from public workflows (those who run on PR). It also updates Gradle to 8.12.1 and removes the `build` step from the `quality.yml` workflow.

## Changes made

- Replace `secrets.GITHUB_TOKEN` with `github.token`. [Both are equivalent](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#about-the-github_token-secret), but using `github.token` shows that it's not a custom secret.
- Remove `secrets.GRADLE_CACHE_ENCRYPTION_KEY` from the `gradle/actions` action. It means that we will cache slightly less data, but it probably won't have a big impact on build time.
- Remove the `build` step from the `quality.yml` workflow. This probably had no significant advantage in terms of performance. So now each step is independent.
- Update to Gradle 8.12.1. The release notes are available [here](https://docs.gradle.org/8.12.1/release-notes.html).

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).