### PR TITLE
Fix Detekt warnings in `PillarboxCastPlayer`

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClient.kt
@@ -2,17 +2,62 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
+
+@file:Suppress("TooManyFunctions")
+
 package ch.srgssr.pillarbox.cast.extension
 
 import androidx.media3.common.C
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
+import androidx.media3.common.Player.COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS
+import androidx.media3.common.Player.COMMAND_CHANGE_MEDIA_ITEMS
+import androidx.media3.common.Player.COMMAND_GET_CURRENT_MEDIA_ITEM
+import androidx.media3.common.Player.COMMAND_GET_TIMELINE
+import androidx.media3.common.Player.COMMAND_GET_TRACKS
+import androidx.media3.common.Player.COMMAND_GET_VOLUME
+import androidx.media3.common.Player.COMMAND_PLAY_PAUSE
+import androidx.media3.common.Player.COMMAND_RELEASE
+import androidx.media3.common.Player.COMMAND_SEEK_BACK
+import androidx.media3.common.Player.COMMAND_SEEK_FORWARD
+import androidx.media3.common.Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM
+import androidx.media3.common.Player.COMMAND_SEEK_TO_DEFAULT_POSITION
+import androidx.media3.common.Player.COMMAND_SEEK_TO_MEDIA_ITEM
+import androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT
+import androidx.media3.common.Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM
+import androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS
+import androidx.media3.common.Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM
+import androidx.media3.common.Player.COMMAND_SET_MEDIA_ITEM
+import androidx.media3.common.Player.COMMAND_SET_PLAYLIST_METADATA
+import androidx.media3.common.Player.COMMAND_SET_REPEAT_MODE
+import androidx.media3.common.Player.COMMAND_SET_SHUFFLE_MODE
+import androidx.media3.common.Player.COMMAND_SET_SPEED_AND_PITCH
+import androidx.media3.common.Player.COMMAND_SET_TRACK_SELECTION_PARAMETERS
+import androidx.media3.common.Player.COMMAND_SET_VOLUME
+import androidx.media3.common.Player.COMMAND_STOP
 import androidx.media3.common.Tracks
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaQueueItem
 import com.google.android.gms.cast.MediaStatus
 import com.google.android.gms.cast.MediaTrack
 import com.google.android.gms.cast.framework.media.RemoteMediaClient
