### PR TITLE
Enable Gradle Configuration Cache on GitHub Actions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -28,6 +28,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Android Lint
         run: >
           ./gradlew
@@ -58,6 +60,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Detekt
         run: ./gradlew detekt
       - name: Upload Detekt results
@@ -83,6 +87,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Dependency Analysis
         run: ./gradlew buildHealth
 
@@ -104,6 +110,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Unit Tests
         run: >
           ./gradlew
@@ -143,6 +151,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Publish to Maven local
         run: ./gradlew publishToMavenLocal
 
@@ -162,6 +172,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Generate documentation
         run: ./gradlew :dokkaGenerate
 
@@ -190,6 +202,8 @@ jobs:
           distribution: 'temurin'
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Android Tests
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryPublishingPlugin.kt
@@ -17,6 +17,8 @@ import org.gradle.kotlin.dsl.getByName
 import org.gradle.kotlin.dsl.register
 import org.jetbrains.dokka.gradle.DokkaExtension
 import org.jetbrains.dokka.gradle.engine.plugins.DokkaHtmlPluginParameters
+import org.jetbrains.dokka.gradle.tasks.DokkaGeneratePublicationTask
+import org.jetbrains.kotlin.gradle.utils.named
 import java.net.URI
 
 /**
@@ -30,18 +32,18 @@ class PillarboxAndroidLibraryPublishingPlugin : Plugin<Project> {
         pluginManager.apply("org.jetbrains.dokka-javadoc")
 
         val dokkaHtmlJar = tasks.register<Jar>("dokkaHtmlJar") {
-            val dokkaHtmlTask = tasks.named("dokkaGeneratePublicationHtml")
+            val dokkaHtmlTask = tasks.named<DokkaGeneratePublicationTask>("dokkaGeneratePublicationHtml")
 
             dependsOn(dokkaHtmlTask)
-            from(dokkaHtmlTask.map { it.outputs })
+            from(dokkaHtmlTask.flatMap { it.outputDirectory })
             archiveClassifier.set("html-docs")
         }
 
         val dokkaJavadocJar = tasks.register<Jar>("dokkaJavadocJar") {
-            val dokkaJavadocTask = tasks.named("dokkaGeneratePublicationJavadoc")
+            val dokkaJavadocTask = tasks.named<DokkaGeneratePublicationTask>("dokkaGeneratePublicationJavadoc")
 
             dependsOn(dokkaJavadocTask)
-            from(dokkaJavadocTask.map { it.outputs })
+            from(dokkaJavadocTask.flatMap { it.outputDirectory })
             archiveClassifier.set("javadoc")
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -34,8 +34,7 @@ org.gradle.caching=true
 
 # Gradle's Configuration Cache
 # https://docs.gradle.org/current/userguide/performance.html#enable_configuration_cache
-# Disable configuration cache until Dokka supports it: https://github.com/Kotlin/dokka/issues/1217
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 
 # Print dependency analysis report to the console


### PR DESCRIPTION
# Pull request

## Description

In #899, the `cache-encryption-key` argument was removed from the `gradle/actions/setup-gradle` action to avoid using secrets.
However, this secret is optional: if the value is not provided, the cache won't be read or updated.
This means that PRs created from the main repository will take advantage of Gradle's Configuration Cache, while PRs from forks won't.

See the corresponding section of the documentation for more information: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#saving-configuration-cache-data

## Changes made

- Enable Configuration Cache in the project.
- Update Dokka tasks to work with Configuration Cache.
- Update the `quality.yml` workflow to support Configuration Cache.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).