### PR TITLE
Improve remote to local playback

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -535,6 +535,7 @@ class PillarboxCastPlayer internal constructor(
 
         override fun onSessionEnding(session: CastSession) {
             Log.i(TAG, "onSessionEnding ${session.sessionId}")
+            sessionAvailabilityListener?.onCastSessionUnavailable()
         }
 
         override fun onSessionResumeFailed(session: CastSession, error: Int) {


### PR DESCRIPTION
# Pull request

## Description

Improve remote to local playback.

## Changes made

- Call `SessionAvailabilityListener.onCastSessionUnavailable` when disconnecting to allow integrators to retrieve the latest state of the player before disconnected.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
