### PR TITLE
Handle seek to time

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -449,6 +449,7 @@ class PillarboxCastPlayer internal constructor(
                     " position = ${remoteMediaClient?.mediaStatus?.streamPosition?.milliseconds}" +
                     " duration = ${remoteMediaClient?.mediaStatus?.mediaInfo?.streamDuration?.milliseconds}"
             )
+            positionSupplier.position = remoteMediaClient?.getContentPositionMs() ?: 0
             invalidateState()
         }
 

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -294,7 +294,6 @@ class PillarboxCastPlayer internal constructor(
 
     override fun handleSetDeviceMuted(muted: Boolean, flags: Int) = withRemoteClient {
         setStreamMute(muted)
-        seekToNext()
     }
 
     override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: @Player.Command Int) = withRemoteClient {

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -173,7 +173,7 @@ class PillarboxCastPlayer internal constructor(
         val itemCount = remoteMediaClient.mediaQueue.itemCount
         val hasNextItem = !isPlayingAd && currentItemIndex + 1 < itemCount
         val hasPreviousItem = !isPlayingAd && currentItemIndex - 1 >= 0
-        val canSeek = !isPlayingAd && isCommandSupported(MediaStatus.COMMAND_SEEK) && contentDurationMs != C.TIME_UNSET
+        val canSeek = itemCount > 0 && !isPlayingAd && isCommandSupported(MediaStatus.COMMAND_SEEK) && contentDurationMs != C.TIME_UNSET
         val canSeekBack = canSeek && contentPositionMs != C.TIME_UNSET && contentPositionMs - seekBackIncrementMs > 0
         val canSeekForward = canSeek && contentPositionMs + seekForwardIncrementMs < contentDurationMs
         val hasNext = hasNextItem || canSeek
@@ -197,7 +197,13 @@ class PillarboxCastPlayer internal constructor(
             .setAvailableCommands(availableCommands)
             .setPlaybackState(if (playlist.isNotEmpty()) remoteMediaClient.getPlaybackState() else STATE_IDLE)
             .setPlaylist(playlist)
-            .setContentPositionMs(positionSupplier)
+            .apply {
+                if (itemCount > 0) {
+                    setContentPositionMs(positionSupplier)
+                } else {
+                    setContentPositionMs(C.TIME_UNSET)
+                }
+            }
             .setCurrentMediaItemIndex(currentItemIndex)
             .setPlayWhenReady(remoteMediaClient.isPlaying, PLAY_WHEN_READY_CHANGE_REASON_REMOTE)
             .setShuffleModeEnabled(false)

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -425,8 +425,8 @@ class PillarboxCastPlayer internal constructor(
         }
 
         override fun onProgressUpdated(position: Long, duration: Long) {
-            position.takeIf { it != MediaInfo.UNKNOWN_DURATION } ?: C.TIME_UNSET
-            this.position = position
+            position.takeIf { it != MediaInfo.UNKNOWN_DURATION } ?: 0L
+            this.position = position - (remoteMediaClient?.approximateLiveSeekableRangeStart ?: 0L)
             invalidateState()
         }
     }

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/CastExtensionsTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/CastExtensionsTest.kt
@@ -71,7 +71,7 @@ class CastExtensionsTest {
         val listenerSlot = slot<SessionAvailabilityListener>()
         val castPlayer = mockk<PillarboxCastPlayer> {
             every { isCastSessionAvailable() } returns false
-            justRun { sessionAvailabilityListener = capture(listenerSlot) }
+            justRun { setSessionAvailabilityListener(capture(listenerSlot)) }
         }
 
         castPlayer.isCastSessionAvailableAsFlow().test {


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to add the seek in time feature into `PillarboxCastPlayer`.

## Changes made
 - PillarboxCastPlayer invalidateState is called periodically by ProgressListener.
 - Handles `seekTo`, `seekBack`, `seekForward`.
 - Improve `seekToPrevious` and `seekToNext`.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
