### PR TITLE
933 custom cast handle tracks

### DIFF
--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryTestedModulePlugin.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/PillarboxAndroidLibraryTestedModulePlugin.kt
@@ -33,6 +33,7 @@ class PillarboxAndroidLibraryTestedModulePlugin : Plugin<Project> {
             testOptions {
                 unitTests {
                     isIncludeAndroidResources = true
+                    isReturnDefaultValues = true
                 }
             }
         }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/CastTrackSelector.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/CastTrackSelector.kt
@@ -14,14 +14,14 @@ import com.google.android.gms.cast.MediaTrack
 interface CastTrackSelector {
 
     /**
-     * Returns the indices of the currently selected media tracks.
+     * Returns the track ids of the currently selected media tracks.
      *
      * This function determines the active tracks based on the provided [parameters]
-     * and the available [tracks]. It returns an array containing the indices of these tracks.
+     * and the available [tracks]. It returns an array containing the ids of these tracks.
      *
      * @param parameters The track selection preferences.
      * @param tracks The available media tracks.
-     * @return An array of track indices for the selected tracks. Returns an empty array if no tracks are selected.
+     * @return An array of track ids for the selected tracks. Returns an empty array if no tracks are selected.
      * @see TrackSelectionParameters
      * @see Tracks
      */

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/CastTrackSelector.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/CastTrackSelector.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.cast
 
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
+import com.google.android.gms.cast.MediaTrack
 
 /**
  * Cast track selector
@@ -24,5 +25,5 @@ interface CastTrackSelector {
      * @see TrackSelectionParameters
      * @see Tracks
      */
-    fun getActiveMediaTracks(parameters: TrackSelectionParameters, tracks: Tracks): LongArray
+    fun getActiveMediaTracks(parameters: TrackSelectionParameters, tracks: List<MediaTrack>): LongArray
 }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/DefaultCastTrackSelector.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/DefaultCastTrackSelector.kt
@@ -6,7 +6,7 @@ package ch.srgssr.pillarbox.cast
 
 import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.TrackSelectionParameters
