### PR TITLE
Add support for playback speed in `PillarboxCastPlayer`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-# Pull request
-
 ## Description
 
 > Describe your changes with sufficient details (e.g., implementation considerations, design choices, etc.). For bug reports, please mention the issue number that was fixed. If no matching bug report exists, you should [open one](https://github.com/SRGSSR/pillarbox-android/issues/new?template=bug_report.yml) first.

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -19,6 +19,7 @@ import androidx.media3.common.C
 import androidx.media3.common.DeviceInfo
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.SimpleBasePlayer
 import androidx.media3.common.TrackSelectionParameters
@@ -33,6 +34,7 @@ import ch.srgssr.pillarbox.player.PillarboxPlayer
 import com.google.android.gms.cast.CastStatusCodes
 import com.google.android.gms.cast.MediaError
 import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaLoadOptions
 import com.google.android.gms.cast.MediaQueueItem
 import com.google.android.gms.cast.MediaSeekOptions
 import com.google.android.gms.cast.MediaStatus
@@ -111,6 +113,7 @@ class PillarboxCastPlayer internal constructor(
             }
         }
 
+    private var playlistMetadata: MediaMetadata = MediaMetadata.EMPTY
     private var sessionAvailabilityListener: SessionAvailabilityListener? = null
     private var playlistTracker: MediaQueueTracker? = null
 
@@ -191,6 +194,7 @@ class PillarboxCastPlayer internal constructor(
             .addIf(COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM, canSeek)
             .addIf(COMMAND_SEEK_BACK, canSeekBack)
             .addIf(COMMAND_SEEK_FORWARD, canSeekForward)
+            .addIf(COMMAND_SET_SPEED_AND_PITCH, isCommandSupported(MediaStatus.COMMAND_PLAYBACK_RATE))
             .build()
         val playlist = remoteMediaClient.createPlaylist()
         return State.Builder()
@@ -214,6 +218,8 @@ class PillarboxCastPlayer internal constructor(
             .setMaxSeekToPreviousPositionMs(maxSeekToPreviousPositionMs)
             .setSeekBackIncrementMs(seekBackIncrementMs)
             .setSeekForwardIncrementMs(seekForwardIncrementMs)
+            .setPlaybackParameters(PlaybackParameters(remoteMediaClient.getPlaybackRate()))
+            .setPlaylistMetadata(playlistMetadata)
             .build()
     }
 
@@ -345,6 +351,19 @@ class PillarboxCastPlayer internal constructor(
 
             else -> super.handleSeek(mediaItemIndex, positionMs, seekCommand)
         }
+    }
+
+    override fun handleSetPlaybackParameters(playbackParameters: PlaybackParameters) = withRemoteClient {
+        val playbackRate = playbackParameters.speed.toDouble().coerceIn(MediaLoadOptions.PLAYBACK_RATE_MIN, MediaLoadOptions.PLAYBACK_RATE_MAX)
+
+        setPlaybackRate(playbackRate)
+    }
+
+    override fun handleSetPlaylistMetadata(playlistMetadata: MediaMetadata): ListenableFuture<*> {
+        this@PillarboxCastPlayer.playlistMetadata = playlistMetadata
+        invalidateState()
+
+        return Futures.immediateVoidFuture()
     }
 
     private fun seekTo(remoteMediaClient: RemoteMediaClient, positionMs: Long): PendingResult<MediaChannelResult> {
@@ -587,6 +606,7 @@ class PillarboxCastPlayer internal constructor(
                 COMMAND_SET_SHUFFLE_MODE,
                 COMMAND_SET_REPEAT_MODE,
                 COMMAND_GET_VOLUME,
+                COMMAND_SET_PLAYLIST_METADATA,
             )
             .build()
 
@@ -671,4 +691,8 @@ private fun RemoteMediaClient.getVolume(): Double {
 
 private fun RemoteMediaClient.isMuted(): Boolean {
     return mediaStatus?.isMute == true
+}
+
+private fun RemoteMediaClient.getPlaybackRate(): Float {
+    return mediaStatus?.playbackRate?.toFloat() ?: PlaybackParameters.DEFAULT.speed
 }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -360,8 +360,10 @@ class PillarboxCastPlayer internal constructor(
     }
 
     override fun handleSetPlaylistMetadata(playlistMetadata: MediaMetadata): ListenableFuture<*> {
-        this@PillarboxCastPlayer.playlistMetadata = playlistMetadata
-        invalidateState()
+        if (this.playlistMetadata != playlistMetadata) {
+            this.playlistMetadata = playlistMetadata
+            invalidateState()
+        }
 
         return Futures.immediateVoidFuture()
     }


### PR DESCRIPTION
## Description

This PR adds support for setting the playback speed to a `PillarboxCastPlayer`.

## Changes made

- Add support for setting the playback parameters in `PillarboxCastPlayer`, in particular to handle playback speed (the pitch value is ignored).
- Add support for setting the playlist metadata in `PillarboxCastPlayer` (see the corresponding [Media3 PR](https://github.com/androidx/media/pull/2235)).
- Remove the `Pull request` title from the Pull Request template, since its redundant.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).