### PR TITLE
895 avoid arbitrary source keys

### DIFF
--- a/pillarbox-analytics/docs/README.md
+++ b/pillarbox-analytics/docs/README.md
@@ -31,7 +31,7 @@ class MyApplication : Application() {
         val config = AnalyticsConfig(
             vendor = AnalyticsConfig.Vendor.SRG,
             appSiteName = "Your AppSiteName here",
-            sourceKey = AnalyticsConfig.SOURCE_KEY_SRG_DEBUG,
+            sourceKey = SourceKey.SRG_DEBUG,
             nonLocalizedApplicationName = "Your non-localized AppSiteName here",
         )
 
@@ -56,7 +56,7 @@ val userConsent = UserConsent(
 val config = AnalyticsConfig(
     vendor = AnalyticsConfig.Vendor.SRG,
     appSiteName = "Your AppSiteName here",
-    sourceKey = AnalyticsConfig.SOURCE_KEY_SRG_DEBUG,
+    sourceKey = SourceKey.SRG_DEBUG,
     nonLocalizedApplicationName = "Your non-localized AppSiteName here",
     userConsent = userConsent,
 )

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
@@ -4,8 +4,6 @@
  */
 package ch.srgssr.pillarbox.analytics
 
-import ch.srgssr.pillarbox.analytics.AnalyticsConfig.Companion.SOURCE_KEY_SRG_DEBUG
-import ch.srgssr.pillarbox.analytics.AnalyticsConfig.Companion.SOURCE_KEY_SRG_PROD
 import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
 
 /**
@@ -17,8 +15,8 @@ import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
  *
  * @property vendor The vendor to which the application belongs to.
  * @property appSiteName The name of the app/site being tracked, given by the analytics team.
- * @property sourceKey The CommandersAct source key. Production apps should use [SOURCE_KEY_SRG_PROD], and apps in development should use
- * [SOURCE_KEY_SRG_DEBUG].
+ * @property sourceKey The CommandersAct source key. Production apps should use [SourceKey.SRG_PROD], and apps in development should use
+ * [SourceKey.SRG_DEBUG].
  * @property nonLocalizedApplicationName The non-localized name of the application. By default, the application name defined in the manifest is used.
  * @property userConsent The user consent to transmit to ComScore and CommandersAct.
  * @property comScorePersistentLabels The initial persistent labels for ComScore analytics.
@@ -27,7 +25,7 @@ import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
 data class AnalyticsConfig(
     val vendor: Vendor,
     val appSiteName: String,
-    val sourceKey: String,
+    val sourceKey: SourceKey,
     val nonLocalizedApplicationName: String? = null,
     val userConsent: UserConsent = UserConsent(),
     val comScorePersistentLabels: Map<String, String>? = null,

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
@@ -46,14 +46,17 @@ data class AnalyticsConfig(
 
     @Suppress("UndocumentedPublicClass")
     companion object {
+
         /**
          * The source key for SRG SSR apps in production.
          */
-        const val SOURCE_KEY_SRG_PROD = "3909d826-0845-40cc-a69a-6cec1036a45c"
+        @Deprecated("Use [SourceKey.SRG_PROD] instead.", ReplaceWith("SourceKey.SRG_PROD"))
+        val SOURCE_KEY_SRG_PROD = SourceKey.SRG_PROD
 
         /**
          * The source key for SRG SSR apps in development.
          */
-        const val SOURCE_KEY_SRG_DEBUG = "6f6bf70e-4129-4e47-a9be-ccd1737ba35f"
+        @Deprecated("Use [SourceKey.SRG_DEBUG] instead.", ReplaceWith("SourceKey.SRG_DEBUG"))
+        val SOURCE_KEY_SRG_DEBUG = SourceKey.SRG_DEBUG
     }
 }

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
@@ -34,7 +34,7 @@ import ch.srgssr.pillarbox.analytics.comscore.NoOpComScore
  *          val config = AnalyticsConfig(
  *              vendor = AnalyticsConfig.Vendor.SRG,
  *              appSiteName = "Your AppSiteName here",
- *              sourceKey = AnalyticsConfig.SOURCE_KEY_SRG_DEBUG,
+ *              sourceKey = SourceKey.SRG_DEBUG,
  *              nonLocalizedApplicationName = "Your non-localized AppSiteName here",
  *          )
  *

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SourceKey.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SourceKey.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.analytics
+
+/**
+ * CommandersAct source key.
+ *
+ * @property key the CommandersAct source key.
+ */
+enum class SourceKey(val key: String) {
+    /**
+     * The source key for SRG SSR apps in production.
+     */
+    SRG_PROD("3909d826-0845-40cc-a69a-6cec1036a45c"),
+
+    /**
+     * The source key for SRG SSR apps in development.
+     */
+    SRG_DEBUG("6f6bf70e-4129-4e47-a9be-ccd1737ba35f"),
+}

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrg.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrg.kt
@@ -48,7 +48,7 @@ internal class CommandersActSrg(
         config: AnalyticsConfig,
         appContext: Context
     ) : this(
-        tcServerSide = TCServerSide(SITE_SRG, config.sourceKey, appContext),
+        tcServerSide = TCServerSide(SITE_SRG, config.sourceKey.key, appContext),
         config = config,
         navigationDevice = appContext.getString(R.string.tc_analytics_device)
     ) {

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
@@ -22,7 +22,7 @@ class SRGAnalyticsSingletonTest {
     private val config = AnalyticsConfig(
         vendor = AnalyticsConfig.Vendor.SRG,
         appSiteName = "pillarbox-test-android",
-        sourceKey = AnalyticsConfig.SOURCE_KEY_SRG_DEBUG
+        sourceKey = SourceKey.SRG_DEBUG
     )
 
     private lateinit var context: Context

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TestUtils.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TestUtils.kt
@@ -5,11 +5,12 @@
 package ch.srgssr.pillarbox.analytics.commandersact
 
 import ch.srgssr.pillarbox.analytics.AnalyticsConfig
+import ch.srgssr.pillarbox.analytics.SourceKey
 
 object TestUtils {
     val analyticsConfig = AnalyticsConfig(
         vendor = AnalyticsConfig.Vendor.SRG,
         appSiteName = "pillarbox-test-android",
-        sourceKey = AnalyticsConfig.SOURCE_KEY_SRG_DEBUG
+        sourceKey = SourceKey.SRG_DEBUG
     )
 }

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.analytics.AnalyticsConfig
+import ch.srgssr.pillarbox.analytics.SourceKey
 import com.comscore.Analytics
 import com.comscore.PublisherConfiguration
 import io.mockk.clearAllMocks
@@ -27,7 +28,7 @@ class ComScoreSrgTest {
     private val config = AnalyticsConfig(
         vendor = AnalyticsConfig.Vendor.SRG,
         appSiteName = "pillarbox-test-android",
-        sourceKey = AnalyticsConfig.SOURCE_KEY_SRG_DEBUG
+        sourceKey = SourceKey.SRG_DEBUG
     )
 
     private lateinit var context: Context

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.demo
 import android.app.Application
 import ch.srgssr.pillarbox.analytics.AnalyticsConfig
 import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
+import ch.srgssr.pillarbox.analytics.SourceKey
 import ch.srgssr.pillarbox.analytics.UserConsent
 import ch.srgssr.pillarbox.analytics.comscore.ComScoreUserConsent
 import ch.srgssr.pillarbox.player.network.PillarboxOkHttp
@@ -33,7 +34,7 @@ class DemoApplication : Application(), SingletonImageLoader.Factory {
             vendor = AnalyticsConfig.Vendor.SRG,
             nonLocalizedApplicationName = "Pillarbox",
             appSiteName = "pillarbox-demo-android",
-            sourceKey = AnalyticsConfig.SOURCE_KEY_SRG_DEBUG,
+            sourceKey = SourceKey.SRG_DEBUG,
             userConsent = initialUserConsent
         )
         initSRGAnalytics(config = config)


### PR DESCRIPTION
# Pull request

## Description

To make API easier, `AnalyticsConfig.sourceKey` has been transformed to an enum type.

```kotlin
val config = AnalyticsConfig(
    vendor = AnalyticsConfig.Vendor.SRG,
    nonLocalizedApplicationName = "Pillarbox",
    appSiteName = "pillarbox-demo-android",
    sourceKey = SourceKey.SRG_DEBUG,
    userConsent = initialUserConsent
)
```

## Changes made

- Introduce `SourceKey` enum.
- Old constants are depreciated.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
