### PR TITLE
Allow getting the device info from `PillarboxCastPlayer`

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -91,11 +91,12 @@ abstract class PillarboxCastPlayerBuilder {
 
     internal fun create(context: Context): PillarboxCastPlayer {
         return PillarboxCastPlayer(
-            context.getCastContext(),
-            mediaItemConverter,
-            seekBackIncrement.inWholeMilliseconds,
-            seekForwardIncrement.inWholeMilliseconds,
-            maxSeekToPreviousPosition.inWholeMilliseconds,
+            context = context,
+            castContext = context.getCastContext(),
+            mediaItemConverter = mediaItemConverter,
+            seekBackIncrementMs = seekBackIncrement.inWholeMilliseconds,
+            seekForwardIncrementMs = seekForwardIncrement.inWholeMilliseconds,
+            maxSeekToPreviousPositionMs = maxSeekToPreviousPosition.inWholeMilliseconds,
         ).apply {
             if (onCastSessionAvailable == null && onCastSessionUnavailable == null) return@apply
             setSessionAvailabilityListener(object : SessionAvailabilityListener {


### PR DESCRIPTION
# Pull request

## Description

This PR adds the necessary logic for the `getDeviceInfo()` to function as expected. The implementation is based on what is done in [Media3 1.6.0](https://github.com/androidx/media/blob/1.6.0/libraries/cast/src/main/java/androidx/media3/cast/CastPlayer.java#L1572).

## Changes made

- Use [MediaRouter2](https://developer.android.com/reference/android/media/MediaRouter2) from Android API 30+ to observe controller changes.
- Set the `deviceInfo` field of the Player `State` object.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).