### PR TITLE
Fix the rollback job of the release workflow

### DIFF
--- a/.github/workflows/actions/delete_package.sh
+++ b/.github/workflows/actions/delete_package.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+#
+# Copyright (c) SRG SSR. All rights reserved.
+# License information is available from the LICENSE file.
+#
+
+ORG="$1"
+PACKAGE_NAME="$2"
+VERSION_NAME="$3"
+PACKAGE_TYPE="maven"
+
+# Check that we have the necessary inputs
+if [[ -z "$ORG" || -z "$PACKAGE_NAME" || -z "$VERSION_NAME" ]]; then
+  echo "Usage: $0 <organization> <package_name> <version_name>"
+  exit 1
+fi
+
+# Get the list of recent versions published for PACKAGE_NAME
+VERSIONS=$(gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/orgs/$ORG/packages/$PACKAGE_TYPE/$PACKAGE_NAME/versions")
+
+if [[ -z "$VERSIONS" ]]; then
+  echo "Failed to retrieve package versions for $ORG/$PACKAGE_NAME"
+  exit 1
+fi
+
+# Get the version id corresponding to the VERSION_NAME we want to delete
+VERSION_ID=$(echo $VERSIONS | jq -r --arg version "$VERSION_NAME" 'map(select(.name == $version) | .id)[0] // ""')
+
+if [[ -z "$VERSION_ID" ]]; then
+  echo "Version '$VERSION_NAME' not found for $ORG/$PACKAGE_NAME"
+  exit 1
+fi
+
+# Delete PACKAGE_NAME version VERSION_NAME (id VERSION_ID)
+gh api \
+  --method DELETE \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  "/orgs/$ORG/packages/$PACKAGE_TYPE/$PACKAGE_NAME/versions/$VERSION_ID"
+
+if [[ "$?" -ne 0 ]]; then
+    echo "Failed to delete version $VERSION_NAME of $ORG/$PACKAGE_NAME"
+    exit 1
+fi
+
+echo "Successfully deleted version '$VERSION_NAME' of $ORG/$PACKAGE_NAME"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,28 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+-[0-9a-zA-Z]+'
 
 jobs:
+  check-pre-release:
+    name: Check pre-release
+    runs-on: ubuntu-latest
+    env:
+      VERSION_NAME: ${{ github.ref_name }}
+    outputs:
+      prerelease: ${{ steps.check-tag.outputs.prerelease }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check if pre-release tag
+        id: check-tag
+        run: |
+          if [[ "${GITHUB_REF_NAME}" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}-[0-9a-zA-Z]+$ ]]; then
+              echo "prerelease=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Print version information
+        run: |
+          echo "Tag: ${GITHUB_REF_NAME}"
+          echo "Version name: ${VERSION_NAME}"
+          echo "Pre-release: ${{ steps.check-tag.outputs.prerelease }}"
+
   publish-packages:
     name: Publish packages
     runs-on: ubuntu-latest
@@ -65,34 +87,26 @@ jobs:
   create-github-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
+    needs: check-pre-release
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check if pre-release tag
-        id: check-tag
-        run: |
-          if [[ "${GITHUB_REF_NAME}" =~ ^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}-[0-9a-zA-Z]+$ ]]; then
-              echo "prerelease=true" >> $GITHUB_OUTPUT
-          fi
-      - name: Print version information
-        run: |
-          echo "Tag: ${GITHUB_REF_NAME}"
-          echo "Version name: ${VERSION_NAME}"
-          echo "Pre-release: ${{ steps.check-tag.outputs.prerelease }}"
       - name: Create Github release
         uses: ncipollo/release-action@v1
         with:
           draft: true
-          prerelease: steps.check-tag.outputs.prerelease == 'true'
+          prerelease: ${{ needs.check-pre-release.outputs.prerelease == 'true' }}
           skipIfReleaseExists: true
           generateReleaseNotes: true
 
   publish-documentation:
     name: Publish Documentation
     runs-on: ubuntu-latest