+
+internal val PERMANENT_AVAILABLE_COMMANDS = Player.Commands.Builder()
+    .addAll(
+        COMMAND_PLAY_PAUSE,
+        COMMAND_GET_CURRENT_MEDIA_ITEM,
+        COMMAND_GET_TIMELINE,
+        COMMAND_STOP,
+        COMMAND_RELEASE,
+        COMMAND_SET_MEDIA_ITEM,
+        COMMAND_CHANGE_MEDIA_ITEMS,
+        COMMAND_SET_SHUFFLE_MODE,
+        COMMAND_SET_REPEAT_MODE,
+        COMMAND_GET_VOLUME,
+        COMMAND_GET_TRACKS,
+        COMMAND_SET_PLAYLIST_METADATA,
+    )
+    .build()
 
 internal fun RemoteMediaClient.getContentPositionMs(): Long {
     return if (approximateStreamPosition == MediaInfo.UNKNOWN_DURATION) {
@@ -90,4 +135,37 @@ internal fun RemoteMediaClient.getTracks(): Tracks {
  */
 internal fun RemoteMediaClient.getPlaybackRate(): Float {
     return mediaStatus?.playbackRate?.toFloat()?.takeIf { it > 0f } ?: PlaybackParameters.DEFAULT.speed
+}
+
+internal fun RemoteMediaClient.getAvailableCommands(
+    seekBackIncrementMs: Long,
+    seekForwardIncrementMs: Long,
+): Player.Commands {
+    val contentPositionMs = getContentPositionMs()
+    val contentDurationMs = getContentDurationMs()
+    val isCommandSupported = { command: Long -> mediaStatus?.isMediaCommandSupported(command) == true }
+    val currentItemIndex = getCurrentMediaItemIndex()
+    val isPlayingAd = mediaStatus?.isPlayingAd == true
+    val itemCount = mediaQueue.itemCount
+    val hasNextItem = !isPlayingAd && currentItemIndex + 1 < itemCount
+    val hasPreviousItem = !isPlayingAd && currentItemIndex - 1 >= 0
+    val canSeek = itemCount > 0 && !isPlayingAd && isCommandSupported(MediaStatus.COMMAND_SEEK) && contentDurationMs != C.TIME_UNSET
+    val canSeekBack = canSeek && contentPositionMs != C.TIME_UNSET && contentPositionMs - seekBackIncrementMs > 0
+    val canSeekForward = canSeek && contentPositionMs + seekForwardIncrementMs < contentDurationMs
+
+    return PERMANENT_AVAILABLE_COMMANDS.buildUpon()
+        .addIf(COMMAND_SET_TRACK_SELECTION_PARAMETERS, isCommandSupported(MediaStatus.COMMAND_EDIT_TRACKS))
+        .addIf(COMMAND_SEEK_TO_DEFAULT_POSITION, !isPlayingAd)
+        .addIf(COMMAND_SEEK_TO_MEDIA_ITEM, !isPlayingAd)
+        .addIf(COMMAND_SEEK_TO_NEXT_MEDIA_ITEM, hasNextItem)
+        .addIf(COMMAND_SEEK_TO_NEXT, hasNextItem || canSeek)
+        .addIf(COMMAND_SEEK_TO_PREVIOUS, hasPreviousItem || canSeek)
+        .addIf(COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM, hasPreviousItem)
+        .addIf(COMMAND_SET_VOLUME, isCommandSupported(MediaStatus.COMMAND_SET_VOLUME))
+        .addIf(COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS, isCommandSupported(MediaStatus.COMMAND_TOGGLE_MUTE))
+        .addIf(COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM, canSeek)
+        .addIf(COMMAND_SEEK_BACK, canSeekBack)
+        .addIf(COMMAND_SEEK_FORWARD, canSeekForward)
+        .addIf(COMMAND_SET_SPEED_AND_PITCH, isCommandSupported(MediaStatus.COMMAND_PLAYBACK_RATE))
+        .build()
 }

--- a/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClientTest.kt
+++ b/pillarbox-cast/src/test/java/ch/srgssr/pillarbox/cast/extension/RemoteMediaClientTest.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.Player
 import androidx.media3.common.Tracks
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.srgssr.pillarbox.player.utils.StringUtil
 import com.google.android.gms.cast.MediaInfo
 import com.google.android.gms.cast.MediaQueueItem
 import com.google.android.gms.cast.MediaStatus
@@ -18,23 +19,24 @@ import com.google.android.gms.cast.framework.media.RemoteMediaClient
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.asserter
 
 @RunWith(AndroidJUnit4::class)
 class RemoteMediaClientTest {
 
     private lateinit var remoteMediaClient: RemoteMediaClient
 
-    @Before
+    @BeforeTest
     fun setupTests() {
         remoteMediaClient = mockk(relaxed = false)
     }
 
-    @After
+    @AfterTest
     fun afterTests() {
         unmockkAll()
     }
@@ -60,21 +62,21 @@ class RemoteMediaClientTest {
     }
 
     @Test
-    fun `getContentDuration returns TIME_UNSET`() {
+    fun `getContentDurationMs returns TIME_UNSET`() {
         every { remoteMediaClient.isLiveStream } returns false
         every { remoteMediaClient.streamDuration } returns MediaInfo.UNKNOWN_DURATION
         assertEquals(C.TIME_UNSET, remoteMediaClient.getContentDurationMs())
     }
 
     @Test
-    fun `getContentDuration returns streamDuration`() {
+    fun `getContentDurationMs returns streamDuration`() {
         every { remoteMediaClient.isLiveStream } returns false
         every { remoteMediaClient.streamDuration } returns 12334L
         assertEquals(12334L, remoteMediaClient.getContentDurationMs())
     }
 
     @Test
-    fun `getContentDuration for live stream returns live window length`() {
+    fun `getContentDurationMs for live stream returns live window length`() {
         every { remoteMediaClient.isLiveStream } returns true
         every { remoteMediaClient.streamDuration } returns 100L
         every { remoteMediaClient.approximateLiveSeekableRangeStart } returns 1000L
@@ -257,5 +259,45 @@ class RemoteMediaClientTest {
         every { mediaStatus.playbackRate } returns -Double.MIN_VALUE
         every { remoteMediaClient.mediaStatus } returns mediaStatus
         assertEquals(PlaybackParameters.DEFAULT.speed, remoteMediaClient.getPlaybackRate())
+    }
+
+    @Test
+    fun getAvailableCommands() {
+        every { remoteMediaClient.approximateStreamPosition } returns 200L
+        every { remoteMediaClient.approximateLiveSeekableRangeStart } returns 1_000L
+        every { remoteMediaClient.approximateLiveSeekableRangeEnd } returns 10_000L
+        every { remoteMediaClient.currentItem } returns null
+        every { remoteMediaClient.isLiveStream } returns true
+        every { remoteMediaClient.mediaStatus } returns mockk {
+            every { isPlayingAd } returns false
+            every { isMediaCommandSupported(any()) } returns false
+        }
+        every { remoteMediaClient.mediaQueue } returns mockk {
+            every { itemCount } returns 10
+        }
+
+        val expectedCommands = PERMANENT_AVAILABLE_COMMANDS.buildUpon()
+            .add(Player.COMMAND_SEEK_TO_DEFAULT_POSITION)
+            .add(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            .add(Player.COMMAND_SEEK_TO_NEXT)
+            .add(Player.COMMAND_SEEK_TO_MEDIA_ITEM)
+            .build()
+
+        assertEquals(expectedCommands, remoteMediaClient.getAvailableCommands(5_000L, 10_000L))
+    }
+
+    private companion object {
+        private fun assertEquals(expected: Player.Commands, actual: Player.Commands, message: String? = null) {
+            asserter.assertTrue(
+                lazyMessage = {
+                    val messagePrefix = if (message == null) "" else "$message. "
+                    val expectedCommands = StringUtil.playerCommandsString(expected)
+                    val actualCommands = StringUtil.playerCommandsString(actual)
+
+                    "${messagePrefix}Expected <$expectedCommands>, actual <$actualCommands>."
+                },
+                actual = actual == expected,
+            )
+        }
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/StringUtil.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/utils/StringUtil.kt
@@ -80,4 +80,60 @@ object StringUtil {
             else -> UNKNOWN
         }
     }
+
+    /**
+     * Converts player commands to a human readable string.
+     *
+     * @param value The [Player.Commands].
+     *
+     * @return A string representation of the player commands.
+     */
+    @Suppress("CyclomaticComplexMethod")
+    fun playerCommandsString(value: Player.Commands): String {
+        return buildList {
+            repeat(value.size()) {
+                val commandName = when (val command = value.get(it)) {
+                    Player.COMMAND_INVALID -> "COMMAND_INVALID"
+                    Player.COMMAND_PLAY_PAUSE -> "COMMAND_PLAY_PAUSE"
+                    Player.COMMAND_PREPARE -> "COMMAND_PREPARE"
+                    Player.COMMAND_STOP -> "COMMAND_STOP"
+                    Player.COMMAND_SEEK_TO_DEFAULT_POSITION -> "COMMAND_SEEK_TO_DEFAULT_POSITION"
+                    Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM -> "COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM"
+                    Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM -> "COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM"
+                    Player.COMMAND_SEEK_TO_PREVIOUS -> "COMMAND_SEEK_TO_PREVIOUS"
+                    Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM -> "COMMAND_SEEK_TO_NEXT_MEDIA_ITEM"
+                    Player.COMMAND_SEEK_TO_NEXT -> "COMMAND_SEEK_TO_NEXT"
+                    Player.COMMAND_SEEK_TO_MEDIA_ITEM -> "COMMAND_SEEK_TO_MEDIA_ITEM"
+                    Player.COMMAND_SEEK_BACK -> "COMMAND_SEEK_BACK"
+                    Player.COMMAND_SEEK_FORWARD -> "COMMAND_SEEK_FORWARD"
+                    Player.COMMAND_SET_SPEED_AND_PITCH -> "COMMAND_SET_SPEED_AND_PITCH"
+                    Player.COMMAND_SET_SHUFFLE_MODE -> "COMMAND_SET_SHUFFLE_MODE"
+                    Player.COMMAND_SET_REPEAT_MODE -> "COMMAND_SET_REPEAT_MODE"
+                    Player.COMMAND_GET_CURRENT_MEDIA_ITEM -> "COMMAND_GET_CURRENT_MEDIA_ITEM"
+                    Player.COMMAND_GET_TIMELINE -> "COMMAND_GET_TIMELINE"
+                    Player.COMMAND_GET_METADATA -> "COMMAND_GET_METADATA"
+                    Player.COMMAND_SET_PLAYLIST_METADATA -> "COMMAND_SET_PLAYLIST_METADATA"
+                    Player.COMMAND_SET_MEDIA_ITEM -> "COMMAND_SET_MEDIA_ITEM"
+                    Player.COMMAND_CHANGE_MEDIA_ITEMS -> "COMMAND_CHANGE_MEDIA_ITEMS"
+                    Player.COMMAND_GET_AUDIO_ATTRIBUTES -> "COMMAND_GET_AUDIO_ATTRIBUTES"
+                    Player.COMMAND_GET_VOLUME -> "COMMAND_GET_VOLUME"
+                    Player.COMMAND_GET_DEVICE_VOLUME -> "COMMAND_GET_DEVICE_VOLUME"
+                    Player.COMMAND_SET_VOLUME -> "COMMAND_SET_VOLUME"
+                    Player.COMMAND_SET_DEVICE_VOLUME -> "COMMAND_SET_DEVICE_VOLUME"
+                    Player.COMMAND_SET_DEVICE_VOLUME_WITH_FLAGS -> "COMMAND_SET_DEVICE_VOLUME_WITH_FLAGS"
+                    Player.COMMAND_ADJUST_DEVICE_VOLUME -> "COMMAND_ADJUST_DEVICE_VOLUME"
+                    Player.COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS -> "COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS"
+                    Player.COMMAND_SET_AUDIO_ATTRIBUTES -> "COMMAND_SET_AUDIO_ATTRIBUTES"
+                    Player.COMMAND_SET_VIDEO_SURFACE -> "COMMAND_SET_VIDEO_SURFACE"
+                    Player.COMMAND_GET_TEXT -> "COMMAND_GET_TEXT"
+                    Player.COMMAND_SET_TRACK_SELECTION_PARAMETERS -> "COMMAND_SET_TRACK_SELECTION_PARAMETERS"
+                    Player.COMMAND_GET_TRACKS -> "COMMAND_GET_TRACKS"
+                    Player.COMMAND_RELEASE -> "COMMAND_RELEASE"
+                    else -> error("Unknown command $command")
+                }
+
+                add(commandName)
+            }
+        }.toString()
+    }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/utils/StringUtilTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/utils/StringUtilTest.kt
@@ -5,9 +5,12 @@
 package ch.srgssr.pillarbox.player.utils
 
 import androidx.media3.common.Player
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.runner.RunWith
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@RunWith(AndroidJUnit4::class)
 class StringUtilTest {
     @Test
     fun `media item transition reason string`() {
@@ -47,5 +50,75 @@ class StringUtilTest {
         assertEquals("DISCONTINUITY_REASON_SILENCE_SKIP", StringUtil.discontinuityReasonString(Player.DISCONTINUITY_REASON_SILENCE_SKIP))
         assertEquals("DISCONTINUITY_REASON_SKIP", StringUtil.discontinuityReasonString(Player.DISCONTINUITY_REASON_SKIP))
         assertEquals("UNKNOWN", StringUtil.discontinuityReasonString(42))
+    }
+
+    @Test
+    fun `player commands string`() {
+        assertEquals("[COMMAND_INVALID]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_INVALID)))
+        assertEquals("[COMMAND_PLAY_PAUSE]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_PLAY_PAUSE)))
+        assertEquals("[COMMAND_PREPARE]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_PREPARE)))
+        assertEquals("[COMMAND_STOP]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_STOP)))
+        assertEquals("[COMMAND_SEEK_TO_DEFAULT_POSITION]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_TO_DEFAULT_POSITION)))
+        assertEquals(
+            "[COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM]",
+            StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_IN_CURRENT_MEDIA_ITEM))
+        )
+        assertEquals(
+            "[COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM]",
+            StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM))
+        )
+        assertEquals("[COMMAND_SEEK_TO_PREVIOUS]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_TO_PREVIOUS)))
+        assertEquals("[COMMAND_SEEK_TO_NEXT_MEDIA_ITEM]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)))
+        assertEquals("[COMMAND_SEEK_TO_NEXT]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_TO_NEXT)))
+        assertEquals("[COMMAND_SEEK_TO_MEDIA_ITEM]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_TO_MEDIA_ITEM)))
+        assertEquals("[COMMAND_SEEK_BACK]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_BACK)))
+        assertEquals("[COMMAND_SEEK_FORWARD]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SEEK_FORWARD)))
+        assertEquals("[COMMAND_SET_SPEED_AND_PITCH]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_SPEED_AND_PITCH)))
+        assertEquals("[COMMAND_SET_SHUFFLE_MODE]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_SHUFFLE_MODE)))
+        assertEquals("[COMMAND_SET_REPEAT_MODE]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_REPEAT_MODE)))
+        assertEquals("[COMMAND_GET_CURRENT_MEDIA_ITEM]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_CURRENT_MEDIA_ITEM)))
+        assertEquals("[COMMAND_GET_TIMELINE]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_TIMELINE)))
+        assertEquals("[COMMAND_GET_METADATA]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_METADATA)))
+        assertEquals("[COMMAND_SET_PLAYLIST_METADATA]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_PLAYLIST_METADATA)))
+        assertEquals("[COMMAND_SET_MEDIA_ITEM]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_MEDIA_ITEM)))
+        assertEquals("[COMMAND_CHANGE_MEDIA_ITEMS]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_CHANGE_MEDIA_ITEMS)))
+        assertEquals("[COMMAND_GET_AUDIO_ATTRIBUTES]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_AUDIO_ATTRIBUTES)))
+        assertEquals("[COMMAND_GET_VOLUME]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_VOLUME)))
+        assertEquals("[COMMAND_GET_DEVICE_VOLUME]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_DEVICE_VOLUME)))
+        assertEquals("[COMMAND_SET_VOLUME]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_VOLUME)))
+        assertEquals("[COMMAND_SET_DEVICE_VOLUME]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_DEVICE_VOLUME)))
+        assertEquals(
+            "[COMMAND_SET_DEVICE_VOLUME_WITH_FLAGS]",
+            StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_DEVICE_VOLUME_WITH_FLAGS))
+        )
+        assertEquals("[COMMAND_ADJUST_DEVICE_VOLUME]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_ADJUST_DEVICE_VOLUME)))
+        assertEquals(
+            "[COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS]",
+            StringUtil.playerCommandsString(playerCommand(Player.COMMAND_ADJUST_DEVICE_VOLUME_WITH_FLAGS))
+        )
+        assertEquals("[COMMAND_SET_AUDIO_ATTRIBUTES]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_AUDIO_ATTRIBUTES)))
+        assertEquals("[COMMAND_SET_VIDEO_SURFACE]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_VIDEO_SURFACE)))
+        assertEquals("[COMMAND_GET_TEXT]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_TEXT)))
+        assertEquals(
+            "[COMMAND_SET_TRACK_SELECTION_PARAMETERS]",
+            StringUtil.playerCommandsString(playerCommand(Player.COMMAND_SET_TRACK_SELECTION_PARAMETERS))
+        )
+        assertEquals("[COMMAND_GET_TRACKS]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_TRACKS)))
+        assertEquals("[COMMAND_RELEASE]", StringUtil.playerCommandsString(playerCommand(Player.COMMAND_RELEASE)))
+        assertEquals(
+            "[COMMAND_GET_TRACKS, COMMAND_RELEASE]",
+            StringUtil.playerCommandsString(playerCommand(Player.COMMAND_GET_TRACKS, Player.COMMAND_RELEASE))
+        )
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `player commands string invalid command`() {
+        StringUtil.playerCommandsString(playerCommand(36))
+    }
+
+    private companion object {
+        private fun playerCommand(vararg commands: @Player.Command Int): Player.Commands {
+            return Player.Commands.Builder().addAll(*commands).build()
+        }
     }
 }


### PR DESCRIPTION
# Pull request

## Description

I've extracted the logic to define the supported commands in a dedicated method. This reduces the complexity of the `getState()` method, and makes it more readable.

## Changes made

- Extract the logic of the supported commands in a dedicated method.
- Add missing documentation to `PillarboxCastPlayer`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).