-import androidx.media3.common.Tracks
+import com.google.android.gms.cast.MediaTrack
 
 /**
  * Default cast track selector
@@ -16,7 +16,7 @@ object DefaultCastTrackSelector : CastTrackSelector {
 
     override fun getActiveMediaTracks(
         parameters: TrackSelectionParameters,
-        tracks: Tracks
+        tracks: List<MediaTrack>
     ): LongArray {
         return parameters.overrides.keys
             .mapNotNull { it.id.toLongOrNull() }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -404,9 +404,7 @@ class PillarboxCastPlayer internal constructor(
                         isLive = isLiveStream || mediaInfo?.streamType == MediaInfo.STREAM_TYPE_LIVE
                         isDynamic = mediaStatus?.liveSeekableRange?.isMovingWindow == true
                         duration = getContentDurationMs()
-                        tracks = mediaStatus?.let {
-                            getTracks(it)
-                        } ?: Tracks.EMPTY
+                        tracks = mediaStatus?.getTracks() ?: Tracks.EMPTY
                     } else {
                         duration = queueItem.media?.streamDuration.takeIf { it != MediaInfo.UNKNOWN_DURATION } ?: C.TIME_UNSET
                         isLive = queueItem.media?.streamType == MediaInfo.STREAM_TYPE_LIVE

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -44,7 +44,6 @@ import com.google.android.gms.cast.MediaError
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaSeekOptions
 import com.google.android.gms.cast.MediaStatus
-import com.google.android.gms.cast.MediaTrack
 import com.google.android.gms.cast.framework.CastContext
 import com.google.android.gms.cast.framework.CastSession
 import com.google.android.gms.cast.framework.SessionManagerListener
@@ -320,7 +319,7 @@ class PillarboxCastPlayer internal constructor(
 
     override fun handleSetTrackSelectionParameters(trackSelectionParameters: TrackSelectionParameters) = withRemoteClient {
         this@PillarboxCastPlayer.trackSelectionParameters = trackSelectionParameters
-        val mediaTrack = this.mediaStatus?.mediaInfo?.mediaTracks ?: emptyList<MediaTrack>()
+        val mediaTrack = this.mediaStatus?.mediaInfo?.mediaTracks.orEmpty()
         val selectedTrackIds = trackSelector.getActiveMediaTracks(trackSelectionParameters, mediaTrack)
         setActiveMediaTracks(selectedTrackIds)
     }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayerBuilder.kt
@@ -97,6 +97,7 @@ abstract class PillarboxCastPlayerBuilder {
             seekBackIncrementMs = seekBackIncrement.inWholeMilliseconds,
             seekForwardIncrementMs = seekForwardIncrement.inWholeMilliseconds,
             maxSeekToPreviousPositionMs = maxSeekToPreviousPosition.inWholeMilliseconds,
+            trackSelector = trackSelector,
         ).apply {
             if (onCastSessionAvailable == null && onCastSessionUnavailable == null) return@apply
             setSessionAvailabilityListener(object : SessionAvailabilityListener {

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/MediaTrack.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/MediaTrack.kt
@@ -14,7 +14,7 @@ internal fun MediaTrack.toFormat(): Format {
     val builder = Format.Builder()
     // Cast sends a contentType that isn't compatible with exoplayer Track type parsing.
     val trackType = MimeTypes.getTrackType(contentType)
-    var containerMimeType = if (trackType == C.TRACK_TYPE_UNKNOWN) {
+    val containerMimeType = if (trackType == C.TRACK_TYPE_UNKNOWN) {
         when (type) {
             MediaTrack.TYPE_AUDIO -> MimeTypes.AUDIO_UNKNOWN
             MediaTrack.TYPE_VIDEO -> MimeTypes.VIDEO_UNKNOWN

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/MediaTrack.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/MediaTrack.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.cast.extension
+
+import androidx.media3.common.C
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import com.google.android.gms.cast.MediaTrack
+
+const val CAST_TEXT_TRACK = MimeTypes.BASE_TYPE_TEXT + "/cast"
+
+internal fun MediaTrack.toFormat(): Format {
+    val builder = Format.Builder()
+    if (type == MediaTrack.TYPE_TEXT && MimeTypes.getTrackType(contentType) == C.TRACK_TYPE_UNKNOWN) {
+        builder.setSampleMimeType(CAST_TEXT_TRACK)
+    }
+    return builder
+        .setId(contentId)
+        .setContainerMimeType(contentType)
+        .setLanguage(language)
+        .build()
+}

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -6,7 +6,6 @@ package ch.srgssr.pillarbox.cast.extension
 
 import androidx.media3.common.C
 import androidx.media3.common.Player
-import androidx.media3.common.TrackGroup
 import androidx.media3.common.Tracks
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaQueueItem
@@ -75,7 +74,7 @@ internal fun RemoteMediaClient.getTracks(): Tracks {
     } else {
         val selectedTrackIds: LongArray = mediaStatus?.activeTrackIds ?: longArrayOf()
         val tabTrackGroup = mediaTracks.map { mediaTrack ->
-            val trackGroup = TrackGroup(mediaTrack.id.toString(), mediaTrack.toFormat())
+            val trackGroup = mediaTrack.toTrackGroup()
             Tracks.Group(trackGroup, false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(selectedTrackIds.contains(mediaTrack.id)))
         }
         Tracks(tabTrackGroup)

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.cast.extension
+
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.TrackGroup
+import androidx.media3.common.Tracks
+import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaQueueItem
+import com.google.android.gms.cast.MediaStatus
+import com.google.android.gms.cast.MediaTrack
+import com.google.android.gms.cast.framework.media.RemoteMediaClient
+
+internal fun RemoteMediaClient.getContentPositionMs(): Long {
+    return if (approximateStreamPosition == MediaInfo.UNKNOWN_DURATION) {
+        C.TIME_UNSET
+    } else {
+        // approximateLiveSeekableRangeStart = 0 when it is a seekable live.
+        approximateStreamPosition - approximateLiveSeekableRangeStart
+    }
+}
+
+internal fun RemoteMediaClient.getContentDurationMs(): Long {
+    return if (isLiveStream) {
+        approximateLiveSeekableRangeEnd - approximateLiveSeekableRangeStart
+    } else {
+        streamDuration.takeIf { it != MediaInfo.UNKNOWN_DURATION } ?: C.TIME_UNSET
+    }
+}
+
+internal fun RemoteMediaClient.getPlaybackState(): @Player.State Int {
+    if (mediaQueue.itemCount == 0) return Player.STATE_IDLE
+    return when (playerState) {
+        MediaStatus.PLAYER_STATE_IDLE, MediaStatus.PLAYER_STATE_UNKNOWN -> Player.STATE_IDLE
+        MediaStatus.PLAYER_STATE_PAUSED, MediaStatus.PLAYER_STATE_PLAYING -> Player.STATE_READY
+        MediaStatus.PLAYER_STATE_BUFFERING, MediaStatus.PLAYER_STATE_LOADING -> Player.STATE_BUFFERING
+        else -> Player.STATE_IDLE
+    }
+}
+
+internal fun RemoteMediaClient.getCurrentMediaItemIndex(): Int {
+    return currentItem?.let { mediaQueue.indexOfItemWithId(it.itemId) } ?: MediaQueueItem.INVALID_ITEM_ID
+}
+
+internal fun RemoteMediaClient.getMediaIdFromIndex(index: Int): Int {
+    return mediaQueue.itemIdAtIndex(index)
+}
+
+internal fun RemoteMediaClient.getRepeatMode(): @Player.RepeatMode Int {
+    return when (mediaStatus?.queueRepeatMode) {
+        MediaStatus.REPEAT_MODE_REPEAT_ALL,
+        MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE -> Player.REPEAT_MODE_ALL
+
+        MediaStatus.REPEAT_MODE_REPEAT_OFF -> Player.REPEAT_MODE_OFF
+        MediaStatus.REPEAT_MODE_REPEAT_SINGLE -> Player.REPEAT_MODE_ONE
+        else -> Player.REPEAT_MODE_OFF
+    }
+}
+
+internal fun RemoteMediaClient.getVolume(): Double {
+    return mediaStatus?.streamVolume ?: 0.0
+}
+
+internal fun RemoteMediaClient.isMuted(): Boolean {
+    return mediaStatus?.isMute == true
+}
+
+internal fun RemoteMediaClient.getTracks(): Tracks {
+    val mediaTracks = mediaInfo?.mediaTracks ?: emptyList<MediaTrack>()
+    return if (mediaTracks.isEmpty()) {
+        Tracks.EMPTY
+    } else {
+        val selectedTrackIds: LongArray = mediaStatus?.activeTrackIds ?: longArrayOf()
+        val tabTrackGroup = mediaTracks.map { mediaTrack ->
+            val trackGroup = TrackGroup(mediaTrack.id.toString(), mediaTrack.toFormat())
+            Tracks.Group(trackGroup, false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(selectedTrackIds.contains(mediaTrack.id)))
+        }
+        Tracks(tabTrackGroup)
+    }
+}

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/MediaTrackExtensionTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/MediaTrackExtensionTest.kt
@@ -4,10 +4,11 @@
  */
 package ch.srgssr.pillarbox.cast
 
