### PR TITLE
Automatically include published modules in Dokka documentation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -113,15 +113,7 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Unit Tests
-        run: >
-          ./gradlew
-          :build-logic:plugins:koverXmlReport
-          :pillarbox-analytics:koverXmlReportDebug
-          :pillarbox-cast:koverXmlReportDebug
-          :pillarbox-core-business:koverXmlReportDebug
-          :pillarbox-core-business-cast:koverXmlReportDebug
-          :pillarbox-player:koverXmlReportDebug
-          :pillarbox-ui:koverXmlReportDebug
+        run: ./gradlew :build-logic:plugins:koverXmlReport koverXmlReportDebug
       - name: Report Code Coverage
         if: ${{ github.event_name == 'pull_request' }}
         uses: madrapps/jacoco-report@v1.7.1

--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
@@ -13,10 +13,8 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
 import org.jetbrains.dokka.gradle.DokkaExtension
-import org.jetbrains.dokka.gradle.engine.plugins.DokkaHtmlPluginParameters
 import org.jetbrains.dokka.gradle.tasks.DokkaGeneratePublicationTask
 import org.jetbrains.kotlin.gradle.utils.named
 import java.net.URI
@@ -112,15 +110,6 @@ class PillarboxAndroidLibraryPublishingPlugin : Plugin<Project> {
                     localDirectory.set(projectDir.resolve("src"))
                     remoteUrl.set(URI("https://github.com/SRGSSR/pillarbox-android/tree/$version/${target.name}/src"))
                 }
-            }
-
-            // Follow https://github.com/Kotlin/dokka/issues/3883 to see if it's necessary to duplicate this config
-            pluginsConfiguration.getByName<DokkaHtmlPluginParameters>("html") {
-                customStyleSheets.from(rootProject.projectDir.resolve("config/dokka/styles/pillarbox.css"))
-                footerMessage.set("© SRG SSR")
-                // TODO Enable this once we have some content there
-                // homepageLink.set("https://android.pillarbox.ch/")
-                templatesDir.set(rootProject.projectDir.resolve("config/dokka/templates"))
             }
         }
     }

--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
@@ -47,6 +47,8 @@ class PillarboxAndroidLibraryPublishingPlugin : Plugin<Project> {
             archiveClassifier.set("javadoc")
         }
 
+        rootProject.dependencies.add("dokka", project(path))
+
         extensions.configure<LibraryExtension> {
             defaultConfig {
                 group = "ch.srgssr.pillarbox"

--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryTestedModulePlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryTestedModulePlugin.kt
@@ -22,6 +22,8 @@ class PillarboxAndroidLibraryTestedModulePlugin : Plugin<Project> {
         pluginManager.apply("com.android.library")
         pluginManager.apply("org.jetbrains.kotlinx.kover")
 
+        rootProject.dependencies.add("kover", project(path))
+
         extensions.configure<LibraryExtension> {
             defaultConfig {
                 testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,15 +37,6 @@ dokka {
     }
 }
 
-dependencies {
-    dokka(project(":pillarbox-analytics"))
-    dokka(project(":pillarbox-cast"))
-    dokka(project(":pillarbox-core-business"))
-    dokka(project(":pillarbox-core-business-cast"))
-    dokka(project(":pillarbox-player"))
-    dokka(project(":pillarbox-ui"))
-}
-
 // Configure the `wrapper` task, so it can easily be updated by simply running `./gradlew wrapper`.
 tasks.wrapper {
     distributionType = Wrapper.DistributionType.ALL

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,22 +18,28 @@ plugins {
     alias(libs.plugins.pillarbox.detekt)
 }
 
-dokka {
-    moduleVersion = providers.environmentVariable("VERSION_NAME").orElse("dev")
+allprojects {
+    if (pluginManager.hasPlugin("org.jetbrains.dokka")) {
+        dokka {
+            moduleVersion = providers.environmentVariable("VERSION_NAME").orElse("dev")
 
+            pluginsConfiguration.html {
+                // See the overridable images here:
+                // https://github.com/Kotlin/dokka/tree/master/dokka-subprojects/plugin-base/src/main/resources/dokka/images
+                customAssets.from(rootProject.projectDir.resolve("config/dokka/images/logo-icon.svg")) // TODO Use Pillarbox logo
+                customStyleSheets.from(rootProject.projectDir.resolve("config/dokka/styles/pillarbox.css"))
+                footerMessage.set("© SRG SSR")
+                // TODO Enable this once we have some content there
+                // homepageLink.set("https://android.pillarbox.ch/")
+                templatesDir.set(rootProject.projectDir.resolve("config/dokka/templates"))
+            }
+        }
+    }
+}
+
+dokka {
     dokkaPublications.html {
         includes.from("config/dokka/Pillarbox.md")
-    }
-
-    pluginsConfiguration.html {
-        // See the overridable images here:
-        // https://github.com/Kotlin/dokka/tree/master/dokka-subprojects/plugin-base/src/main/resources/dokka/images
-        customAssets.from("config/dokka/images/logo-icon.svg") // TODO Use Pillarbox logo
-        customStyleSheets.from("config/dokka/styles/pillarbox.css")
-        footerMessage.set("© SRG SSR")
-        // TODO Enable this once we have some content there
-        // homepageLink.set("https://android.pillarbox.ch/")
-        templatesDir.set(file("config/dokka/templates"))
     }
 }
 


### PR DESCRIPTION
# Pull request

## Description

This PR simplifies the Gradle configuration to not have to maintain the list of modules.

## Changes made

- Published modules are now automatically added to Dokka configuration.
- Tested modules are now automatically added to Kover configuration.
- Deduplicate Dokka configuration.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).