### PR TITLE
Make sure the playback speed is in range ]0,1]

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -13,6 +13,7 @@ import com.google.android.gms.cast.MediaQueueItem
 import com.google.android.gms.cast.MediaStatus
 import com.google.android.gms.cast.MediaTrack
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
+import kotlin.math.absoluteValue
 
 internal fun RemoteMediaClient.getContentPositionMs(): Long {
     return if (approximateStreamPosition == MediaInfo.UNKNOWN_DURATION) {
@@ -82,6 +83,13 @@ internal fun RemoteMediaClient.getTracks(): Tracks {
     }
 }
 
+/**
+ * MediaStatus.playbackRate return
+ * - 0 if it is paused.
+ * - Negative value if playing backward.
+ * - Positive value if playing normally.
+ */
 internal fun RemoteMediaClient.getPlaybackRate(): Float {
-    return mediaStatus?.playbackRate?.toFloat() ?: PlaybackParameters.DEFAULT.speed
+    val playbackRate = mediaStatus?.playbackRate?.toFloat().takeUnless { it == 0f }
+    return playbackRate?.absoluteValue ?: PlaybackParameters.DEFAULT.speed
 }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -90,6 +90,7 @@ internal fun RemoteMediaClient.getTracks(): Tracks {
  * - A positive value if playing normally.
  */
 internal fun RemoteMediaClient.getPlaybackRate(): Float {
-    val playbackRate = mediaStatus?.playbackRate?.toFloat().takeUnless { it == 0f }
+    val playbackRate = mediaStatus?.playbackRate?.toFloat()?.takeIf { it > 0f }
+
     return playbackRate?.absoluteValue ?: PlaybackParameters.DEFAULT.speed
 }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -13,7 +13,6 @@ import com.google.android.gms.cast.MediaQueueItem
 import com.google.android.gms.cast.MediaStatus
 import com.google.android.gms.cast.MediaTrack
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
-import kotlin.math.absoluteValue
 
 internal fun RemoteMediaClient.getContentPositionMs(): Long {
     return if (approximateStreamPosition == MediaInfo.UNKNOWN_DURATION) {
@@ -90,7 +89,5 @@ internal fun RemoteMediaClient.getTracks(): Tracks {
  * - A positive value if playing normally.
  */
 internal fun RemoteMediaClient.getPlaybackRate(): Float {
-    val playbackRate = mediaStatus?.playbackRate?.toFloat()?.takeIf { it > 0f }
-
-    return playbackRate?.absoluteValue ?: PlaybackParameters.DEFAULT.speed
+    return mediaStatus?.playbackRate?.toFloat()?.takeIf { it > 0f } ?: PlaybackParameters.DEFAULT.speed
 }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -84,10 +84,10 @@ internal fun RemoteMediaClient.getTracks(): Tracks {
 }
 
 /**
- * MediaStatus.playbackRate return
+ * [MediaStatus.playbackRate] returns:
  * - 0 if it is paused.
- * - Negative value if playing backward.
- * - Positive value if playing normally.
+ * - A negative value if playing backward.
+ * - A positive value if playing normally.
  */
 internal fun RemoteMediaClient.getPlaybackRate(): Float {
     val playbackRate = mediaStatus?.playbackRate?.toFloat().takeUnless { it == 0f }

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/MediaTrackTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/MediaTrackTest.kt
@@ -2,13 +2,12 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.cast
+package ch.srgssr.pillarbox.cast.extension
 
 import androidx.media3.common.C
 import androidx.media3.common.Format
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.TrackGroup
-import ch.srgssr.pillarbox.cast.extension.toTrackGroup
 import com.google.android.gms.cast.MediaTrack
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -16,7 +15,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
-class MediaTrackExtensionTest(
+class MediaTrackTest(
     val mediaTrack: MediaTrack,
     val trackGroup: TrackGroup
 ) {

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClientTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClientTest.kt
@@ -2,21 +2,13 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.cast
+package ch.srgssr.pillarbox.cast.extension
 
 import androidx.media3.common.C
+import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import ch.srgssr.pillarbox.cast.extension.getContentDurationMs
-import ch.srgssr.pillarbox.cast.extension.getContentPositionMs
-import ch.srgssr.pillarbox.cast.extension.getCurrentMediaItemIndex
-import ch.srgssr.pillarbox.cast.extension.getPlaybackState
-import ch.srgssr.pillarbox.cast.extension.getRepeatMode
-import ch.srgssr.pillarbox.cast.extension.getTracks
-import ch.srgssr.pillarbox.cast.extension.getVolume
-import ch.srgssr.pillarbox.cast.extension.isMuted
-import ch.srgssr.pillarbox.cast.extension.toTrackGroup
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaQueueItem
 import com.google.android.gms.cast.MediaStatus
@@ -219,5 +211,51 @@ class RemoteMediaClientTest {
             Tracks.Group(listMediaTrack[2].toTrackGroup(), false, intArrayOf(C.FORMAT_HANDLED), booleanArrayOf(true)),
         )
         assertEquals(Tracks(tabTrackGroup), remoteMediaClient.getTracks())
+    }
+
+    @Test
+    fun `Playback rate is positive`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { mediaStatus.playbackRate } returns 0.5
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        assertEquals(0.5f, remoteMediaClient.getPlaybackRate())
+    }
+
+    @Test
+    fun `Playback rate is negative returns default speed`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { mediaStatus.playbackRate } returns -0.5
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        assertEquals(PlaybackParameters.DEFAULT.speed, remoteMediaClient.getPlaybackRate())
+    }
+
+    @Test
+    fun `Playback rate is zero returns default speed`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { mediaStatus.playbackRate } returns 0.0
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        assertEquals(PlaybackParameters.DEFAULT.speed, remoteMediaClient.getPlaybackRate())
+    }
+
+    @Test
+    fun `Media status is null`() {
+        every { remoteMediaClient.mediaStatus } returns null
+        assertEquals(PlaybackParameters.DEFAULT.speed, remoteMediaClient.getPlaybackRate())
+    }
+
+    @Test
+    fun `Playback rate is a small positive number`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { mediaStatus.playbackRate } returns Double.MIN_VALUE
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        assertEquals(PlaybackParameters.DEFAULT.speed, remoteMediaClient.getPlaybackRate())
+    }
+
+    @Test
+    fun `Playback rate is a small negative number`() {
+        val mediaStatus = mockk<MediaStatus>()
+        every { mediaStatus.playbackRate } returns -Double.MIN_VALUE
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
+        assertEquals(PlaybackParameters.DEFAULT.speed, remoteMediaClient.getPlaybackRate())
     }
 }

--- a/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/playlist/EditablePlaylistView.kt
+++ b/pillarbox-demo-cast/src/main/java/ch/srgssr/pillarbox/demo/cast/playlist/EditablePlaylistView.kt
@@ -53,6 +53,7 @@ import ch.srgssr.pillarbox.ui.extension.getCurrentMediaItemsAsState
  *
  * @param player The player whose playlist is managed.
  * @param modifier Modifier of the layout.
+ * @param playlist The playlist to display.
  */
 @Composable
 fun EditablePlaylistView(


### PR DESCRIPTION
# Pull request

## Description

There is an issue with RemoteClient playback rate that can be equal to zero when it is in pause. It can be negative too.

## Changes made

- Ensure the playback rate is valid.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
