### PR TITLE
967 better handle cast request

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -234,6 +234,7 @@ class PillarboxCastPlayer internal constructor(
             .setTrackSelectionParameters(trackSelectionParameters)
             .setPlaybackParameters(PlaybackParameters(remoteMediaClient.getPlaybackRate()))
             .setPlaylistMetadata(playlistMetadata)
+            .setIsLoading(isLoading && playlist.isNotEmpty())
             .build()
     }
 

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -178,6 +178,7 @@ class PillarboxCastPlayer internal constructor(
 
     override fun getState(): State {
         val remoteMediaClient = remoteMediaClient ?: return State.Builder().build()
+        val isLoading = remoteMediaClient.playerState == MediaStatus.PLAYER_STATE_LOADING
         val mediaStatus = remoteMediaClient.mediaStatus
         val contentPositionMs = remoteMediaClient.getContentPositionMs()
         val contentDurationMs = remoteMediaClient.getContentDurationMs()
@@ -185,9 +186,9 @@ class PillarboxCastPlayer internal constructor(
         val currentItemIndex = remoteMediaClient.getCurrentMediaItemIndex()
         val isPlayingAd = mediaStatus?.isPlayingAd == true
         val itemCount = remoteMediaClient.mediaQueue.itemCount
-        val hasNextItem = !isPlayingAd && currentItemIndex + 1 < itemCount
-        val hasPreviousItem = !isPlayingAd && currentItemIndex - 1 >= 0
-        val canSeek = itemCount > 0 && !isPlayingAd && isCommandSupported(MediaStatus.COMMAND_SEEK) && contentDurationMs != C.TIME_UNSET
+        val hasNextItem = !isLoading && !isPlayingAd && currentItemIndex + 1 < itemCount
+        val hasPreviousItem = !isLoading && !isPlayingAd && currentItemIndex - 1 >= 0
+        val canSeek = !isLoading && itemCount > 0 && !isPlayingAd && isCommandSupported(MediaStatus.COMMAND_SEEK) && contentDurationMs != C.TIME_UNSET
         val canSeekBack = canSeek && contentPositionMs != C.TIME_UNSET && contentPositionMs - seekBackIncrementMs > 0
         val canSeekForward = canSeek && contentPositionMs + seekForwardIncrementMs < contentDurationMs
         val hasNext = hasNextItem || canSeek

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -56,7 +56,6 @@ import com.google.android.gms.cast.framework.media.RemoteMediaClient.ProgressLis
 import com.google.android.gms.common.api.PendingResult
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
-import java.util.concurrent.Executor
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
@@ -177,17 +176,13 @@ class PillarboxCastPlayer internal constructor(
         sessionAvailabilityListener = listener
     }
 
-    private var pendingMediaItemIndex: Int? = null
-    private var pendingSeekPosition: Long? = null
-    private var pendingSeekCommand: PendingResult<MediaChannelResult>? = null
-
     override fun getState(): State {
         val remoteMediaClient = remoteMediaClient ?: return State.Builder().build()
         val mediaStatus = remoteMediaClient.mediaStatus
-        val contentPositionMs = pendingSeekPosition ?: remoteMediaClient.getContentPositionMs()
+        val contentPositionMs = remoteMediaClient.getContentPositionMs()
         val contentDurationMs = remoteMediaClient.getContentDurationMs()
         val isCommandSupported = { command: Long -> mediaStatus?.isMediaCommandSupported(command) == true }
-        val currentItemIndex = pendingMediaItemIndex ?: remoteMediaClient.getCurrentMediaItemIndex()
+        val currentItemIndex = remoteMediaClient.getCurrentMediaItemIndex()
         val isPlayingAd = mediaStatus?.isPlayingAd == true
         val itemCount = remoteMediaClient.mediaQueue.itemCount
         val hasNextItem = !isPlayingAd && currentItemIndex + 1 < itemCount
@@ -336,25 +331,7 @@ class PillarboxCastPlayer internal constructor(
         setActiveMediaTracks(selectedTrackIds)
     }
 
-    override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: Int): ListenableFuture<*> {
-        if (remoteMediaClient == null) return Futures.immediateVoidFuture()
-        Log.d("Coucou", "handle seek $mediaItemIndex $positionMs $seekCommand")
-        return Futures.submit(
-            {
-                remoteMediaClient?.let {
-                    Log.d("Coucou", "remote client jump to")
-                    jumpTo(it, mediaItemIndex, positionMs)?.await()
-                }
-            },
-            object : Executor {
-                override fun execute(command: Runnable?) {
-                    command?.run()
-                }
-            }
-        )
-    }
-
-    fun handleSeek2(mediaItemIndex: Int, positionMs: Long, seekCommand: @Player.Command Int) = withRemoteClient {
+    override fun handleSeek(mediaItemIndex: Int, positionMs: Long, seekCommand: @Player.Command Int) = withRemoteClient {
         Log.d(TAG, "handle seek $mediaItemIndex $positionMs $seekCommand")
         when (seekCommand) {
             COMMAND_SEEK_TO_DEFAULT_POSITION -> {
@@ -373,21 +350,11 @@ class PillarboxCastPlayer internal constructor(
             }
 
             COMMAND_SEEK_TO_PREVIOUS, COMMAND_SEEK_TO_NEXT -> {
-                pendingSeekCommand?.cancel()
-                jumpTo(this, mediaItemIndex, positionMs)?.apply { pendingSeekCommand = this }?.setResultCallback {
-                    if (it.status.statusCode == CastStatusCodes.FAILED) {
-                        pendingSeekPosition = null
-                        pendingMediaItemIndex = null
-                        invalidateState()
-                    } else if (it.status.statusCode == CastStatusCodes.CANCELED) {
-                        Log.i("Coucou", "Cancel")
-                    } else {
-                        pendingSeekPosition = positionMs
-                        pendingMediaItemIndex = mediaItemIndex
-                        invalidateState()
-                    }
+                if (mediaItemIndex != currentMediaItemIndex) {
+                    if (seekCommand == COMMAND_SEEK_TO_PREVIOUS) queuePrev(null) else queueNext(null)
+                } else {
+                    seekTo(this, positionMs)
                 }
-                // seekTo(this, positionMs)
             }
 
             COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM -> {
@@ -535,8 +502,6 @@ class PillarboxCastPlayer internal constructor(
                     " duration = ${remoteMediaClient?.mediaStatus?.mediaInfo?.streamDuration?.milliseconds}"
             )
             positionSupplier.position = remoteMediaClient?.getContentPositionMs() ?: 0
-            pendingMediaItemIndex = null
-            pendingSeekPosition = null
             invalidateState()
         }
 

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -195,6 +195,7 @@ class PillarboxCastPlayer internal constructor(
         val hasPrevious = hasPreviousItem || canSeek
 
         val availableCommands = PERMANENT_AVAILABLE_COMMANDS.buildUpon()
+            .addIf(COMMAND_SET_SHUFFLE_MODE, !isLoading)
             .addIf(COMMAND_SET_TRACK_SELECTION_PARAMETERS, isCommandSupported(MediaStatus.COMMAND_EDIT_TRACKS))
             .addIf(COMMAND_SEEK_TO_DEFAULT_POSITION, !isPlayingAd)
             .addIf(COMMAND_SEEK_TO_MEDIA_ITEM, !isPlayingAd)
@@ -631,7 +632,6 @@ class PillarboxCastPlayer internal constructor(
                 COMMAND_RELEASE,
                 COMMAND_SET_MEDIA_ITEM,
                 COMMAND_CHANGE_MEDIA_ITEMS,
-                COMMAND_SET_SHUFFLE_MODE,
                 COMMAND_SET_REPEAT_MODE,
                 COMMAND_GET_VOLUME,
                 COMMAND_GET_TRACKS,

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -98,6 +98,8 @@ fun <Builder : PillarboxCastPlayerBuilder> PillarboxCastPlayer(
  * @param seekForwardIncrementMs The [seekForward] increment, in milliseconds.
  * @param maxSeekToPreviousPositionMs The maximum position for which [seekToPrevious] seeks to the previous [MediaItem], in milliseconds.
  * @param trackSelector The [CastTrackSelector] to use when selecting tracks from [TrackSelectionParameters].
+ * @param applicationLooper The [Looper] to use it for the application thread.
+ * @param clock The [Clock] to use.
  */
 @Suppress("LongParameterList")
 class PillarboxCastPlayer internal constructor(
@@ -176,6 +178,7 @@ class PillarboxCastPlayer internal constructor(
         sessionAvailabilityListener = listener
     }
 
+    @Suppress("CyclomaticComplexMethod")
     override fun getState(): State {
         val remoteMediaClient = remoteMediaClient ?: return State.Builder().build()
         val isLoading = remoteMediaClient.playerState == MediaStatus.PLAYER_STATE_LOADING

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -42,7 +42,7 @@ internal fun RemoteMediaClient.getPlaybackState(): @Player.State Int {
 }
 
 internal fun RemoteMediaClient.getCurrentMediaItemIndex(): Int {
-    return currentItem?.let { mediaQueue.indexOfItemWithId(it.itemId) } ?: MediaQueueItem.INVALID_ITEM_ID
+    return mediaStatus?.currentItemId?.let { mediaQueue.indexOfItemWithId(it) } ?: MediaQueueItem.INVALID_ITEM_ID
 }
 
 internal fun RemoteMediaClient.getMediaIdFromIndex(index: Int): Int {

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClientTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClientTest.kt
@@ -115,19 +115,24 @@ class RemoteMediaClientTest {
 
     @Test
     fun `getCurrentMediaItemIndex returns INVALID_ITEM_ID when not currentItem`() {
-        every { remoteMediaClient.currentItem } returns null
+        every { remoteMediaClient.mediaStatus } returns null
         assertEquals(MediaQueueItem.INVALID_ITEM_ID, remoteMediaClient.getCurrentMediaItemIndex())
     }
 
     @Test
     fun `getCurrentMediaItemIndex returns current index`() {
         val mediaQueue = mockk<MediaQueue>()
+        val mediaStatus = mockk<MediaStatus>()
         val currentMediaQueueItem = mockk<MediaQueueItem>()
+
+        every { mediaStatus.currentItemId } returns 1
+        every { remoteMediaClient.mediaStatus } returns mediaStatus
         every { mediaQueue.itemCount } returns 10
         every { remoteMediaClient.mediaQueue } returns mediaQueue
         every { remoteMediaClient.currentItem } returns currentMediaQueueItem
         every { currentMediaQueueItem.itemId } returns 1
         every { mediaQueue.indexOfItemWithId(1) } returns 2
+
         assertEquals(2, remoteMediaClient.getCurrentMediaItemIndex())
     }
 

--- a/pillarbox-core-business-cast/src/main/java/ch/srgssr/pillarbox/core/business/cast/SRGMediaItemConverter.kt
+++ b/pillarbox-core-business-cast/src/main/java/ch/srgssr/pillarbox/core/business/cast/SRGMediaItemConverter.kt
@@ -49,7 +49,6 @@ class SRGMediaItemConverter : MediaItemConverter {
             } ?: CastMediaMetadata.MEDIA_TYPE_GENERIC
             val contentUrl = localConfiguration.uri.toString()
             val mediaInfo = MediaInfo.Builder(if (contentId == MediaItem.DEFAULT_MEDIA_ID) contentUrl else contentId)
-                .setStreamType(MediaInfo.STREAM_TYPE_BUFFERED)
                 .setContentType(localConfiguration.mimeType)
                 .setContentUrl(contentUrl)
                 .setCustomData(localConfiguration.drmConfiguration?.let(::createCustomData))

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
@@ -47,6 +47,7 @@ import ch.srgssr.pillarbox.demo.R
 import ch.srgssr.pillarbox.demo.shared.data.DemoItem
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
+import ch.srgssr.pillarbox.ui.extension.availableCommandsAsState
 import ch.srgssr.pillarbox.ui.extension.currentMediaItemIndexAsState
 import ch.srgssr.pillarbox.ui.extension.getCurrentMediaItemsAsState
 import ch.srgssr.pillarbox.ui.extension.shuffleModeEnabledAsState
@@ -67,6 +68,7 @@ fun PlaylistView(
     val currentMediaItems by player.getCurrentMediaItemsAsState()
     val currentMediaItemIndex by player.currentMediaItemIndexAsState()
     val shuffleModeEnabled by player.shuffleModeEnabledAsState()
+    val availableCommand by player.availableCommandsAsState()
 
     var addItemDialogState by remember {
         mutableStateOf(false)
@@ -101,6 +103,7 @@ fun PlaylistView(
             addItemDialogState = true
         },
         onRemoveAll = player::clearMediaItems,
+        canShuffle = availableCommand.contains(Player.COMMAND_SET_SHUFFLE_MODE),
         shuffleEnabled = shuffleModeEnabled,
         onShuffleToggled = player::setShuffleModeEnabled,
     )
@@ -115,6 +118,7 @@ private fun PlaylistView(
     onMoveItemIndex: (from: Int, to: Int) -> Unit,
     onAddToPlaylistClick: () -> Unit,
     onRemoveAll: () -> Unit,
+    canShuffle: Boolean,
     shuffleEnabled: Boolean,
     onShuffleToggled: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
@@ -140,7 +144,11 @@ private fun PlaylistView(
                         contentDescription = stringResource(R.string.add_to_playlist),
                     )
                 }
-                IconToggleButton(checked = shuffleEnabled, onShuffleToggled) {
+                IconToggleButton(
+                    checked = shuffleEnabled,
+                    enabled = canShuffle,
+                    onCheckedChange = onShuffleToggled,
+                ) {
                     val imageVector = if (shuffleEnabled) Icons.Default.ShuffleOn else Icons.Default.Shuffle
 
                     Icon(
@@ -237,7 +245,8 @@ private fun PlaylistPreview() {
             onAddToPlaylistClick = {},
             onRemoveAll = {},
             onShuffleToggled = {},
-            shuffleEnabled = false
+            shuffleEnabled = false,
+            canShuffle = true,
         )
     }
 }
@@ -258,7 +267,8 @@ private fun PlaylistPreviewEmptyList() {
             onAddToPlaylistClick = {},
             onRemoveAll = {},
             onShuffleToggled = {},
-            shuffleEnabled = false
+            shuffleEnabled = false,
+            canShuffle = true,
         )
     }
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcase.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.media3.common.util.RepeatModeUtil
 import androidx.media3.ui.PlayerView
 import androidx.mediarouter.media.MediaControlIntent
 import androidx.mediarouter.media.MediaRouteSelector
@@ -52,6 +53,7 @@ fun CastShowcase() {
                 setupView = {
                     setShowShuffleButton(true)
                     setShowSubtitleButton(true)
+                    setRepeatToggleModes(RepeatModeUtil.REPEAT_TOGGLE_MODE_ALL)
                     setShutterBackgroundColor(Color.BLACK)
                     if (player is PillarboxCastPlayer) {
                         artworkDisplayMode = PlayerView.ARTWORK_DISPLAY_MODE_FIT

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcaseViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcaseViewModel.kt
@@ -53,7 +53,7 @@ class CastShowcaseViewModel(application: Application) : AndroidViewModel(applica
 
     private fun switchPlayer(player: Player) {
         val oldPlayer = if (player is PillarboxCastPlayer) localPlayer else castPlayer
-        if (oldPlayer == player) return
+        if (oldPlayer == player || (oldPlayer == localPlayer && oldPlayer.playbackState == Player.STATE_IDLE)) return
         player.repeatMode = oldPlayer.repeatMode
         player.playWhenReady = oldPlayer.playWhenReady
         player.setMediaItems(oldPlayer.getCurrentMediaItems(), oldPlayer.currentMediaItemIndex, oldPlayer.currentPosition)


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to avoid the receiver bad behavior when using commands that make it loading something. For exemple by clicking a lot on skip to next or skip to previous button.

## Changes made

- When `RemoteMediaClient` is in `STATE_LOADING` some commands are not available to avoid the receiver to fail.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