+import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
-import ch.srgssr.pillarbox.cast.extension.CAST_TEXT_TRACK
-import ch.srgssr.pillarbox.cast.extension.toFormat
+import androidx.media3.common.TrackGroup
+import ch.srgssr.pillarbox.cast.extension.toTrackGroup
 import com.google.android.gms.cast.MediaTrack
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -17,15 +18,26 @@ import kotlin.test.assertEquals
 @RunWith(Parameterized::class)
 class MediaTrackExtensionTest(
     val mediaTrack: MediaTrack,
-    val format: Format
+    val trackGroup: TrackGroup
 ) {
 
     @Test
-    fun `MediaTrack to Format`() {
-        assertEquals(format, mediaTrack.toFormat())
+    fun `MediaTrack to TrackGroup`() {
+        assertEquals(trackGroup, mediaTrack.toTrackGroup())
+        assertEquals(trackGroup.type, getType(mediaTrack.type))
     }
 
     companion object {
+
+        private fun getType(castType: Int): Int {
+            return when (castType) {
+                MediaTrack.TYPE_AUDIO -> C.TRACK_TYPE_AUDIO
+                MediaTrack.TYPE_VIDEO -> C.TRACK_TYPE_VIDEO
+                MediaTrack.TYPE_TEXT -> C.TRACK_TYPE_TEXT
+                else -> C.TRACK_TYPE_UNKNOWN
+            }
+        }
+
         @JvmStatic
         @Parameterized.Parameters
         fun parameters(): Iterable<Any> {
@@ -33,49 +45,88 @@ class MediaTrackExtensionTest(
                 arrayOf(
                     MediaTrack.Builder(0, MediaTrack.TYPE_TEXT)
                         .setLanguage("en")
-                        .setContentType("unknown")
+                        .setContentType("mp4/webvtt")
                         .setContentId("ID")
                         .build(),
-                    Format.Builder()
-                        .setId("ID")
-                        .setSampleMimeType(CAST_TEXT_TRACK)
-                        .setContainerMimeType("unknown")
-                        .setLanguage("en")
-                        .build()
+                    TrackGroup(
+                        "0",
+                        Format.Builder()
+                            .setId("ID")
+                            .setContainerMimeType(MimeTypes.TEXT_UNKNOWN)
+                            .setLanguage("en")
+                            .build()
+                    )
                 ),
                 arrayOf(
-                    MediaTrack.Builder(0, MediaTrack.TYPE_AUDIO)
+                    MediaTrack.Builder(0, MediaTrack.TYPE_TEXT)
+                        .setLanguage("en")
+                        .setContentType(MimeTypes.APPLICATION_TTML)
+                        .setContentId("ID")
+                        .build(),
+                    TrackGroup(
+                        "0",
+                        Format.Builder()
+                            .setId("ID")
+                            .setContainerMimeType(MimeTypes.APPLICATION_TTML)
+                            .setLanguage("en")
+                            .build()
+                    )
+                ),
+                arrayOf(
+                    MediaTrack.Builder(1, MediaTrack.TYPE_AUDIO)
                         .setLanguage("en")
                         .setContentId("ID")
                         .setContentType("unknown")
                         .build(),
-                    Format.Builder()
-                        .setId("ID")
-                        .setLanguage("en")
-                        .setContainerMimeType("unknown")
-                        .build()
+                    TrackGroup(
+                        "1",
+                        Format.Builder()
+                            .setId("ID")
+                            .setLanguage("en")
+                            .setContainerMimeType(MimeTypes.AUDIO_UNKNOWN)
+                            .build()
+                    )
                 ),
                 arrayOf(
-                    MediaTrack.Builder(0, MediaTrack.TYPE_AUDIO)
+                    MediaTrack.Builder(2, MediaTrack.TYPE_AUDIO)
                         .setLanguage("en")
                         .setContentId("ID")
                         .setContentType(MimeTypes.AUDIO_AAC)
                         .build(),
-                    Format.Builder()
-                        .setId("ID")
-                        .setLanguage("en")
-                        .setContainerMimeType(MimeTypes.AUDIO_AAC)
-                        .build()
+                    TrackGroup(
+                        "2",
+                        Format.Builder()
+                            .setId("ID")
+                            .setLanguage("en")
+                            .setContainerMimeType(MimeTypes.AUDIO_AAC)
+                            .build()
+                    )
                 ),
                 arrayOf(
-                    MediaTrack.Builder(0, MediaTrack.TYPE_VIDEO)
+                    MediaTrack.Builder(3, MediaTrack.TYPE_VIDEO)
                         .setContentId("ID")
                         .setContentType(MimeTypes.VIDEO_H263)
                         .build(),
-                    Format.Builder()
-                        .setId("ID")
-                        .setContainerMimeType(MimeTypes.VIDEO_H263)
-                        .build()
+                    TrackGroup(
+                        "3",
+                        Format.Builder()
+                            .setId("ID")
+                            .setContainerMimeType(MimeTypes.VIDEO_H263)
+                            .build()
+                    )
+                ),
+                arrayOf(
+                    MediaTrack.Builder(3, MediaTrack.TYPE_VIDEO)
+                        .setContentId("ID")
+                        .setContentType("unknown")
+                        .build(),
+                    TrackGroup(
+                        "3",
+                        Format.Builder()
+                            .setId("ID")
+                            .setContainerMimeType(MimeTypes.VIDEO_UNKNOWN)
+                            .build()
+                    )
                 ),
             )
         }

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/MediaTrackExtensionTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/MediaTrackExtensionTest.kt
@@ -47,6 +47,7 @@ class MediaTrackExtensionTest(
                         .setLanguage("en")
                         .setContentType("mp4/webvtt")
                         .setContentId("ID")
+                        .setName("TextTrack1")
                         .build(),
                     TrackGroup(
                         "0",
@@ -54,6 +55,7 @@ class MediaTrackExtensionTest(
                             .setId("ID")
                             .setContainerMimeType(MimeTypes.TEXT_UNKNOWN)
                             .setLanguage("en")
+                            .setLabel("TextTrack1")
                             .build()
                     )
                 ),
@@ -92,12 +94,14 @@ class MediaTrackExtensionTest(
                         .setLanguage("en")
                         .setContentId("ID")
                         .setContentType(MimeTypes.AUDIO_AAC)
+                        .setName("AudioTrack1")
                         .build(),
                     TrackGroup(
                         "2",
                         Format.Builder()
                             .setId("ID")
                             .setLanguage("en")
+                            .setLabel("AudioTrack1")
                             .setContainerMimeType(MimeTypes.AUDIO_AAC)
                             .build()
                     )
@@ -106,12 +110,14 @@ class MediaTrackExtensionTest(
                     MediaTrack.Builder(3, MediaTrack.TYPE_VIDEO)
                         .setContentId("ID")
                         .setContentType(MimeTypes.VIDEO_H263)
+                        .setName("VideoTrack1")
                         .build(),
                     TrackGroup(
                         "3",
                         Format.Builder()
                             .setId("ID")
                             .setContainerMimeType(MimeTypes.VIDEO_H263)
+                            .setLabel("VideoTrack1")
                             .build()
                     )
                 ),

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/MediaTrackExtensionTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/MediaTrackExtensionTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.cast
+
+import androidx.media3.common.Format
+import androidx.media3.common.MimeTypes
+import ch.srgssr.pillarbox.cast.extension.CAST_TEXT_TRACK
+import ch.srgssr.pillarbox.cast.extension.toFormat
+import com.google.android.gms.cast.MediaTrack
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@RunWith(Parameterized::class)
+class MediaTrackExtensionTest(
+    val mediaTrack: MediaTrack,
+    val format: Format
+) {
+
+    @Test
+    fun `MediaTrack to Format`() {
+        assertEquals(format, mediaTrack.toFormat())
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun parameters(): Iterable<Any> {
+            return listOf(
+                arrayOf(
+                    MediaTrack.Builder(0, MediaTrack.TYPE_TEXT)
+                        .setLanguage("en")
+                        .setContentType("unknown")
+                        .setContentId("ID")
+                        .build(),
+                    Format.Builder()
+                        .setId("ID")
+                        .setSampleMimeType(CAST_TEXT_TRACK)
+                        .setContainerMimeType("unknown")
+                        .setLanguage("en")
+                        .build()
+                ),
+                arrayOf(
+                    MediaTrack.Builder(0, MediaTrack.TYPE_AUDIO)
+                        .setLanguage("en")
+                        .setContentId("ID")
+                        .setContentType("unknown")
+                        .build(),
+                    Format.Builder()
+                        .setId("ID")
+                        .setLanguage("en")
+                        .setContainerMimeType("unknown")
+                        .build()
+                ),
+                arrayOf(
+                    MediaTrack.Builder(0, MediaTrack.TYPE_AUDIO)
+                        .setLanguage("en")
+                        .setContentId("ID")
+                        .setContentType(MimeTypes.AUDIO_AAC)
+                        .build(),
+                    Format.Builder()
+                        .setId("ID")
+                        .setLanguage("en")
+                        .setContainerMimeType(MimeTypes.AUDIO_AAC)
+                        .build()
+                ),
+                arrayOf(
+                    MediaTrack.Builder(0, MediaTrack.TYPE_VIDEO)
+                        .setContentId("ID")
+                        .setContentType(MimeTypes.VIDEO_H263)
+                        .build(),
+                    Format.Builder()
+                        .setId("ID")
+                        .setContainerMimeType(MimeTypes.VIDEO_H263)
+                        .build()
+                ),
+            )
+        }
+    }
+}

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/RemoteMediaClientTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/RemoteMediaClientTest.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.cast
+
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.Tracks
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.srgssr.pillarbox.cast.extension.getContentDurationMs
+import ch.srgssr.pillarbox.cast.extension.getContentPositionMs
+import ch.srgssr.pillarbox.cast.extension.getCurrentMediaItemIndex
+import ch.srgssr.pillarbox.cast.extension.getPlaybackState
+import ch.srgssr.pillarbox.cast.extension.getRepeatMode
+import ch.srgssr.pillarbox.cast.extension.getTracks
+import ch.srgssr.pillarbox.cast.extension.getVolume
+import ch.srgssr.pillarbox.cast.extension.isMuted
+import ch.srgssr.pillarbox.cast.extension.toTrackGroup
+import com.google.android.gms.cast.MediaInfo
+import com.google.android.gms.cast.MediaQueueItem
+import com.google.android.gms.cast.MediaStatus
+import com.google.android.gms.cast.MediaTrack
+import com.google.android.gms.cast.framework.media.MediaQueue
+import com.google.android.gms.cast.framework.media.RemoteMediaClient
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import kotlin.test.assertEquals
+
+@RunWith(AndroidJUnit4::class)
+class RemoteMediaClientTest {
+
+    private lateinit var remoteMediaClient: RemoteMediaClient
+
+    @Before
+    fun setupTests() {
+        remoteMediaClient = mockk(relaxed = false)
+    }
+
+    @After
+    fun afterTests() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `getContentPositionMs returns TIME_UNSET`() {
+        every { remoteMediaClient.approximateStreamPosition } returns MediaInfo.UNKNOWN_DURATION
+        assertEquals(C.TIME_UNSET, remoteMediaClient.getContentPositionMs())
+    }
+
+    @Test
+    fun `getContentPositionMs returns position`() {
+        every { remoteMediaClient.approximateStreamPosition } returns 120L
+        every { remoteMediaClient.approximateLiveSeekableRangeStart } returns 0
+        assertEquals(120L, remoteMediaClient.getContentPositionMs())
+    }
+
+    @Test
+    fun `getContentPositionMs returns position with live window start position`() {
+        every { remoteMediaClient.approximateStreamPosition } returns 120L
+        every { remoteMediaClient.approximateLiveSeekableRangeStart } returns 20L
+        assertEquals(100L, remoteMediaClient.getContentPositionMs())
+    }
+
+    @Test
+    fun `getContentDuration returns TIME_UNSET`() {
+        every { remoteMediaClient.isLiveStream } returns false
+        every { remoteMediaClient.streamDuration } returns MediaInfo.UNKNOWN_DURATION
+        assertEquals(C.TIME_UNSET, remoteMediaClient.getContentDurationMs())
+    }
+
+    @Test
+    fun `getContentDuration returns streamDuration`() {
+        every { remoteMediaClient.isLiveStream } returns false
+        every { remoteMediaClient.streamDuration } returns 12334L
+        assertEquals(12334L, remoteMediaClient.getContentDurationMs())
+    }
+
+    @Test
+    fun `getContentDuration for live stream returns live window length`() {
+        every { remoteMediaClient.isLiveStream } returns true
+        every { remoteMediaClient.streamDuration } returns 100L
+        every { remoteMediaClient.approximateLiveSeekableRangeStart } returns 1000L
+        every { remoteMediaClient.approximateLiveSeekableRangeEnd } returns 5000L
+        assertEquals(5000L - 1000L, remoteMediaClient.getContentDurationMs())
+    }
+
+    @Test
+    fun `getPlaybackState return STATE_IDLE when where is no items`() {
+        val mediaQueue = mockk<MediaQueue>()
+        every { mediaQueue.itemCount } returns 0
+        every { remoteMediaClient.mediaQueue } returns mediaQueue
+        every { remoteMediaClient.playerState } returns MediaStatus.PLAYER_STATE_PLAYING
+        assertEquals(Player.STATE_IDLE, remoteMediaClient.getPlaybackState())
+    }
+
+    @Test
+    fun `getPlaybackState return ExoPlayer state`() {
+        val mediaQueue = mockk<MediaQueue>()
+        every { mediaQueue.itemCount } returns 10
+        every { remoteMediaClient.mediaQueue } returns mediaQueue
+        every { remoteMediaClient.playerState } returnsMany listOf(
+            MediaStatus.PLAYER_STATE_PLAYING,
+            MediaStatus.PLAYER_STATE_PAUSED,
+            MediaStatus.PLAYER_STATE_LOADING,
+            MediaStatus.PLAYER_STATE_BUFFERING,
+            MediaStatus.PLAYER_STATE_IDLE,
+            MediaStatus.PLAYER_STATE_UNKNOWN
+        )
+
+        assertEquals(Player.STATE_READY, remoteMediaClient.getPlaybackState())
+        assertEquals(Player.STATE_READY, remoteMediaClient.getPlaybackState())
+        assertEquals(Player.STATE_BUFFERING, remoteMediaClient.getPlaybackState())
+        assertEquals(Player.STATE_BUFFERING, remoteMediaClient.getPlaybackState())
+        assertEquals(Player.STATE_IDLE, remoteMediaClient.getPlaybackState())
+        assertEquals(Player.STATE_IDLE, remoteMediaClient.getPlaybackState())
+    }
+
+    @Test
+    fun `getCurrentMediaItemIndex returns INVALID_ITEM_ID when not currentItem`() {
+        every { remoteMediaClient.currentItem } returns null
+        assertEquals(MediaQueueItem.INVALID_ITEM_ID, remoteMediaClient.getCurrentMediaItemIndex())
+    }
+
+    @Test
+    fun `getCurrentMediaItemIndex returns current index`() {
+        val mediaQueue = mockk<MediaQueue>()
+        val currentMediaQueueItem = mockk<MediaQueueItem>()
+        every { mediaQueue.itemCount } returns 10
+        every { remoteMediaClient.mediaQueue } returns mediaQueue
+        every { remoteMediaClient.currentItem } returns currentMediaQueueItem
+        every { currentMediaQueueItem.itemId } returns 1
+        every { mediaQueue.indexOfItemWithId(1) } returns 2
+        assertEquals(2, remoteMediaClient.getCurrentMediaItemIndex())
+    }
+
+    @Test
+    fun `getRepeatMode returns Player repeat mode`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        every { mediaStatus.queueRepeatMode } returnsMany listOf(
+            MediaStatus.REPEAT_MODE_REPEAT_OFF,
+            MediaStatus.REPEAT_MODE_REPEAT_SINGLE,
+            MediaStatus.REPEAT_MODE_REPEAT_ALL,
+            MediaStatus.REPEAT_MODE_REPEAT_ALL_AND_SHUFFLE
+        )
+
+        assertEquals(Player.REPEAT_MODE_OFF, remoteMediaClient.getRepeatMode())
+        assertEquals(Player.REPEAT_MODE_ONE, remoteMediaClient.getRepeatMode())
+        assertEquals(Player.REPEAT_MODE_ALL, remoteMediaClient.getRepeatMode())
+        assertEquals(Player.REPEAT_MODE_ALL, remoteMediaClient.getRepeatMode())
+    }
+
+    @Test
+    fun `getVolume returns 0 when mediaStatus is null`() {
+        every { remoteMediaClient.mediaStatus } returns null
+        assertEquals(0.0, remoteMediaClient.getVolume())
+    }
+
+    @Test
+    fun `getVolume returns streamVolume`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        every { mediaStatus.streamVolume } returns 0.5
+        assertEquals(0.5, remoteMediaClient.getVolume())
+    }
+
+    @Test
+    fun `isMuted returns false when mediaStatus is null`() {
+        every { remoteMediaClient.mediaStatus } returns null
+        assertEquals(false, remoteMediaClient.isMuted())
+    }
+
+    @Test
+    fun `isMuted returns isMute`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        every { mediaStatus.isMute } returns true
+        assertEquals(true, remoteMediaClient.isMuted())
+    }
+
+    @Test
+    fun `getTracks returns EMPTY when mediaInfo is null`() {
+        every { remoteMediaClient.mediaInfo } returns null
+        assertEquals(Tracks.EMPTY, remoteMediaClient.getTracks())
+    }
+
+    @Test
+    fun `getTracks returns EMPTY when media tracks is empty`() {
+        val mediaInfo = mockk<MediaInfo>()
+        every { remoteMediaClient.mediaInfo } returns mediaInfo
+        every { mediaInfo.mediaTracks } returns emptyList<MediaTrack>()
+        assertEquals(Tracks.EMPTY, remoteMediaClient.getTracks())
+    }
+
+    @Test
+    fun `getTracks returns Tracks`() {
+        val listMediaTrack = listOf(
+            MediaTrack.Builder(10, MediaTrack.TYPE_TEXT).build(),
+            MediaTrack.Builder(20, MediaTrack.TYPE_TEXT).build(),
+            MediaTrack.Builder(30, MediaTrack.TYPE_AUDIO).build(),
+        )
+        val mediaInfo = mockk<MediaInfo>()
+        val mediaStatus = mockk<MediaStatus>()
+        every { remoteMediaClient.mediaInfo } returns mediaInfo
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+
+        every { mediaInfo.mediaTracks } returns listMediaTrack
+        every { mediaStatus.activeTrackIds } returns longArrayOf(10, 30)
+
+        val tabTrackGroup = listOf(
+            Tracks.Group(listMediaTrack[0].toTrackGroup(), false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(true)),
+            Tracks.Group(listMediaTrack[1].toTrackGroup(), false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(false)),
+            Tracks.Group(listMediaTrack[2].toTrackGroup(), false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(true)),
+        )
+        assertEquals(Tracks(tabTrackGroup), remoteMediaClient.getTracks())
+    }
+}

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/RemoteMediaClientTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/RemoteMediaClientTest.kt
@@ -91,7 +91,7 @@ class RemoteMediaClientTest {
     }
 
     @Test
-    fun `getPlaybackState return STATE_IDLE when where is no items`() {
+    fun `getPlaybackState return STATE_IDLE when there are no items`() {
         val mediaQueue = mockk<MediaQueue>()
         every { mediaQueue.itemCount } returns 0
         every { remoteMediaClient.mediaQueue } returns mediaQueue


### PR DESCRIPTION
# Pull request

## Description

A tracks handle to `PillarboxCastPlayer`. Each cast `MediaTrack` are stored into a `TrackGroup` with a single `Format`. The `TrackGroup.id` is the `MediaTrack.id` so it is easy to select a track.

## Changes made
- Move some extensions to clean a bit `PillarboxCastPlayer` class.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
