### PR TITLE
override default method as they are not implement by delegation

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -14,6 +14,7 @@ import androidx.media3.common.Player
 import androidx.media3.common.Timeline.Window
 import androidx.media3.common.util.ListenerSet
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.Renderer
 import ch.srgssr.pillarbox.player.analytics.PillarboxAnalyticsCollector
 import ch.srgssr.pillarbox.player.analytics.metrics.PlaybackMetrics
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
@@ -325,6 +326,10 @@ class PillarboxExoPlayer internal constructor(
 
     override fun setPlaybackSpeed(speed: Float) {
         playbackParameters = playbackParameters.withSpeed(speed)
+    }
+
+    override fun getSecondaryRenderer(index: Int): Renderer? {
+        return exoPlayer.getSecondaryRenderer(index)
     }
 
     private fun seekEnd() {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
@@ -17,9 +17,9 @@ import kotlin.test.assertEquals
 class PillarboxExoPlayerTest {
 
     @Test
-    fun `check all default method are implemented`() {
-        val defaultMethod = ExoPlayer::class.java.declaredMethods.filter { it.isDefault }
-        for (method in defaultMethod) {
+    fun `check that all default methods are implemented`() {
+        val defaultMethods = ExoPlayer::class.java.declaredMethods.filter { it.isDefault }
+        for (method in defaultMethods) {
             val name = method.name
             val parameters = method.parameterTypes
             assertEquals(PillarboxExoPlayer::class.java, PillarboxExoPlayer::class.java.getDeclaredMethod(name, *parameters).declaringClass)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.player
+
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Tests inspired by https://github.com/androidx/media/blob/839c4a90f2ab36e48be73e1b5e907f3283dce72e/libraries/common/src/test/java/androidx/media3/common/ForwardingSimpleBasePlayerTest.java#L60-L78
+ */
+@RunWith(AndroidJUnit4::class)
+class PillarboxExoPlayerTest {
+
+    @Test
+    fun `check all default method are implemented`() {
+        val defaultMethod = ExoPlayer::class.java.declaredMethods.filter { it.isDefault }
+        for (method in defaultMethod) {
+            val name = method.name
+            val parameters = method.parameterTypes
+            assertEquals(PillarboxExoPlayer::class.java, PillarboxExoPlayer::class.java.getDeclaredMethod(name, *parameters).declaringClass)
+        }
+    }
+}

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxMediaPeriodTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxMediaPeriodTest.kt
@@ -52,6 +52,16 @@ class PillarboxMediaPeriodTest {
     }
 
     @Test
+    fun `check all default method are implemented`() {
+        val defaultMethod = MediaPeriod::class.java.declaredMethods.filter { it.isDefault }
+        for (method in defaultMethod) {
+            val name = method.name
+            val parameters = method.parameterTypes
+            assertEquals(PillarboxMediaPeriod::class.java, PillarboxMediaPeriod::class.java.getDeclaredMethod(name, *parameters).declaringClass)
+        }
+    }
+
+    @Test
     fun `test track group with no tracker data and no blocked time range`() {
         val mediaPeriod = PillarboxMediaPeriod(
             mediaPeriod = mediaPeriod,

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxMediaPeriodTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxMediaPeriodTest.kt
@@ -52,9 +52,9 @@ class PillarboxMediaPeriodTest {
     }
 
     @Test
-    fun `check all default method are implemented`() {
-        val defaultMethod = MediaPeriod::class.java.declaredMethods.filter { it.isDefault }
-        for (method in defaultMethod) {
+    fun `check that all default methods are implemented`() {
+        val defaultMethods = MediaPeriod::class.java.declaredMethods.filter { it.isDefault }
+        for (method in defaultMethods) {
             val name = method.name
             val parameters = method.parameterTypes
             assertEquals(PillarboxMediaPeriod::class.java, PillarboxMediaPeriod::class.java.getDeclaredMethod(name, *parameters).declaringClass)


### PR DESCRIPTION
# Pull request

## Description

Media3 changes some method from `ExoPlayer` interface and as we use implements delegation, it doesn't work.

## Changes made

- Implements default method and forward it to real implementation

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
