### PR TITLE
Refactoring PillarboxAnalyticsCollector

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,7 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="150" />
-    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
+    <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="false" />
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,9 +29,9 @@ allprojects {
                 customAssets.from(rootProject.projectDir.resolve("config/dokka/images/logo-icon.svg")) // TODO Use Pillarbox logo
                 customStyleSheets.from(rootProject.projectDir.resolve("config/dokka/styles/pillarbox.css"))
                 footerMessage.set("© SRG SSR")
-                // TODO Enable this once we have some content there
-                // homepageLink.set("https://android.pillarbox.ch/")
+                homepageLink.set("https://www.pillarbox.ch/")
                 templatesDir.set(rootProject.projectDir.resolve("config/dokka/templates"))
+                separateInheritedMembers = true
             }
         }
     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -87,9 +87,7 @@ class PillarboxExoPlayer internal constructor(
     internal val monitoring = Monitoring(
         context = context,
         player = this,
-        metricsCollector = analyticsCollector.metricsCollector,
         messageHandler = monitoringMessageHandler,
-        sessionManager = analyticsCollector.sessionManager,
         coroutineContext = coroutineContext,
     )
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -14,8 +14,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.Timeline.Window
 import androidx.media3.common.util.ListenerSet
 import androidx.media3.exoplayer.ExoPlayer
-import ch.srgssr.pillarbox.player.analytics.PlaybackSessionManager
-import ch.srgssr.pillarbox.player.analytics.metrics.MetricsCollector
+import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsCollector
 import ch.srgssr.pillarbox.player.analytics.metrics.PlaybackMetrics
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
@@ -82,19 +81,15 @@ class PillarboxExoPlayer internal constructor(
         listener.onEvents(this, Player.Events(flags))
     }
     private val analyticsTracker = AnalyticsMediaItemTracker(this)
-    internal val sessionManager = PlaybackSessionManager()
     private val window = Window()
-
-    @VisibleForTesting
-    internal val metricsCollector: MetricsCollector = MetricsCollector()
 
     @VisibleForTesting
     internal val monitoring = Monitoring(
         context = context,
         player = this,
-        metricsCollector = metricsCollector,
+        metricsCollector = analyticsCollector.metricsCollector,
         messageHandler = monitoringMessageHandler,
-        sessionManager = sessionManager,
+        sessionManager = analyticsCollector.sessionManager,
         coroutineContext = coroutineContext,
     )
 
@@ -132,8 +127,6 @@ class PillarboxExoPlayer internal constructor(
     private val mediaMetadataTracker = PillarboxMediaMetaDataTracker(this::notifyTimeRangeChanged)
 
     init {
-        sessionManager.setPlayer(this)
-        metricsCollector.setPlayer(this)
         mediaMetadataTracker.setPlayer(this)
         blockedTimeRangeTracker.setPlayer(this)
         addListener(analyticsCollector)
@@ -143,19 +136,23 @@ class PillarboxExoPlayer internal constructor(
         }
     }
 
+    override fun getAnalyticsCollector(): PillarboxAnalyticsCollector {
+        return exoPlayer.analyticsCollector as PillarboxAnalyticsCollector
+    }
+
     /**
      * Get current metrics
      * @return `null` if there is no current metrics.
      */
     fun getCurrentMetrics(): PlaybackMetrics? {
-        return metricsCollector.getCurrentMetrics()
+        return analyticsCollector.metricsCollector.getCurrentMetrics()
     }
 
     /**
      * @return The current playback session id if any.
      */
     fun getCurrentPlaybackSessionId(): String? {
-        return sessionManager.getCurrentSession()?.sessionId
+        return analyticsCollector.sessionManager.getCurrentSession()?.sessionId
     }
 
     /**
@@ -168,7 +165,9 @@ class PillarboxExoPlayer internal constructor(
         if (currentTimeline.isEmpty) return null
         currentTimeline.getWindow(index, window)
         val periodUid = currentTimeline.getUidOfPeriod(window.firstPeriodIndex)
-        return sessionManager.getSessionFromPeriodUid(periodUid)?.let { metricsCollector.getMetricsForSession(it) }
+        return analyticsCollector.sessionManager.getSessionFromPeriodUid(periodUid)?.let {
+            analyticsCollector.metricsCollector.getMetricsForSession(it)
+        }
     }
 
     override fun addListener(listener: Player.Listener) {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
@@ -27,7 +27,7 @@ class PillarboxAnalyticsCollector(
 
     internal val sessionManager = PlaybackSessionManager()
 
-    internal val metricsCollector: MetricsCollector = MetricsCollector(sessionManager)
+    internal val metricsCollector: MetricsCollector = MetricsCollector(sessionManager, clock)
 
     init {
         addListener(sessionManager)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
@@ -4,11 +4,14 @@
  */
 package ch.srgssr.pillarbox.player.analytics
 
+import android.os.Looper
+import androidx.media3.common.Player
 import androidx.media3.common.util.Clock
 import androidx.media3.common.util.ListenerSet.Event
 import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
 import androidx.media3.exoplayer.analytics.DefaultAnalyticsCollector
 import ch.srgssr.pillarbox.player.PillarboxPlayer
+import ch.srgssr.pillarbox.player.analytics.metrics.MetricsCollector
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
 import ch.srgssr.pillarbox.player.asset.timeRange.Credit
@@ -19,18 +22,27 @@ import ch.srgssr.pillarbox.player.asset.timeRange.Credit
  * @param clock The [Clock] used to generate timestamps.
  */
 class PillarboxAnalyticsCollector(
-    clock: Clock = Clock.DEFAULT
+    clock: Clock = Clock.DEFAULT,
 ) : DefaultAnalyticsCollector(clock), PillarboxPlayer.Listener, StallDetector.Listener {
 
     private val stallDetector = StallDetector()
 
+    internal val sessionManager = PlaybackSessionManager()
+
+    internal val metricsCollector: MetricsCollector = MetricsCollector(sessionManager)
+
     init {
+        addListener(sessionManager)
+        addListener(metricsCollector)
         addListener(stallDetector)
         stallDetector.addListener(this)
     }
 
+    override fun setPlayer(player: Player, looper: Looper) {
+        super.setPlayer(player, looper)
+    }
+
     override fun release() {
-        removeListener(stallDetector)
         stallDetector.removeListener(this)
         super.release()
     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PillarboxAnalyticsCollector.kt
@@ -4,8 +4,6 @@
  */
 package ch.srgssr.pillarbox.player.analytics
 
-import android.os.Looper
-import androidx.media3.common.Player
 import androidx.media3.common.util.Clock
 import androidx.media3.common.util.ListenerSet.Event
 import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
@@ -36,10 +34,6 @@ class PillarboxAnalyticsCollector(
         addListener(metricsCollector)
         addListener(stallDetector)
         stallDetector.addListener(this)
-    }
-
-    override fun setPlayer(player: Player, looper: Looper) {
-        super.setPlayer(player, looper)
     }
 
     override fun release() {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/metrics/MetricsCollector.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/metrics/MetricsCollector.kt
@@ -14,7 +14,6 @@ import androidx.media3.exoplayer.analytics.AnalyticsListener.EventTime
 import androidx.media3.exoplayer.drm.DrmSession
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
-import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsListener
 import ch.srgssr.pillarbox.player.analytics.PlaybackSessionManager
 import ch.srgssr.pillarbox.player.analytics.extension.getUidOfPeriod
@@ -31,9 +30,10 @@ import java.io.IOException
  * - Dropped video frames
  * - Surface size
  */
-class MetricsCollector private constructor(
-    private val timeProvider: () -> Long,
-) {
+class MetricsCollector(
+    private val sessionManager: PlaybackSessionManager,
+    private val timeProvider: () -> Long = { System.currentTimeMillis() },
+) : PillarboxAnalyticsListener {
     /**
      * A listener interface for receiving updates about playback metrics.
      */
@@ -48,21 +48,14 @@ class MetricsCollector private constructor(
 
     private var currentSession: PlaybackSessionManager.Session? = null
     private val listeners = mutableSetOf<Listener>()
-    private lateinit var player: PillarboxExoPlayer
     private val metricsSessions = mutableMapOf<Any, SessionMetrics>()
     private var surfaceSize: Size = Size.UNKNOWN
+    private val window = Window()
+    private var playbackState: Int = Player.STATE_IDLE
+    private var isPlaying: Boolean = false
 
-    constructor() : this({ System.currentTimeMillis() })
-
-    /**
-     * Sets the [PillarboxExoPlayer] instance to be used for analytics and session management.
-     *
-     * @param player The [PillarboxExoPlayer] instance to be used.
-     */
-    fun setPlayer(player: PillarboxExoPlayer) {
-        player.sessionManager.addListener(MetricsSessionManagerListener())
-        player.addAnalyticsListener(MetricsAnalyticsListener())
-        this.player = player
+    init {
+        sessionManager.addListener(MetricsSessionManagerListener())
     }
 
     /**
@@ -102,8 +95,8 @@ class MetricsCollector private constructor(
             currentSession = newSession?.session
             currentSession?.let { session ->
                 getOrCreateSessionMetrics(session.periodUid).apply {
-                    setIsPlaying(player.isPlaying)
-                    setPlaybackState(player.playbackState)
+                    setIsPlaying(isPlaying)
+                    setPlaybackState(playbackState)
                 }
             }
         }
@@ -116,7 +109,7 @@ class MetricsCollector private constructor(
         private fun getOrCreateSessionMetrics(periodUid: Any): SessionMetrics {
             return metricsSessions.getOrPut(periodUid) {
                 SessionMetrics(timeProvider) { sessionMetrics ->
-                    player.sessionManager.getSessionFromPeriodUid(periodUid)?.let {
+                    sessionManager.getSessionFromPeriodUid(periodUid)?.let {
                         notifyMetricsReady(createPlaybackMetrics(session = it, metrics = sessionMetrics))
                     }
                 }
@@ -124,125 +117,123 @@ class MetricsCollector private constructor(
         }
     }
 
-    private inner class MetricsAnalyticsListener : PillarboxAnalyticsListener {
-        private val window = Window()
+    override fun onStallChanged(eventTime: EventTime, isStall: Boolean) {
+        getSessionMetrics(eventTime)?.setIsStall(isStall)
+    }
 
-        override fun onStallChanged(eventTime: EventTime, isStall: Boolean) {
-            getSessionMetrics(eventTime)?.setIsStall(isStall)
-        }
+    override fun onIsPlayingChanged(eventTime: EventTime, isPlaying: Boolean) {
+        this.isPlaying = isPlaying
+        getSessionMetrics(eventTime)?.setIsPlaying(isPlaying)
+    }
 
-        override fun onIsPlayingChanged(eventTime: EventTime, isPlaying: Boolean) {
-            getSessionMetrics(eventTime)?.setIsPlaying(isPlaying)
-        }
+    override fun onBandwidthEstimate(eventTime: EventTime, totalLoadTimeMs: Int, totalBytesLoaded: Long, bitrateEstimate: Long) {
+        getSessionMetrics(eventTime)?.setBandwidthEstimate(totalLoadTimeMs, totalBytesLoaded, bitrateEstimate)
+    }
 
-        override fun onBandwidthEstimate(eventTime: EventTime, totalLoadTimeMs: Int, totalBytesLoaded: Long, bitrateEstimate: Long) {
-            getSessionMetrics(eventTime)?.setBandwidthEstimate(totalLoadTimeMs, totalBytesLoaded, bitrateEstimate)
-        }
+    override fun onVideoInputFormatChanged(eventTime: EventTime, format: Format, decoderReuseEvaluation: DecoderReuseEvaluation?) {
+        getSessionMetrics(eventTime)?.videoFormat = format
+    }
 
-        override fun onVideoInputFormatChanged(eventTime: EventTime, format: Format, decoderReuseEvaluation: DecoderReuseEvaluation?) {
-            getSessionMetrics(eventTime)?.videoFormat = format
-        }
+    /**
+     * On video disabled is called when releasing the player
+     *
+     * @param eventTime
+     * @param decoderCounters
+     */
+    override fun onVideoDisabled(eventTime: EventTime, decoderCounters: DecoderCounters) {
+        if (playbackState == Player.STATE_IDLE || eventTime.timeline.isEmpty) return
+        getSessionMetrics(eventTime)?.videoFormat = null
+    }
 
-        /**
-         * On video disabled is called when releasing the player
-         *
-         * @param eventTime
-         * @param decoderCounters
-         */
-        override fun onVideoDisabled(eventTime: EventTime, decoderCounters: DecoderCounters) {
-            if (player.playbackState == Player.STATE_IDLE || eventTime.timeline.isEmpty) return
-            getSessionMetrics(eventTime)?.videoFormat = null
-        }
+    override fun onAudioInputFormatChanged(eventTime: EventTime, format: Format, decoderReuseEvaluation: DecoderReuseEvaluation?) {
+        getSessionMetrics(eventTime)?.audioFormat = format
+    }
 
-        override fun onAudioInputFormatChanged(eventTime: EventTime, format: Format, decoderReuseEvaluation: DecoderReuseEvaluation?) {
-            getSessionMetrics(eventTime)?.audioFormat = format
-        }
+    override fun onAudioDisabled(eventTime: EventTime, decoderCounters: DecoderCounters) {
+        if (playbackState == Player.STATE_IDLE || eventTime.timeline.isEmpty) return
+        getSessionMetrics(eventTime)?.audioFormat = null
+    }
 
-        override fun onAudioDisabled(eventTime: EventTime, decoderCounters: DecoderCounters) {
-            if (player.playbackState == Player.STATE_IDLE || eventTime.timeline.isEmpty) return
-            getSessionMetrics(eventTime)?.audioFormat = null
-        }
+    override fun onPlaybackStateChanged(eventTime: EventTime, state: Int) {
+        playbackState = state
+        getSessionMetrics(eventTime)?.setPlaybackState(state)
+    }
 
-        override fun onPlaybackStateChanged(eventTime: EventTime, state: Int) {
-            getSessionMetrics(eventTime)?.setPlaybackState(state)
-        }
+    override fun onRenderedFirstFrame(eventTime: EventTime, output: Any, renderTimeMs: Long) {
+        getSessionMetrics(eventTime)?.setRenderFirstFrameOrAudioPositionAdvancing()
+    }
 
-        override fun onRenderedFirstFrame(eventTime: EventTime, output: Any, renderTimeMs: Long) {
-            getSessionMetrics(eventTime)?.setRenderFirstFrameOrAudioPositionAdvancing()
-        }
+    override fun onAudioPositionAdvancing(eventTime: EventTime, playoutStartSystemTimeMs: Long) {
+        getSessionMetrics(eventTime)?.setRenderFirstFrameOrAudioPositionAdvancing()
+    }
 
-        override fun onAudioPositionAdvancing(eventTime: EventTime, playoutStartSystemTimeMs: Long) {
-            getSessionMetrics(eventTime)?.setRenderFirstFrameOrAudioPositionAdvancing()
-        }
+    override fun onLoadCompleted(eventTime: EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
+        getSessionMetrics(eventTime)?.setLoadCompleted(loadEventInfo, mediaLoadData)
+    }
 
-        override fun onLoadCompleted(eventTime: EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
-            getSessionMetrics(eventTime)?.setLoadCompleted(loadEventInfo, mediaLoadData)
-        }
+    override fun onLoadStarted(eventTime: EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
+        getSessionMetrics(eventTime)?.setLoadStarted(loadEventInfo)
+    }
 
-        override fun onLoadStarted(eventTime: EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
-            getSessionMetrics(eventTime)?.setLoadStarted(loadEventInfo)
-        }
+    override fun onLoadError(
+        eventTime: EventTime,
+        loadEventInfo: LoadEventInfo,
+        mediaLoadData: MediaLoadData,
+        error: IOException,
+        wasCanceled: Boolean
+    ) {
+        getSessionMetrics(eventTime)?.setLoadCompleted(loadEventInfo, mediaLoadData)
+    }
 
-        override fun onLoadError(
-            eventTime: EventTime,
-            loadEventInfo: LoadEventInfo,
-            mediaLoadData: MediaLoadData,
-            error: IOException,
-            wasCanceled: Boolean
-        ) {
-            getSessionMetrics(eventTime)?.setLoadCompleted(loadEventInfo, mediaLoadData)
+    override fun onDrmSessionAcquired(eventTime: EventTime, state: Int) {
+        DebugLogger.debug(TAG, "onDrmSessionAcquired $state")
+        if (state == DrmSession.STATE_OPENED) {
+            getSessionMetrics(eventTime)?.setDrmSessionAcquired()
         }
+    }
 
-        override fun onDrmSessionAcquired(eventTime: EventTime, state: Int) {
-            DebugLogger.debug(TAG, "onDrmSessionAcquired $state")
-            if (state == DrmSession.STATE_OPENED) {
-                getSessionMetrics(eventTime)?.setDrmSessionAcquired()
-            }
-        }
+    override fun onDrmSessionReleased(eventTime: EventTime) {
+        DebugLogger.debug(TAG, "onDrmSessionReleased")
+    }
 
-        override fun onDrmSessionReleased(eventTime: EventTime) {
-            DebugLogger.debug(TAG, "onDrmSessionReleased")
-        }
+    override fun onDrmKeysLoaded(eventTime: EventTime) {
+        DebugLogger.debug(TAG, "onDrmKeysLoaded")
+        getSessionMetrics(eventTime)?.setDrmKeyLoaded()
+    }
 
-        override fun onDrmKeysLoaded(eventTime: EventTime) {
-            DebugLogger.debug(TAG, "onDrmKeysLoaded")
-            getSessionMetrics(eventTime)?.setDrmKeyLoaded()
-        }
+    override fun onDrmKeysRestored(eventTime: EventTime) {
+        DebugLogger.debug(TAG, "onDrmKeysRestored")
+        getSessionMetrics(eventTime)?.setDrmKeyLoaded()
+    }
 
-        override fun onDrmKeysRestored(eventTime: EventTime) {
-            DebugLogger.debug(TAG, "onDrmKeysRestored")
-            getSessionMetrics(eventTime)?.setDrmKeyLoaded()
-        }
+    override fun onDrmKeysRemoved(eventTime: EventTime) {
+        DebugLogger.debug(TAG, "onDrmKeysRemoved")
+        getSessionMetrics(eventTime)?.setDrmKeyLoaded()
+    }
 
-        override fun onDrmKeysRemoved(eventTime: EventTime) {
-            DebugLogger.debug(TAG, "onDrmKeysRemoved")
-            getSessionMetrics(eventTime)?.setDrmKeyLoaded()
-        }
+    override fun onPlayerReleased(eventTime: EventTime) {
+        listeners.clear()
+    }
 
-        override fun onPlayerReleased(eventTime: EventTime) {
-            listeners.clear()
+    override fun onDroppedVideoFrames(eventTime: EventTime, droppedFrames: Int, elapsedMs: Long) {
+        getSessionMetrics(eventTime)?.let {
+            it.totalDroppedFrames += droppedFrames
         }
+    }
 
-        override fun onDroppedVideoFrames(eventTime: EventTime, droppedFrames: Int, elapsedMs: Long) {
-            getSessionMetrics(eventTime)?.let {
-                it.totalDroppedFrames += droppedFrames
-            }
-        }
+    override fun onSurfaceSizeChanged(eventTime: EventTime, width: Int, height: Int) {
+        surfaceSize = Size(width, height)
+    }
 
-        override fun onSurfaceSizeChanged(eventTime: EventTime, width: Int, height: Int) {
-            surfaceSize = Size(width, height)
-        }
-
-        /**
-         * Get session metrics
-         *
-         * @param eventTime
-         * @return `null` if there is no item in the timeline or session already finished.
-         */
-        private fun getSessionMetrics(eventTime: EventTime): SessionMetrics? {
-            if (eventTime.timeline.isEmpty) return null
-            return metricsSessions[(eventTime.getUidOfPeriod(window))]
-        }
+    /**
+     * Get session metrics
+     *
+     * @param eventTime
+     * @return `null` if there is no item in the timeline or session already finished.
+     */
+    private fun getSessionMetrics(eventTime: EventTime): SessionMetrics? {
+        if (eventTime.timeline.isEmpty) return null
+        return metricsSessions[(eventTime.getUidOfPeriod(window))]
     }
 
     /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/metrics/MetricsCollector.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/metrics/MetricsCollector.kt
@@ -7,6 +7,7 @@ package ch.srgssr.pillarbox.player.analytics.metrics
 import androidx.media3.common.Format
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline.Window
+import androidx.media3.common.util.Clock
 import androidx.media3.common.util.Size
 import androidx.media3.exoplayer.DecoderCounters
 import androidx.media3.exoplayer.DecoderReuseEvaluation
@@ -32,8 +33,9 @@ import java.io.IOException
  */
 class MetricsCollector(
     private val sessionManager: PlaybackSessionManager,
-    private val timeProvider: () -> Long = { System.currentTimeMillis() },
+    private val clock: Clock,
 ) : PillarboxAnalyticsListener {
+
     /**
      * A listener interface for receiving updates about playback metrics.
      */
@@ -108,7 +110,7 @@ class MetricsCollector(
 
         private fun getOrCreateSessionMetrics(periodUid: Any): SessionMetrics {
             return metricsSessions.getOrPut(periodUid) {
-                SessionMetrics(timeProvider) { sessionMetrics ->
+                SessionMetrics(clock::currentTimeMillis) { sessionMetrics ->
                     sessionManager.getSessionFromPeriodUid(periodUid)?.let {
                         notifyMetricsReady(createPlaybackMetrics(session = it, metrics = sessionMetrics))
                     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Context.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Context.kt
@@ -10,9 +10,9 @@ import android.provider.Settings.Secure
 import ch.srgssr.pillarbox.player.monitoring.models.Session
 
 /**
- * Get a device id that is send with [Session].
+ * Get a device id that is sent with a [Session].
  *
- * @return a unique Device identifier or empty if not available.
+ * @return A unique device identifier, or empty if not available.
  */
 @SuppressLint("HardwareIds")
 fun Context.getMonitoringDeviceId(): String {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Context.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/Context.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player.extension
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.provider.Settings.Secure
+import ch.srgssr.pillarbox.player.monitoring.models.Session
+
+/**
+ * Get a device id that is send with [Session].
+ *
+ * @return a unique Device identifier or empty if not available.
+ */
+@SuppressLint("HardwareIds")
+fun Context.getMonitoringDeviceId(): String {
+    return Secure.getString(
+        contentResolver,
+        Secure.ANDROID_ID
+    ) ?: ""
+}

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
@@ -12,10 +12,10 @@ import android.util.Log
 import androidx.media3.common.C
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Timeline.Window
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.analytics.AnalyticsListener
 import androidx.media3.exoplayer.source.LoadEventInfo
 import androidx.media3.exoplayer.source.MediaLoadData
+import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsListener
 import ch.srgssr.pillarbox.player.analytics.PlaybackSessionManager
 import ch.srgssr.pillarbox.player.analytics.metrics.MetricsCollector
@@ -39,15 +39,15 @@ import kotlin.time.Duration.Companion.seconds
 
 internal class Monitoring(
     private val context: Context,
-    private val player: ExoPlayer,
-    private val metricsCollector: MetricsCollector,
+    private val player: PillarboxExoPlayer,
     private val messageHandler: MonitoringMessageHandler,
-    private val sessionManager: PlaybackSessionManager,
     private val coroutineContext: CoroutineContext,
 ) : PillarboxAnalyticsListener,
     MetricsCollector.Listener,
     PlaybackSessionManager.Listener {
     private val window = Window()
+    private val metricsCollector: MetricsCollector = player.analyticsCollector.metricsCollector
+    private val sessionManager: PlaybackSessionManager = player.analyticsCollector.sessionManager
 
     internal class SessionHolder(
         val session: PlaybackSessionManager.Session,

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
@@ -4,14 +4,13 @@
  */
 package ch.srgssr.pillarbox.player.monitoring.models
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Rect
 import android.os.Build
-import android.provider.Settings.Secure
 import android.view.WindowManager
 import ch.srgssr.pillarbox.player.BuildConfig
+import ch.srgssr.pillarbox.player.extension.getMonitoringDeviceId
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -50,7 +49,7 @@ data class Session(
         qosTimings: Timings.QoS,
     ) : this(
         device = Device(
-            id = getDeviceId(context),
+            id = context.getMonitoringDeviceId(),
             model = getDeviceModel(),
             type = context.getDeviceType(),
         ),
@@ -158,20 +157,6 @@ data class Session(
         private const val PLATFORM_NAME = "Android"
         private const val PLAYER_NAME = "Pillarbox"
         private const val PLAYER_VERSION = BuildConfig.VERSION_NAME
-
-        /**
-         * Get a device id that is send with [Session].
-         *
-         * @param context The [Context].
-         * @return a unique Device identifier or empty if not available.
-         */
-        @SuppressLint("HardwareIds")
-        fun getDeviceId(context: Context): String {
-            return Secure.getString(
-                context.contentResolver,
-                Secure.ANDROID_ID
-            ) ?: ""
-        }
 
         private fun getDeviceModel(): String {
             return Build.MANUFACTURER + " " + Build.MODEL

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
@@ -152,15 +152,21 @@ data class Session(
         }
     }
 
-    private companion object {
+    companion object {
         private val OPERATING_SYSTEM_VERSION = Build.VERSION.RELEASE
         private const val PHONE_TABLET_WIDTH_THRESHOLD = 600
         private const val PLATFORM_NAME = "Android"
         private const val PLAYER_NAME = "Pillarbox"
         private const val PLAYER_VERSION = BuildConfig.VERSION_NAME
 
+        /**
+         * Get a device id that is send with [Session].
+         *
+         * @param context The [Context].
+         * @return a unique Device identifier or empty if not available.
+         */
         @SuppressLint("HardwareIds")
-        private fun getDeviceId(context: Context): String {
+        fun getDeviceId(context: Context): String {
             return Secure.getString(
                 context.contentResolver,
                 Secure.ANDROID_ID

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
@@ -151,7 +151,7 @@ data class Session(
         }
     }
 
-    companion object {
+    private companion object {
         private val OPERATING_SYSTEM_VERSION = Build.VERSION.RELEASE
         private const val PHONE_TABLET_WIDTH_THRESHOLD = 600
         private const val PLATFORM_NAME = "Android"

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/MetricsCollectorTest.kt
@@ -40,7 +40,7 @@ class MetricsCollectorTest {
     fun setUp() {
         metricsListener = mockk(relaxed = true)
         player = PillarboxExoPlayer()
-        player.metricsCollector.addListener(metricsListener)
+        player.analyticsCollector.metricsCollector.addListener(metricsListener)
         player.prepare()
         player.play()
 

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManagerTest.kt
@@ -7,7 +7,6 @@ package ch.srgssr.pillarbox.player.analytics
 import android.os.Looper
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
@@ -30,7 +29,7 @@ import kotlin.test.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class PlaybackSessionManagerTest {
-    private lateinit var player: ExoPlayer
+    private lateinit var player: PillarboxExoPlayer
     private lateinit var sessionManager: PlaybackSessionManager
     private lateinit var sessionManagerListener: PlaybackSessionManager.Listener
 
@@ -39,11 +38,8 @@ class PlaybackSessionManagerTest {
         sessionManagerListener = mockk(relaxed = true)
         player = PillarboxExoPlayer()
         player.prepare()
-
-        sessionManager = PlaybackSessionManager().apply {
-            setPlayer(player)
-            addListener(sessionManagerListener)
-        }
+        sessionManager = player.analyticsCollector.sessionManager
+        sessionManager.addListener(sessionManagerListener)
 
         clearMocks(sessionManagerListener)
     }
@@ -51,6 +47,7 @@ class PlaybackSessionManagerTest {
     @AfterTest
     fun tearDown() {
         player.release()
+        sessionManager.removeListener(sessionManagerListener)
         shadowOf(Looper.getMainLooper()).idle()
         clearAllMocks()
     }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to simplify PillarboxExoPlayer by creating `PlaybackSessionManager` and `MetricsCollector` into `PillarboxAnalyticsCollector`.

## Changes made
 - Expose `Session.getDeviceId` used by the monitoring.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
