### PR TITLE
Align naming with Apple and commandersAct dashboard

### DIFF
--- a/pillarbox-analytics/docs/README.md
+++ b/pillarbox-analytics/docs/README.md
@@ -31,7 +31,7 @@ class MyApplication : Application() {
         val config = AnalyticsConfig(
             vendor = AnalyticsConfig.Vendor.SRG,
             appSiteName = "Your AppSiteName here",
-            sourceKey = SourceKey.SRG_DEBUG,
+            sourceKey = SourceKey.DEVELOPMENT,
             nonLocalizedApplicationName = "Your non-localized AppSiteName here",
         )
 
@@ -56,7 +56,7 @@ val userConsent = UserConsent(
 val config = AnalyticsConfig(
     vendor = AnalyticsConfig.Vendor.SRG,
     appSiteName = "Your AppSiteName here",
-    sourceKey = SourceKey.SRG_DEBUG,
+    sourceKey = SourceKey.DEVELOPMENT,
     nonLocalizedApplicationName = "Your non-localized AppSiteName here",
     userConsent = userConsent,
 )

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
@@ -43,19 +43,4 @@ data class AnalyticsConfig(
         SRF,
         RTR
     }
-
-    companion object {
-
-        /**
-         * The source key for SRG SSR apps in production.
-         */
-        @Deprecated("Use [SourceKey.SRG_PROD] instead.", ReplaceWith("SourceKey.SRG_PROD"))
-        val SOURCE_KEY_PRODUCTION = SourceKey.PRODUCTION
-
-        /**
-         * The source key for SRG SSR apps in development.
-         */
-        @Deprecated("Use [SourceKey.SRG_DEBUG] instead.", ReplaceWith("SourceKey.SRG_DEBUG"))
-        val SOURCE_KEY_DEVELOPMENT = SourceKey.DEVELOPMENT
-    }
 }

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
@@ -15,8 +15,8 @@ import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
  *
  * @property vendor The vendor to which the application belongs to.
  * @property appSiteName The name of the app/site being tracked, given by the analytics team.
- * @property sourceKey The CommandersAct source key. Production apps should use [SourceKey.SRG_PROD], and apps in development should use
- * [SourceKey.SRG_DEBUG].
+ * @property sourceKey The CommandersAct source key. Production apps should use [SourceKey.PRODUCTION], and apps in development should use
+ * [SourceKey.DEVELOPMENT].
  * @property nonLocalizedApplicationName The non-localized name of the application. By default, the application name defined in the manifest is used.
  * @property userConsent The user consent to transmit to ComScore and CommandersAct.
  * @property comScorePersistentLabels The initial persistent labels for ComScore analytics.
@@ -50,12 +50,12 @@ data class AnalyticsConfig(
          * The source key for SRG SSR apps in production.
          */
         @Deprecated("Use [SourceKey.SRG_PROD] instead.", ReplaceWith("SourceKey.SRG_PROD"))
-        val SOURCE_KEY_SRG_PROD = SourceKey.SRG_PROD
+        val SOURCE_KEY_PRODUCTION = SourceKey.PRODUCTION
 
         /**
          * The source key for SRG SSR apps in development.
          */
         @Deprecated("Use [SourceKey.SRG_DEBUG] instead.", ReplaceWith("SourceKey.SRG_DEBUG"))
-        val SOURCE_KEY_SRG_DEBUG = SourceKey.SRG_DEBUG
+        val SOURCE_KEY_DEVELOPMENT = SourceKey.DEVELOPMENT
     }
 }

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SRGAnalytics.kt
@@ -34,7 +34,7 @@ import ch.srgssr.pillarbox.analytics.comscore.NoOpComScore
  *          val config = AnalyticsConfig(
  *              vendor = AnalyticsConfig.Vendor.SRG,
  *              appSiteName = "Your AppSiteName here",
- *              sourceKey = SourceKey.SRG_DEBUG,
+ *              sourceKey = SourceKey.DEVELOPMENT,
  *              nonLocalizedApplicationName = "Your non-localized AppSiteName here",
  *          )
  *

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SourceKey.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/SourceKey.kt
@@ -13,10 +13,10 @@ enum class SourceKey(val key: String) {
     /**
      * The source key for SRG SSR apps in production.
      */
-    SRG_PROD("3909d826-0845-40cc-a69a-6cec1036a45c"),
+    PRODUCTION("3909d826-0845-40cc-a69a-6cec1036a45c"),
 
     /**
      * The source key for SRG SSR apps in development.
      */
-    SRG_DEBUG("6f6bf70e-4129-4e47-a9be-ccd1737ba35f"),
+    DEVELOPMENT("6f6bf70e-4129-4e47-a9be-ccd1737ba35f"),
 }

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
@@ -22,7 +22,7 @@ class SRGAnalyticsSingletonTest {
     private val config = AnalyticsConfig(
         vendor = AnalyticsConfig.Vendor.SRG,
         appSiteName = "pillarbox-test-android",
-        sourceKey = SourceKey.SRG_DEBUG
+        sourceKey = SourceKey.DEVELOPMENT
     )
 
     private lateinit var context: Context

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TestUtils.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TestUtils.kt
@@ -11,6 +11,6 @@ object TestUtils {
     val analyticsConfig = AnalyticsConfig(
         vendor = AnalyticsConfig.Vendor.SRG,
         appSiteName = "pillarbox-test-android",
-        sourceKey = SourceKey.SRG_DEBUG
+        sourceKey = SourceKey.DEVELOPMENT
     )
 }

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
@@ -28,7 +28,7 @@ class ComScoreSrgTest {
     private val config = AnalyticsConfig(
         vendor = AnalyticsConfig.Vendor.SRG,
         appSiteName = "pillarbox-test-android",
-        sourceKey = SourceKey.SRG_DEBUG
+        sourceKey = SourceKey.DEVELOPMENT
     )
 
     private lateinit var context: Context

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
@@ -34,7 +34,7 @@ class DemoApplication : Application(), SingletonImageLoader.Factory {
             vendor = AnalyticsConfig.Vendor.SRG,
             nonLocalizedApplicationName = "Pillarbox",
             appSiteName = "pillarbox-demo-android",
-            sourceKey = SourceKey.SRG_DEBUG,
+            sourceKey = SourceKey.DEVELOPMENT,
             userConsent = initialUserConsent
         )
         initSRGAnalytics(config = config)


### PR DESCRIPTION
# Pull request

## Description

This PR renames commanders act source key enum names to match the name from apple and commanders act dashboard.

## Changes made

- Rename `SourceKey.SRG_PROD` to `SourceKey.PRODUTION`.
- Rename `SourceKey.SRG_DEBUG` to `SourceKey.DEVELOPMENT`.
- Remove depreciated symbols `AnalyticsConfig.SOURCE_KEY_SRG_PROD` and `AnalyticsConfig.SOURCE_KEY_SRG_DEBUG`.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
