### PR TITLE
Remove preload for some demo

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/MultiPlayerViewModel.kt
@@ -10,8 +10,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.media3.common.C
 import androidx.media3.common.Player
 import androidx.media3.ui.PlayerNotificationManager
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
-import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.extension.setHandleAudioFocus
@@ -37,13 +37,13 @@ class MultiPlayerViewModel(application: Application) : AndroidViewModel(applicat
         .build()
     private val mediaSession: PillarboxMediaSession
 
-    private val _playerOne = PlayerModule.provideDefaultPlayer(application).apply {
+    private val _playerOne = PillarboxExoPlayer(application).apply {
         repeatMode = Player.REPEAT_MODE_ONE
         setMediaItem(DemoItem.LiveVideo.toMediaItem())
         prepare()
         play()
     }
-    private val _playerTwo = PlayerModule.provideDefaultPlayer(application).apply {
+    private val _playerTwo = PillarboxExoPlayer(application).apply {
         repeatMode = Player.REPEAT_MODE_ONE
         setMediaItem(DemoItem.DvrVideo.toMediaItem())
         prepare()

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SphericalSurfaceShowcase.kt
@@ -12,8 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.LifecycleStartEffect
 import androidx.media3.common.Player
+import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.core.business.SRGMediaItem
-import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
 import ch.srgssr.pillarbox.ui.ScaleMode
 import ch.srgssr.pillarbox.ui.widget.player.PlayerSurface
 import ch.srgssr.pillarbox.ui.widget.player.SurfaceType
@@ -25,7 +25,7 @@ import ch.srgssr.pillarbox.ui.widget.player.SurfaceType
 fun SphericalSurfaceShowcase() {
     val context = LocalContext.current
     val player = remember {
-        PlayerModule.provideDefaultPlayer(context = context).apply {
+        PillarboxExoPlayer(context = context).apply {
             setMediaItem(SRGMediaItem("urn:rts:video:8414077"))
             repeatMode = Player.REPEAT_MODE_ONE
         }


### PR DESCRIPTION
# Pull request

## Description

Some show case demo doesn't work anymore since we introduce preload configuration by default in the demo DI. The showcases that doesn't work are:
- 360° showcase
-  Mutliplayer showcase

## Changes made

- Create PillarboxExoPlayer without preload configuration

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
