### PR TITLE
Add application information and audio/subtitles language to monitoring events

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
@@ -29,6 +29,9 @@ import ch.srgssr.pillarbox.player.monitoring.models.MessageData
 import ch.srgssr.pillarbox.player.monitoring.models.Session
 import ch.srgssr.pillarbox.player.monitoring.models.Timings
 import ch.srgssr.pillarbox.player.runOnApplicationLooper
+import ch.srgssr.pillarbox.player.tracks.Track
+import ch.srgssr.pillarbox.player.tracks.audioTracks
+import ch.srgssr.pillarbox.player.tracks.textTracks
 import ch.srgssr.pillarbox.player.utils.DebugLogger
 import ch.srgssr.pillarbox.player.utils.Heartbeat
 import java.io.IOException
@@ -231,6 +234,7 @@ internal class Monitoring(
 
     private fun PlaybackMetrics.toQoSEvent(position: Long, window: Window): EventMessageData {
         return EventMessageData(
+            audio = player.currentTracks.audioTracks.selectedLanguage,
             bandwidth = bandwidth,
             bitrate = indicatedBitrate,
             bufferDuration = player.totalBufferedDuration,
@@ -243,6 +247,7 @@ internal class Monitoring(
                 duration = stallDuration.inWholeMilliseconds,
             ),
             streamType = if (window.isLive) StreamType.LIVE else StreamType.ON_DEMAND,
+            subtitles = player.currentTracks.textTracks.selectedLanguage,
             url = url.toString(),
             vpn = hasActiveVPN(),
             frameDrops = totalDroppedFrames,
@@ -271,7 +276,6 @@ internal class Monitoring(
                     assetUrl = sessionHolder.assetUrl ?: "",
                     id = sessionHolder.session.mediaItem.mediaId,
                     metadataUrl = sessionHolder.session.mediaItem.localConfiguration?.uri.toString(),
-                    origin = context.packageName,
                 ),
                 qoeTimings = sessionHolder.qoeTimings,
                 qosTimings = sessionHolder.qosTimings,
@@ -279,9 +283,12 @@ internal class Monitoring(
         )
     }
 
-    private companion object {
+    internal companion object {
         private val HEARTBEAT_PERIOD = 30.seconds
         private const val TAG = "Monitoring"
+
+        internal val List<Track>.selectedLanguage: String?
+            get() = find { it.isSelected }?.format?.language
 
         private fun Window.getPositionTimestamp(position: Long): Long? {
             if (position == C.TIME_UNSET || windowStartTimeMs == C.TIME_UNSET) return null

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageData.kt
@@ -7,28 +7,35 @@ package ch.srgssr.pillarbox.player.monitoring.models
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import ch.srgssr.pillarbox.player.extension.getUnixTimeMs
+import ch.srgssr.pillarbox.player.monitoring.Monitoring.Companion.selectedLanguage
+import ch.srgssr.pillarbox.player.tracks.audioTracks
+import ch.srgssr.pillarbox.player.tracks.textTracks
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 /**
  * Represents a [Player] error to send to a monitoring server.
  *
+ * @property audio The audio track language code.
  * @property duration The duration of the media being played, in milliseconds.
  * @property log The log associated with the error.
  * @property message The error message.
  * @property name The name of the error.
  * @property position The playback position, in milliseconds, when the error occurred.
  * @property positionTimestamp The current player timestamp, as retrieved from the playlist.
+ * @property subtitles The subtitles language code (CC, subtitles or forced subtitles).
  * @property url The last loaded url.
  */
 @Serializable
 data class ErrorMessageData(
+    val audio: String?,
     val duration: Long?,
     val log: String,
     val message: String,
     val name: String,
     val position: Long?,
     @SerialName("position_timestamp") val positionTimestamp: Long?,
+    val subtitles: String?,
     val url: String,
 ) : MessageData {
     constructor(
@@ -36,12 +43,14 @@ data class ErrorMessageData(
         player: Player,
         url: String,
     ) : this(
+        audio = player.currentTracks.audioTracks.selectedLanguage,
         duration = player.duration,
         log = throwable.stackTraceToString(),
         message = throwable.message.orEmpty(),
         name = throwable::class.simpleName.orEmpty(),
         position = player.currentPosition,
         positionTimestamp = player.getUnixTimeMs().takeIf { it != C.TIME_UNSET },
+        subtitles = player.currentTracks.textTracks.selectedLanguage,
         url = url,
     )
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/EventMessageData.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/EventMessageData.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a generic event, which contains metrics about the current media stream.
  *
+ * @property audio The audio track language code.
  * @property bandwidth The device-measured network bandwidth, in bits per second.
  * @property bitrate The bitrate of the current stream, in bits per second.
  * @property bufferDuration The forward duration of the buffer, in milliseconds.
@@ -19,12 +20,14 @@ import kotlinx.serialization.Serializable
  * @property positionTimestamp The current player timestamp, as retrieved from the playlist.
  * @property stall Information about stalls that have occurred during playback.
  * @property streamType The type of stream being played.
+ * @property subtitles The subtitles language code (CC, subtitles or forced subtitles).
  * @property url The URL of the stream being played.
  * @property vpn Indicates whether a VPN is enabled, or if the status could not be determined.
  * @property frameDrops The number of frame drops that have occurred during playback.
  */
 @Serializable
 data class EventMessageData(
+    val audio: String?,
     val bandwidth: Long,
     val bitrate: Long,
     @SerialName("buffered_duration") val bufferDuration: Long,
@@ -34,6 +37,7 @@ data class EventMessageData(
     @SerialName("position_timestamp") val positionTimestamp: Long?,
     val stall: Stall,
     @SerialName("stream_type") val streamType: StreamType,
+    val subtitles: String?,
     val url: String,
     val vpn: Boolean?,
     @SerialName("frame_drops")

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/models/Session.kt
@@ -17,6 +17,7 @@ import kotlinx.serialization.Serializable
 /**
  * Represents a monitoring session, which encapsulates information about the device, current media, player, and performance metrics.
  *
+ * @property application Information about the application.
  * @property device Information about the device.
  * @property media Information about the media being played.
  * @property operatingSystem Information about the device's operating system.
@@ -27,6 +28,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class Session(
+    val application: Application,
     val device: Device,
     val media: Media,
     @SerialName("os") val operatingSystem: OS = OS(
@@ -48,6 +50,12 @@ data class Session(
         qoeTimings: Timings.QoE,
         qosTimings: Timings.QoS,
     ) : this(
+        application = Application(
+            id = context.packageName,
+            version = context.packageManager
+                .getPackageInfo(context.packageName, 0)
+                .versionName,
+        ),
         device = Device(
             id = context.getMonitoringDeviceId(),
             model = getDeviceModel(),
@@ -62,6 +70,18 @@ data class Session(
                 width = windowBounds.width(),
             )
         },
+    )
+
+    /**
+     * Represents the information about the application.
+     *
+     * @property id A unique identifier for the application.
+     * @property version The application version.
+     */
+    @Serializable
+    data class Application(
+        val id: String,
+        val version: String?,
     )
 
     /**
@@ -108,14 +128,12 @@ data class Session(
      * @property assetUrl The URL of the asset.
      * @property id The id of the media.
      * @property metadataUrl The URL of the metadata.
-     * @property origin The origin of the media.
      */
     @Serializable
     data class Media(
         @SerialName("asset_url") val assetUrl: String,
         val id: String,
         @SerialName("metadata_url") val metadataUrl: String,
-        val origin: String,
     )
 
     /**

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageDataTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/ErrorMessageDataTest.kt
@@ -4,11 +4,18 @@
  */
 package ch.srgssr.pillarbox.player.monitoring.models
 
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
+import androidx.media3.common.TrackGroup
+import androidx.media3.common.Tracks
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
+import org.junit.runner.RunWith
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -18,6 +25,7 @@ import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
+@RunWith(AndroidJUnit4::class)
 class ErrorMessageDataTest {
     private lateinit var player: Player
 
@@ -27,6 +35,7 @@ class ErrorMessageDataTest {
             every { duration } returns DURATION
             every { currentPosition } returns CURRENT_POSITION
             every { currentTimeline } returns Timeline.EMPTY
+            every { currentTracks } returns TRACKS
         }
     }
 
@@ -46,6 +55,7 @@ class ErrorMessageDataTest {
 
         val logLines = qosErrorMessageData.log.lineSequence()
 
+        assertEquals("en", qosErrorMessageData.audio)
         assertEquals(DURATION, qosErrorMessageData.duration)
         assertTrue(logLines.count() > 1, "Expected log to contain the stacktrace")
         assertEquals("java.lang.IllegalStateException", logLines.first())
@@ -54,6 +64,7 @@ class ErrorMessageDataTest {
         assertEquals("IllegalStateException", qosErrorMessageData.name)
         assertEquals(CURRENT_POSITION, qosErrorMessageData.position)
         assertNull(qosErrorMessageData.positionTimestamp)
+        assertEquals("text-eng-sdh", qosErrorMessageData.subtitles)
         assertEquals(URL, qosErrorMessageData.url)
     }
 
@@ -69,6 +80,7 @@ class ErrorMessageDataTest {
 
         val logLines = qosErrorMessageData.log.lineSequence()
 
+        assertEquals("en", qosErrorMessageData.audio)
         assertEquals(DURATION, qosErrorMessageData.duration)
         assertTrue(logLines.count() > 1, "Expected log to contain the stacktrace")
         assertEquals("java.lang.RuntimeException: ${throwable.message}", logLines.first())
@@ -80,12 +92,73 @@ class ErrorMessageDataTest {
         assertEquals("RuntimeException", qosErrorMessageData.name)
         assertEquals(CURRENT_POSITION, qosErrorMessageData.position)
         assertNull(qosErrorMessageData.positionTimestamp)
+        assertEquals("text-eng-sdh", qosErrorMessageData.subtitles)
         assertEquals(URL, qosErrorMessageData.url)
     }
 
     private companion object {
         private val DURATION = 10.minutes.inWholeMilliseconds
         private val CURRENT_POSITION = 30.seconds.inWholeMilliseconds
+        private val TRACKS = Tracks(
+            listOf(
+                // Audio tracks (fr)
+                Tracks.Group(
+                    TrackGroup(
+                        Format.Builder()
+                            .setId("5_A_audio_fra_1")
+                            .setSampleMimeType(MimeTypes.AUDIO_AAC)
+                            .setContainerMimeType(MimeTypes.AUDIO_MP4)
+                            .setPeakBitrate(128000)
+                            .setCodecs("mp4a.40.2")
+                            .setSampleRate(48000)
+                            .setLanguage("fr")
+                            .build(),
+                    ),
+                    true,
+                    intArrayOf(C.FORMAT_HANDLED),
+                    booleanArrayOf(false),
+                ),
+                // Audio tracks (en)
+                Tracks.Group(
+                    TrackGroup(
+                        Format.Builder()
+                            .setId("5_A_audio_eng_1")
+                            .setSampleMimeType(MimeTypes.AUDIO_AAC)
+                            .setContainerMimeType(MimeTypes.AUDIO_MP4)
+                            .setPeakBitrate(128000)
+                            .setCodecs("mp4a.40.2")
+                            .setSampleRate(48000)
+                            .setLanguage("en")
+                            .build(),
+                    ),
+                    true,
+                    intArrayOf(C.FORMAT_HANDLED),
+                    booleanArrayOf(true),
+                ),
+                // Text tracks
+                Tracks.Group(
+                    TrackGroup(
+                        Format.Builder()
+                            .setId("fr")
+                            .setSampleMimeType(MimeTypes.TEXT_VTT)
+                            .setContainerMimeType(MimeTypes.TEXT_VTT)
+                            .setPeakBitrate(0)
+                            .setLanguage("text-fra-sdh")
+                            .build(),
+                        Format.Builder()
+                            .setId("en")
+                            .setSampleMimeType(MimeTypes.TEXT_VTT)
+                            .setContainerMimeType(MimeTypes.TEXT_VTT)
+                            .setPeakBitrate(0)
+                            .setLanguage("text-eng-sdh")
+                            .build(),
+                    ),
+                    true,
+                    intArrayOf(C.FORMAT_HANDLED, C.FORMAT_HANDLED),
+                    booleanArrayOf(false, true),
+                ),
+            )
+        )
         private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/da2b38fb-ca9f-3c76-80c6-e6fa7f3c2699/master.m3u8"
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/SessionTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/monitoring/models/SessionTest.kt
@@ -5,9 +5,12 @@
 package ch.srgssr.pillarbox.player.monitoring.models
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,13 +22,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.PHONE, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -42,13 +46,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values (API 30)`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("robolectric robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.PHONE, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("11", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -65,13 +70,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values for car`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.CAR, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -88,13 +94,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values for desktop`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.DESKTOP, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -111,13 +118,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values for phone (sw320dp)`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.PHONE, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -134,13 +142,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values for tablet (sw600dp)`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.TABLET, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -157,13 +166,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values for tablet (sw720dp)`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.TABLET, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -180,13 +190,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values for TV`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertEquals(Session.Device.Type.TV, qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -203,13 +214,14 @@ class SessionTest {
     fun `contextConstructor provides correct default values for watch`() {
         val qosSession = createQoSSession()
 
+        assertEquals(APPLICATION_ID, qosSession.application.id)
+        assertEquals(APPLICATION_VERSION, qosSession.application.version)
         assertEquals("", qosSession.device.id)
         assertEquals("unknown robolectric", qosSession.device.model)
         assertNull(qosSession.device.type)
         assertEquals(ASSET_URL, qosSession.media.assetUrl)
         assertEquals(MEDIA_ID, qosSession.media.id)
         assertEquals(METADATA_URL, qosSession.media.metadataUrl)
-        assertEquals(ORIGIN, qosSession.media.origin)
         assertEquals(OPERATING_SYSTEM_NAME, qosSession.operatingSystem.name)
         assertEquals("5.0.2", qosSession.operatingSystem.version)
         assertEquals(PLAYER_NAME, qosSession.player.name)
@@ -222,7 +234,17 @@ class SessionTest {
     }
 
     private fun createQoSSession(): Session {
+        val appInfo = ApplicationInfo()
+        appInfo.flags = ApplicationInfo.FLAG_INSTALLED
+        appInfo.packageName = APPLICATION_ID
+
+        val packageInfo = PackageInfo()
+        packageInfo.applicationInfo = appInfo
+        packageInfo.packageName = APPLICATION_ID
+        packageInfo.versionName = APPLICATION_VERSION
+
         val context = ApplicationProvider.getApplicationContext<Context>()
+        shadowOf(context.packageManager).installPackage(packageInfo)
 
         return Session(
             context = context,
@@ -230,7 +252,6 @@ class SessionTest {
                 assetUrl = ASSET_URL,
                 id = MEDIA_ID,
                 metadataUrl = METADATA_URL,
-                origin = ORIGIN,
             ),
             qoeTimings = Timings.QoE(),
             qosTimings = Timings.QoS(),
@@ -238,11 +259,12 @@ class SessionTest {
     }
 
     private companion object {
+        private const val APPLICATION_ID = "ch.srgssr.pillarbox.player.test"
+        private const val APPLICATION_VERSION = "1.2.3"
         private const val ASSET_URL = "https://rts-vod-amd.akamaized.net/ww/12345/3037738d-fe91-32e3-93f2-4dbb62a0f9bd/master.m3u8"
         private const val MEDIA_ID = "urn:rts:video:12345"
         private const val METADATA_URL = "https://il-stage.srgssr.ch/integrationlayer/2.1/mediaComposition/byUrn/urn:rts:video:12345?vector=APPPLAY"
         private const val OPERATING_SYSTEM_NAME = "Android"
-        private const val ORIGIN = "ch.srgssr.pillarbox.player.test"
         private const val PLAYER_NAME = "Pillarbox"
         private const val PLAYER_PLATFORM = "Android"
         private const val PLAYER_VERSION = "Local"


### PR DESCRIPTION
# Pull request

## Description

This commit updates the monitoring models to include more information, based on the latest [update of the specification](https://github.com/SRGSSR/pillarbox-documentation/issues/131).

## Changes made

- Adds application id and version to `Session`.
- Adds `audio` and `subtitles` information to `EventMessageData` and `ErrorMessageData`.
- Removes unused `origin` field from `Session.Media`.
- Adds unit tests for the above.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).