### PR TITLE
Add support for volume control and mute state toggling

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -2,6 +2,41 @@
   <code_scheme name="Project" version="173">
     <option name="RIGHT_MARGIN" value="150" />
     <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="false" />
+    <JavaCodeStyleSettings>
+      <option name="IMPORT_LAYOUT_TABLE">
+        <value>
+          <package name="" withSubpackages="true" static="false" module="true" />
+          <package name="android" withSubpackages="true" static="true" />
+          <package name="androidx" withSubpackages="true" static="true" />
+          <package name="com" withSubpackages="true" static="true" />
+          <package name="junit" withSubpackages="true" static="true" />
+          <package name="net" withSubpackages="true" static="true" />
+          <package name="org" withSubpackages="true" static="true" />
+          <package name="java" withSubpackages="true" static="true" />
+          <package name="javax" withSubpackages="true" static="true" />
+          <package name="" withSubpackages="true" static="true" />
+          <emptyLine />
+          <package name="android" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="androidx" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="com" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="junit" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="net" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="org" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="java" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="javax" withSubpackages="true" static="false" />
+          <emptyLine />
+          <package name="" withSubpackages="true" static="false" />
+          <emptyLine />
+        </value>
+      </option>
+    </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -284,7 +284,7 @@ class PillarboxCastPlayer internal constructor(
     }
 
     private fun withRemoteClient(command: RemoteMediaClient.() -> Unit): ListenableFuture<*> {
-        remoteMediaClient?.let(command)
+        remoteMediaClient?.command()
 
         return Futures.immediateVoidFuture()
     }

--- a/pillarbox-demo-cast/build.gradle.kts
+++ b/pillarbox-demo-cast/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.foundation.layout)
+    implementation(libs.androidx.compose.material.icons.core)
+    implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.compose.runtime)
     implementation(libs.androidx.compose.ui)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -480,6 +480,40 @@ fun PillarboxExoPlayer.currentMetricsAsFlow(): Flow<PlaybackMetrics?> = callback
     addPlayerListener(this@currentMetricsAsFlow, listener)
 }.distinctUntilChanged()
 
+/**
+ * Collects the [current volume][Player.getVolume] as a [Flow].
+ *
+ * @return A [Flow] emitting the current volume.
+ */
+fun Player.getVolumeAsFlow(): Flow<Float> = callbackFlow {
+    val listener = object : Listener {
+        override fun onVolumeChanged(volume: Float) {
+            trySend(volume)
+        }
+    }
+
+    send(volume)
+
+    addPlayerListener(this@getVolumeAsFlow, listener)
+}
+
+/**
+ * Collects the [muted state][Player.isDeviceMuted] of the device as a [Flow].
+ *
+ * @return A [Flow] emitting the current muted state of the device.
+ */
+fun Player.isDeviceMutedAsFlow(): Flow<Boolean> = callbackFlow {
+    val listener = object : Listener {
+        override fun onDeviceVolumeChanged(volume: Int, muted: Boolean) {
+            trySend(muted)
+        }
+    }
+
+    send(isDeviceMuted)
+
+    addPlayerListener(this@isDeviceMutedAsFlow, listener)
+}
+
 private suspend fun <T> ProducerScope<T>.addPlayerListener(player: Player, listener: Listener) {
     player.addListener(listener)
     awaitClose {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
@@ -18,6 +18,7 @@ import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
+import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -225,6 +226,37 @@ class PlayerCallbackFlowTest {
 
         player.getCurrentDefaultPositionAsFlow().test {
             assertEquals(0L, awaitItem())
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    fun `get volume as flow`() = runTest {
+        player.setMediaItem(MediaItem.fromUri(VOD))
+
+        player.getVolumeAsFlow().test {
+            player.volume = 0.5f
+            player.volume = 0f
+
+            assertEquals(1f, awaitItem())
+            assertEquals(0.5f, awaitItem())
+            assertEquals(0f, awaitItem())
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
+    @Ignore("Enable when we use AndroidX Media3 1.6.0")
+    fun `is device muted as flow`() = runTest {
+        player.setMediaItem(MediaItem.fromUri(VOD))
+
+        player.isDeviceMutedAsFlow().test {
+            player.setDeviceMuted(true, 0)
+            player.setDeviceMuted(false, 0)
+
+            assertFalse(awaitItem())
+            assertTrue(awaitItem())
+            assertFalse(awaitItem())
             ensureAllEventsConsumed()
         }
     }

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.geometry)
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.text)
+    debugImplementation(libs.androidx.compose.ui.tooling)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.ui.unit)
     implementation(libs.androidx.lifecycle.common)
@@ -31,6 +32,4 @@ dependencies {
     api(libs.androidx.media3.exoplayer)
     api(libs.androidx.media3.ui)
     implementation(libs.kotlinx.coroutines.core)
-
-    debugImplementation(libs.androidx.compose.ui.tooling)
 }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
@@ -42,7 +42,9 @@ import ch.srgssr.pillarbox.player.getCurrentCreditAsFlow
 import ch.srgssr.pillarbox.player.getCurrentMediaItemIndexAsFlow
 import ch.srgssr.pillarbox.player.getCurrentMediaItemsAsFlow
 import ch.srgssr.pillarbox.player.getPlaybackSpeedAsFlow
+import ch.srgssr.pillarbox.player.getVolumeAsFlow
 import ch.srgssr.pillarbox.player.isCurrentMediaItemLiveAsFlow
+import ch.srgssr.pillarbox.player.isDeviceMutedAsFlow
 import ch.srgssr.pillarbox.player.isPlayingAsFlow
 import ch.srgssr.pillarbox.player.mediaItemCountAsFlow
 import ch.srgssr.pillarbox.player.playWhenReadyAsFlow
@@ -343,4 +345,30 @@ fun PillarboxExoPlayer.getPeriodicallyCurrentMetricsAsState(updateInterval: Dura
     return remember(this) {
         currentPositionAsFlow(updateInterval).map { getCurrentMetrics() }
     }.collectAsState(initial = getCurrentMetrics())
+}
+
+/**
+ * Observe the [Player.getVolume] property as a [State].
+ *
+ * @return A [State] that represents the current volume.
+ */
+@Composable
+fun Player.getVolumeAsState(): FloatState {
+    val flow = remember(this) {
+        getVolumeAsFlow()
+    }
+    return flow.collectAsState(initial = volume).asFloatState()
+}
+
+/**
+ * Observe the [Player.isDeviceMuted] property as a [State].
+ *
+ * @return A [State] that represents the current muted state of the device.
+ */
+@Composable
+fun Player.isDeviceMutedAsState(): State<Boolean> {
+    val flow = remember(this) {
+        isDeviceMutedAsFlow()
+    }
+    return flow.collectAsState(initial = isDeviceMuted)
 }


### PR DESCRIPTION
# Pull request

## Description

This commit adds support for volume management (local and device volume), as well as toggling the muted state of the device.

## Changes made

- Add support for volume control, device volume control, and muted state toggling to `PillarboxCastPlayer`.
- Update `pillarbox-demo-cast` to add a mute button and volume slider.
- Push the automatic changes to `.idea/codeStyles/Project.xml`.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).