+    needs: check-pre-release
+    if: ${{ needs.check-pre-release.outputs.prerelease != 'true' }}
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
@@ -130,54 +144,26 @@ jobs:
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
+      REPO_OWNER: ${{ github.repository_owner }}
+      VERSION_NAME: ${{ github.ref_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Delete tag
-        run: git push origin --delete ${{ github.ref_name }} || true
-      - name: Delete 'pillarbox-analytics' from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
-        with:
-          package-version-ids: ${{ github.ref_name }}
-          package-name: ch.srgssr.pillarbox.pillarbox-analytics
-          package-type: maven
-      - name: Delete 'pillarbox-cast' from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
-        with:
-          package-version-ids: ${{ github.ref_name }}
-          package-name: ch.srgssr.pillarbox.pillarbox-cast
-          package-type: maven
-      - name: Delete 'pillarbox-core-business' from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
-        with:
-          package-version-ids: ${{ github.ref_name }}
-          package-name: ch.srgssr.pillarbox.pillarbox-core-business
-          package-type: maven
-      - name: Delete 'pillarbox-core-business-cast' from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
-        with:
-          package-version-ids: ${{ github.ref_name }}
-          package-name: ch.srgssr.pillarbox.pillarbox-core-business-cast
-          package-type: maven
-      - name: Delete 'pillarbox-player' from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
-        with:
-          package-version-ids: ${{ github.ref_name }}
-          package-name: ch.srgssr.pillarbox.pillarbox-player
-          package-type: maven
-      - name: Delete 'pillarbox-ui' from GitHub Packages
-        uses: actions/delete-package-versions@v5
-        continue-on-error: true
-        with:
-          package-version-ids: ${{ github.ref_name }}
-          package-name: ch.srgssr.pillarbox.pillarbox-ui
-          package-type: maven
+        run: git push origin --delete ${{ env.VERSION_NAME }} || true
       - name: Delete GitHub Release
-        run: gh release delete ${{ github.ref_name }} -y || true
+        run: gh release delete ${{ env.VERSION_NAME }} -y || true
+      - name: Delete 'pillarbox-analytics' from GitHub Packages
+        run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-analytics" ${{ env.VERSION_NAME }} || true
+      - name: Delete 'pillarbox-cast' from GitHub Packages
+        run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-cast" ${{ env.VERSION_NAME }} || true
+      - name: Delete 'pillarbox-core-business' from GitHub Packages
+        run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-core-business" ${{ env.VERSION_NAME }} || true
+      - name: Delete 'pillarbox-core-business-cast' from GitHub Packages
+        run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-core-business-cast" ${{ env.VERSION_NAME }} || true
+      - name: Delete 'pillarbox-player' from GitHub Packages
+        run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-player" ${{ env.VERSION_NAME }} || true
+      - name: Delete 'pillarbox-ui' from GitHub Packages
+        run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-ui" ${{ env.VERSION_NAME }} || true


### PR DESCRIPTION
# Pull request

## Description

This commit fixes the rollback job in the release workflow.
It also disables documentation publication for snapshot releases.

## Changes made

- Create a new `delete_package.sh` script to be able to delete a package by version.
- Update the `release.yml` workflow to use that script during the `rollback` job to delete the published packages.
- Extract the pre-release logic into its own job so its output can be used in other jobs.
- Fix the `Create GitHub Release` job to properly set the `prerelease` flag.
- Don't publish documentation for prerelease versions.

## Additional information

### Delete packages

The `delete_package.sh` script can be used outside the GitHub Action by running it from the command line:
```bash
./delete_package.sh SRGSSR ch.srgssr.pillarbox.pillarbox-analytics 6.0.0
```
It only looks for the version in the last 30 versions returned by the API. Deleting an older version won't work out of the box with this script.

### Pre-release check

You can see the result of a pre-release [here](https://github.com/MGaetan89/pillarbox-android/actions/runs/13966867993) (6.0.0-SNAPSHOT) and a release [here](https://github.com/MGaetan89/pillarbox-android/actions/runs/13966884435) (6.0.0).

(the publications and Firebase jobs fail because credentials are missing in my fork)

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).