### PR TITLE
Add `rollback` job to the `release.yml` workflow in case of error

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -127,6 +127,44 @@ jobs:
           pass-emoji: 🟢
           fail-emoji: 🔴
 
+  publish-to-maven-local:
+    name: Publish to Maven local
+    runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Publish to Maven local
+        run: ./gradlew publishToMavenLocal
+
+  generate-documentation:
+    name: Generate documentation
+    runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Generate documentation
+        run: ./gradlew :dokkaGenerate
+
   android-tests:
     name: Android Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,28 +8,16 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[0-9a-zA-Z]+'
 
 jobs:
-  build:
+  publish-packages:
+    name: Publish packages
     runs-on: ubuntu-latest
     env:
-      DEMO_KEY_PASSWORD: ${{ secrets.DEMO_KEY_PASSWORD }}
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
       VERSION_NAME: ${{ github.ref_name }}
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check if pre-release tag
-        id: check-tag
-        run: |
-          if [[ "${GITHUB_REF_NAME}" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}-[0-9a-zA-Z]+$ ]]; then
-              echo "prerelease=true" >> $GITHUB_OUTPUT
-          fi
-      - name: Print release tag
-        run: |
-          echo "Tag: ${GITHUB_REF_NAME}"
-          echo "Version name: ${VERSION_NAME}"
-          echo "Pre-release: ${{ steps.check-tag.outputs.prerelease }}"
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
@@ -41,29 +29,157 @@ jobs:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
           cache-read-only: true
       - name: Publish to GitHub Packages
+        id: publish_packages
         run: ./gradlew publish
+
+  upload-to-firebase:
+    name: Upload to Firebase App Distribution
+    runs-on: ubuntu-latest
+    env:
+      DEMO_KEY_PASSWORD: ${{ secrets.DEMO_KEY_PASSWORD }}
+      VERSION_NAME: ${{ github.ref_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+          cache-read-only: true
       - name: Build with Gradle
         run: ./gradlew assembleProdRelease
-      - name: Upload artifact to Firebase App Distribution
+      - name: Upload to Firebase App Distribution
+        id: upload_to_firebase
         uses: wzieba/Firebase-Distribution-Github-Action@v1
         with:
           appId: ${{ secrets.RELEASE_APP_ID }}
           serviceCredentialsFileContent: ${{ secrets.FIREBASE_CREDENTIAL_FILE_CONTENT }}
           groups: ${{ secrets.RELEASE_GROUPS }}
           file: pillarbox-demo/build/outputs/apk/prod/release/pillarbox-demo-prod-release.apk
+
+  create-github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check if pre-release tag
+        id: check-tag
+        run: |
+          if [[ "${GITHUB_REF_NAME}" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}-[0-9a-zA-Z]+$ ]]; then
+              echo "prerelease=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Print version information
+        run: |
+          echo "Tag: ${GITHUB_REF_NAME}"
+          echo "Version name: ${VERSION_NAME}"
+          echo "Pre-release: ${{ steps.check-tag.outputs.prerelease }}"
       - name: Create Github release
+        id: create_github_release
         uses: ncipollo/release-action@v1
         with:
           draft: true
           prerelease: steps.check-tag.outputs.prerelease == 'true'
           skipIfReleaseExists: true
           generateReleaseNotes: true
-      - name: Build Dokka documentation
+
+  publish-documentation:
+    name: Publish Documentation
+    runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ github.token }}
+      VERSION_NAME: ${{ github.ref_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
+          cache-read-only: true
+      - name: Build documentation
         run: ./gradlew :dokkaGenerate
-      - name: Deploy Dokka documentation
+      - name: Publish documentation
+        id: publish_documentation
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: build/dokka/html
           single-commit: true
           target-folder: api
+
+  rollback:
+    name: Rollback
+    if: ${{ failure() }}
+    # We wait for 'upload_to_firebase' and 'publish_documentation' even if there's nothing to rollback there.
+    # This allows us to rollback the other steps, and retry the release later when everything is fixed.
+    needs: [ publish_packages, upload_to_firebase, create_github_release, publish_documentation ]
+    runs-on: ubuntu-latest
+    env:
+      USERNAME: ${{ github.actor }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Delete tag
+        run: git push origin --delete ${{ github.ref_name }} || true
+      - name: Delete 'pillarbox-analytics' from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-version-ids: ${{ github.ref_name }}
+          package-name: ch.srgssr.pillarbox.pillarbox-analytics
+          package-type: maven
+      - name: Delete 'pillarbox-cast' from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-version-ids: ${{ github.ref_name }}
+          package-name: ch.srgssr.pillarbox.pillarbox-cast
+          package-type: maven
+      - name: Delete 'pillarbox-core-business' from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-version-ids: ${{ github.ref_name }}
+          package-name: ch.srgssr.pillarbox.pillarbox-core-business
+          package-type: maven
+      - name: Delete 'pillarbox-core-business-cast' from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-version-ids: ${{ github.ref_name }}
+          package-name: ch.srgssr.pillarbox.pillarbox-core-business-cast
+          package-type: maven
+      - name: Delete 'pillarbox-player' from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-version-ids: ${{ github.ref_name }}
+          package-name: ch.srgssr.pillarbox.pillarbox-player
+          package-type: maven
+      - name: Delete 'pillarbox-ui' from GitHub Packages
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          package-version-ids: ${{ github.ref_name }}
+          package-name: ch.srgssr.pillarbox.pillarbox-ui
+          package-type: maven
+      - name: Delete GitHub Release
+        run: gh release delete ${{ github.ref_name }} -y || true


### PR DESCRIPTION
# Pull request

## Description

This PR reworks the `release.yml` workflow to automate reverting the release when an error occurs.

It now contains four major jobs that run in parallel:
- Publish packages.
- Upload to Firebase App Distribution.
- Create GitHub Release.
- Publish Documentation.

It also introduces a new "Rollback" job that runs if one of the previous four fails. Its goal is to:
- Delete the tag that triggered the workflow to run.
- Delete every package for the current tag from GitHub Packages.
- Delete the GitHub Release.

## Changes made

- Split the `release.yml` workflow into multiple independent jobs.
- Add a `rollback` job to `release.yml` to revert most changes in case of an error.
- Update the `quality.yml` workflow to run `./gradlew publishToMavenLocal`.
- Update the `quality.yml` workflow to run `./gradlew :dokkaGenerate`.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).