### PR TITLE
Add the VPN blocking reason

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
@@ -111,11 +111,12 @@ sealed class BlockReasonException(message: String) : IOException(message) {
     }
 
     /**
-     * Represents an exception thrown when a [Chapter] is blocked due to the usage of a VPN. This corresponds to [BlockReason.VPNPROXYDETECTED].
+     * Represents an exception thrown when a [Chapter] is blocked due to the usage of a VPN or a proxy. This corresponds to
+     * [BlockReason.VPNORPROXYDETECTED].
      */
-    class VPNProxyDetected : BlockReasonException(BlockReason.VPNPROXYDETECTED) {
+    class VPNOrProxyDetected : BlockReasonException(BlockReason.VPNORPROXYDETECTED) {
         override val messageResId: Int
-            get() = R.string.blockReason_vpn_proxy_detected
+            get() = R.string.blockReason_vpn_or_proxy_detected
     }
 
     /**

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
@@ -113,7 +113,7 @@ sealed class BlockReasonException(message: String) : IOException(message) {
     /**
      * Represents an exception thrown when a [Chapter] is blocked due to the usage of a VPN. This corresponds to [BlockReason.VPNPROXYDETECTED].
      */
-    class VPNProxyYDetected : BlockReasonException(BlockReason.VPNPROXYDETECTED) {
+    class VPNProxyDetected : BlockReasonException(BlockReason.VPNPROXYDETECTED) {
         override val messageResId: Int
             get() = R.string.blockReason_vpn_proxy_detected
     }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonException.kt
@@ -111,6 +111,14 @@ sealed class BlockReasonException(message: String) : IOException(message) {
     }
 
     /**
+     * Represents an exception thrown when a [Chapter] is blocked due to the usage of a VPN. This corresponds to [BlockReason.VPNPROXYDETECTED].
+     */
+    class VPNProxyYDetected : BlockReasonException(BlockReason.VPNPROXYDETECTED) {
+        override val messageResId: Int
+            get() = R.string.blockReason_vpn_proxy_detected
+    }
+
+    /**
      * Represents an exception thrown when a [Chapter] is blocked for an unknown reason. This corresponds to [BlockReason.UNKNOWN].
      */
     class Unknown : BlockReasonException(BlockReason.UNKNOWN)

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/Chapter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/Chapter.kt
@@ -14,6 +14,7 @@ import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Journali
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Legal
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.StartDate
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Unknown
+import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.VPNProxyYDetected
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.BlockReason
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 
@@ -33,6 +34,7 @@ fun Chapter.getBlockReasonExceptionOrNull(): BlockReasonException? {
         BlockReason.GEOBLOCK -> GeoBlock()
         BlockReason.COMMERCIAL -> Commercial()
         BlockReason.JOURNALISTIC -> Journalistic()
+        BlockReason.VPNPROXYDETECTED -> VPNProxyYDetected()
         BlockReason.UNKNOWN -> Unknown()
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/Chapter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/Chapter.kt
@@ -14,7 +14,7 @@ import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Journali
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Legal
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.StartDate
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Unknown
-import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.VPNProxyDetected
+import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.VPNOrProxyDetected
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.BlockReason
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 
@@ -34,7 +34,7 @@ fun Chapter.getBlockReasonExceptionOrNull(): BlockReasonException? {
         BlockReason.GEOBLOCK -> GeoBlock()
         BlockReason.COMMERCIAL -> Commercial()
         BlockReason.JOURNALISTIC -> Journalistic()
-        BlockReason.VPNPROXYDETECTED -> VPNProxyDetected()
+        BlockReason.VPNORPROXYDETECTED -> VPNOrProxyDetected()
         BlockReason.UNKNOWN -> Unknown()
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/Chapter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/extension/Chapter.kt
@@ -14,7 +14,7 @@ import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Journali
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Legal
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.StartDate
 import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.Unknown
-import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.VPNProxyYDetected
+import ch.srgssr.pillarbox.core.business.exception.BlockReasonException.VPNProxyDetected
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.BlockReason
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 
@@ -34,7 +34,7 @@ fun Chapter.getBlockReasonExceptionOrNull(): BlockReasonException? {
         BlockReason.GEOBLOCK -> GeoBlock()
         BlockReason.COMMERCIAL -> Commercial()
         BlockReason.JOURNALISTIC -> Journalistic()
-        BlockReason.VPNPROXYDETECTED -> VPNProxyYDetected()
+        BlockReason.VPNPROXYDETECTED -> VPNProxyDetected()
         BlockReason.UNKNOWN -> Unknown()
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
@@ -49,6 +49,11 @@ enum class BlockReason {
     JOURNALISTIC,
 
     /**
+     * The [Chapter] is blocked due to the usage of a VPN.
+     */
+    VPNPROXYDETECTED,
+
+    /**
      * The [Chapter] is blocked for an unknown reason.
      */
     UNKNOWN,

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/data/BlockReason.kt
@@ -49,9 +49,9 @@ enum class BlockReason {
     JOURNALISTIC,
 
     /**
-     * The [Chapter] is blocked due to the usage of a VPN.
+     * The [Chapter] is blocked due to the usage of a VPN or a proxy.
      */
-    VPNPROXYDETECTED,
+    VPNORPROXYDETECTED,
 
     /**
      * The [Chapter] is blocked for an unknown reason.

--- a/pillarbox-core-business/src/main/res/values-de/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-de/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
@@ -16,5 +15,6 @@
     <string name="blockReason_startDate">Dieser Inhalt ist noch nicht verfügbar.</string>
     <string name="blockReason_endDate">Dieser Inhalt ist nicht mehr verfügbar.</string>
     <string name="blockReason_journalistic">Dieser Inhalt steht aus publizistischen Gründen vorübergehend nicht zur Verfügung.</string>
+    <string name="blockReason_vpn_proxy_detected">Dieser Inhalt ist mit VPN oder Proxy nicht abspielbar.</string>
     <string name="blockReason_unknown">Dieser Inhalt ist nicht verfügbar.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values-de/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-de/strings.xml
@@ -15,6 +15,6 @@
     <string name="blockReason_startDate">Dieser Inhalt ist noch nicht verfügbar.</string>
     <string name="blockReason_endDate">Dieser Inhalt ist nicht mehr verfügbar.</string>
     <string name="blockReason_journalistic">Dieser Inhalt steht aus publizistischen Gründen vorübergehend nicht zur Verfügung.</string>
-    <string name="blockReason_vpn_proxy_detected">Dieser Inhalt ist mit VPN oder Proxy nicht abspielbar.</string>
+    <string name="blockReason_vpn_or_proxy_detected">Dieser Inhalt ist mit VPN oder Proxy nicht abspielbar.</string>
     <string name="blockReason_unknown">Dieser Inhalt ist nicht verfügbar.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values-fr/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-fr/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
@@ -16,5 +15,6 @@
     <string name="blockReason_startDate">Ce contenu n’est pas encore disponible.</string>
     <string name="blockReason_endDate">Ce contenu n’est plus disponible.</string>
     <string name="blockReason_journalistic">Ce contenu est temporairement indisponible pour des raisons éditoriales.</string>
+    <string name="blockReason_vpn_proxy_detected">Ce contenu ne peut pas être lu avec un VPN ou un proxy.</string>
     <string name="blockReason_unknown">Ce contenu n’est pas disponible.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values-fr/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-fr/strings.xml
@@ -15,6 +15,6 @@
     <string name="blockReason_startDate">Ce contenu n’est pas encore disponible.</string>
     <string name="blockReason_endDate">Ce contenu n’est plus disponible.</string>
     <string name="blockReason_journalistic">Ce contenu est temporairement indisponible pour des raisons éditoriales.</string>
-    <string name="blockReason_vpn_proxy_detected">Ce contenu ne peut pas être lu avec un VPN ou un proxy.</string>
+    <string name="blockReason_vpn_or_proxy_detected">Ce contenu ne peut pas être lu avec un VPN ou un proxy.</string>
     <string name="blockReason_unknown">Ce contenu n’est pas disponible.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values-it/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-it/strings.xml
@@ -15,6 +15,6 @@
     <string name="blockReason_startDate">Questo contenuto non è ancora disponibile.</string>
     <string name="blockReason_endDate">Questo contenuto non è più disponibile.</string>
     <string name="blockReason_journalistic">Questo contenuto è temporaneamente non disponibile per motivi editoriali.</string>
-    <string name="blockReason_vpn_proxy_detected">Questo contenuto non può essere riprodotto con VPN o proxy.</string>
+    <string name="blockReason_vpn_or_proxy_detected">Questo contenuto non può essere riprodotto con VPN o proxy.</string>
     <string name="blockReason_unknown">Questo contenuto non è disponibile.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values-it/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-it/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
@@ -16,5 +15,6 @@
     <string name="blockReason_startDate">Questo contenuto non è ancora disponibile.</string>
     <string name="blockReason_endDate">Questo contenuto non è più disponibile.</string>
     <string name="blockReason_journalistic">Questo contenuto è temporaneamente non disponibile per motivi editoriali.</string>
+    <string name="blockReason_vpn_proxy_detected">Questo contenuto non può essere riprodotto con VPN o proxy.</string>
     <string name="blockReason_unknown">Questo contenuto non è disponibile.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values-rm/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-rm/strings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) SRG SSR. All rights reserved.
   ~ License information is available from the LICENSE file.
   -->
@@ -16,5 +15,6 @@
     <string name="blockReason_startDate">Quest medium n\'è betg anc disponibel.</string>
     <string name="blockReason_endDate">Quest medium n\'è betg pli disponibel.</string>
     <string name="blockReason_journalistic">Quest cuntegn na stat ad interim betg a disposiziun per motivs publicistics.</string>
+    <string name="blockReason_vpn_proxy_detected">Quest cuntegn na po betg vegnir reproducì cun VPN ni proxy activà.</string>
     <string name="blockReason_unknown">Quest medium n\'è betg disponibel.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values-rm/strings.xml
+++ b/pillarbox-core-business/src/main/res/values-rm/strings.xml
@@ -15,6 +15,6 @@
     <string name="blockReason_startDate">Quest medium n\'è betg anc disponibel.</string>
     <string name="blockReason_endDate">Quest medium n\'è betg pli disponibel.</string>
     <string name="blockReason_journalistic">Quest cuntegn na stat ad interim betg a disposiziun per motivs publicistics.</string>
-    <string name="blockReason_vpn_proxy_detected">Quest cuntegn na po betg vegnir reproducì cun VPN ni proxy activà.</string>
+    <string name="blockReason_vpn_or_proxy_detected">Quest cuntegn na po betg vegnir reproducì cun VPN ni proxy activà.</string>
     <string name="blockReason_unknown">Quest medium n\'è betg disponibel.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values/strings.xml
+++ b/pillarbox-core-business/src/main/res/values/strings.xml
@@ -15,5 +15,6 @@
     <string name="blockReason_startDate">This content is not available yet.</string>
     <string name="blockReason_endDate">This content is not available anymore.</string>
     <string name="blockReason_journalistic">This content is temporarily unavailable for journalistic reasons.</string>
+    <string name="blockReason_vpn_proxy_detected">This content cannot be played while using a VPN or a proxy.</string>
     <string name="blockReason_unknown">This content is not available.</string>
 </resources>

--- a/pillarbox-core-business/src/main/res/values/strings.xml
+++ b/pillarbox-core-business/src/main/res/values/strings.xml
@@ -15,6 +15,6 @@
     <string name="blockReason_startDate">This content is not available yet.</string>
     <string name="blockReason_endDate">This content is not available anymore.</string>
     <string name="blockReason_journalistic">This content is temporarily unavailable for journalistic reasons.</string>
-    <string name="blockReason_vpn_proxy_detected">This content cannot be played while using a VPN or a proxy.</string>
+    <string name="blockReason_vpn_or_proxy_detected">This content cannot be played while using a VPN or a proxy.</string>
     <string name="blockReason_unknown">This content is not available.</string>
 </resources>

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonExceptionTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonExceptionTest.kt
@@ -28,7 +28,7 @@ class BlockReasonExceptionTest {
             BlockReason.GEOBLOCK to BlockReasonException.GeoBlock::class,
             BlockReason.COMMERCIAL to BlockReasonException.Commercial::class,
             BlockReason.JOURNALISTIC to BlockReasonException.Journalistic::class,
-            BlockReason.VPNPROXYDETECTED to BlockReasonException.VPNProxyYDetected::class,
+            BlockReason.VPNPROXYDETECTED to BlockReasonException.VPNProxyDetected::class,
             BlockReason.UNKNOWN to BlockReasonException.Unknown::class,
         )
         BlockReason.entries.forEach { blockReason ->
@@ -97,7 +97,7 @@ class BlockReasonExceptionTest {
         assertEquals(R.string.blockReason_legal, BlockReasonException.Legal().messageResId)
         assertEquals(R.string.blockReason_startDate, BlockReasonException.StartDate(null).messageResId)
         assertEquals(R.string.blockReason_journalistic, BlockReasonException.Journalistic().messageResId)
-        assertEquals(R.string.blockReason_vpn_proxy_detected, BlockReasonException.VPNProxyYDetected().messageResId)
+        assertEquals(R.string.blockReason_vpn_proxy_detected, BlockReasonException.VPNProxyDetected().messageResId)
         assertEquals(R.string.blockReason_unknown, BlockReasonException.Unknown().messageResId)
     }
 }

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonExceptionTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonExceptionTest.kt
@@ -28,6 +28,7 @@ class BlockReasonExceptionTest {
             BlockReason.GEOBLOCK to BlockReasonException.GeoBlock::class,
             BlockReason.COMMERCIAL to BlockReasonException.Commercial::class,
             BlockReason.JOURNALISTIC to BlockReasonException.Journalistic::class,
+            BlockReason.VPNPROXYDETECTED to BlockReasonException.VPNProxyYDetected::class,
             BlockReason.UNKNOWN to BlockReasonException.Unknown::class,
         )
         BlockReason.entries.forEach { blockReason ->
@@ -96,6 +97,7 @@ class BlockReasonExceptionTest {
         assertEquals(R.string.blockReason_legal, BlockReasonException.Legal().messageResId)
         assertEquals(R.string.blockReason_startDate, BlockReasonException.StartDate(null).messageResId)
         assertEquals(R.string.blockReason_journalistic, BlockReasonException.Journalistic().messageResId)
+        assertEquals(R.string.blockReason_vpn_proxy_detected, BlockReasonException.VPNProxyYDetected().messageResId)
         assertEquals(R.string.blockReason_unknown, BlockReasonException.Unknown().messageResId)
     }
 }

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonExceptionTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/exception/BlockReasonExceptionTest.kt
@@ -28,7 +28,7 @@ class BlockReasonExceptionTest {
             BlockReason.GEOBLOCK to BlockReasonException.GeoBlock::class,
             BlockReason.COMMERCIAL to BlockReasonException.Commercial::class,
             BlockReason.JOURNALISTIC to BlockReasonException.Journalistic::class,
-            BlockReason.VPNPROXYDETECTED to BlockReasonException.VPNProxyDetected::class,
+            BlockReason.VPNORPROXYDETECTED to BlockReasonException.VPNOrProxyDetected::class,
             BlockReason.UNKNOWN to BlockReasonException.Unknown::class,
         )
         BlockReason.entries.forEach { blockReason ->
@@ -97,7 +97,7 @@ class BlockReasonExceptionTest {
         assertEquals(R.string.blockReason_legal, BlockReasonException.Legal().messageResId)
         assertEquals(R.string.blockReason_startDate, BlockReasonException.StartDate(null).messageResId)
         assertEquals(R.string.blockReason_journalistic, BlockReasonException.Journalistic().messageResId)
-        assertEquals(R.string.blockReason_vpn_proxy_detected, BlockReasonException.VPNProxyDetected().messageResId)
+        assertEquals(R.string.blockReason_vpn_or_proxy_detected, BlockReasonException.VPNOrProxyDetected().messageResId)
         assertEquals(R.string.blockReason_unknown, BlockReasonException.Unknown().messageResId)
     }
 }


### PR DESCRIPTION
## Description

This PR adds support for the VPN blocking reason.

## Changes made

- Add the `VPN` blocking reason.
- Add the corresponding `VPN` exception.
- Add the corresponding translations.
- Update the tests.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).