### PR TITLE
Add Dokka support for the `:pillarbox-core-business-cast` module

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,22 +73,10 @@ tasks.getByPath(":pillarbox-demo:preBuild").dependsOn(installGitHook)
 
 dependencyAnalysis {
     issues {
-
         all {
             onUnusedDependencies {
                 severity("fail")
                 exclude(libs.androidx.compose.ui.tooling.asProvider())
-                exclude(libs.okio)
-            }
-            onUsedTransitiveDependencies {
-                exclude(libs.okio)
-            }
-        }
-
-        project(":pillarbox-cast") {
-            onUnusedDependencies {
-                // This dependency is not used directly, but needed if we want to use the default Media3 cast receiver
-                exclude(libs.androidx.media3.cast)
             }
         }
 
@@ -110,6 +98,11 @@ dependencyAnalysis {
             onUnusedDependencies {
                 // These dependencies are not used directly, but automatically used by libs.androidx.media3.exoplayer
                 exclude(libs.androidx.media3.dash, libs.androidx.media3.hls)
+                exclude(libs.okio)
+            }
+
+            onUsedTransitiveDependencies {
+                exclude(libs.okio)
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     dokka(project(":pillarbox-analytics"))
     dokka(project(":pillarbox-cast"))
     dokka(project(":pillarbox-core-business"))
+    dokka(project(":pillarbox-core-business-cast"))
     dokka(project(":pillarbox-player"))
     dokka(project(":pillarbox-ui"))
 }

--- a/pillarbox-core-business-cast/build.gradle.kts
+++ b/pillarbox-core-business-cast/build.gradle.kts
@@ -10,12 +10,16 @@ plugins {
 }
 
 dependencies {
-    api(project(":pillarbox-core-business"))
+    implementation(project(":pillarbox-core-business"))
     api(project(":pillarbox-cast"))
-    testImplementation(libs.androidx.test.core)
+    implementation(libs.androidx.core.ktx)
+    api(libs.androidx.media3.cast)
+    api(libs.androidx.media3.common)
+
+    testRuntimeOnly(libs.androidx.test.core)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testRuntimeOnly(libs.robolectric)
-    testImplementation(libs.robolectric.shadows.framework)
+    testRuntimeOnly(libs.robolectric.shadows.framework)
 }

--- a/pillarbox-demo-cast/build.gradle.kts
+++ b/pillarbox-demo-cast/build.gradle.kts
@@ -8,8 +8,10 @@ plugins {
 
 dependencies {
     implementation(project(":pillarbox-cast"))
+    implementation(project(":pillarbox-core-business"))
     implementation(project(":pillarbox-core-business-cast"))
     implementation(project(":pillarbox-demo-shared"))
+    implementation(project(":pillarbox-player"))
     implementation(project(":pillarbox-ui"))
     implementation(libs.androidx.activity)
     implementation(libs.androidx.activity.compose)
@@ -19,9 +21,11 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.ui)
+    implementation(libs.androidx.compose.ui.graphics)
     debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.ui.unit)
+    implementation(libs.androidx.core)
     implementation(libs.androidx.fragment)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/PillarboxCastOptionProvider.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/PillarboxCastOptionProvider.kt
@@ -5,8 +5,6 @@
 package ch.srgssr.pillarbox.demo.cast
 
 import android.content.Context
-import androidx.annotation.OptIn
-import androidx.media3.common.util.UnstableApi
 import com.google.android.gms.cast.framework.CastOptions
 import com.google.android.gms.cast.framework.OptionsProvider
 import com.google.android.gms.cast.framework.SessionProvider
@@ -17,7 +15,6 @@ import com.google.android.gms.cast.framework.SessionProvider
  */
 class PillarboxCastOptionProvider : OptionsProvider {
 
-    @OptIn(UnstableApi::class)
     override fun getCastOptions(context: Context): CastOptions {
         return CastOptions.Builder()
             .setReceiverApplicationId("1AC2931D")


### PR DESCRIPTION
# Pull request

## Description

This PR adds the `pillarbox-core-business-cast` module to the list of Dokka modules to publish.
It also addresses some Dependency Analysis warnings.

## Changes made

- Self-explanatory.
- 
## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).