### PR TITLE
SetMediaItems instead of Add to make it works with CastPlayer

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/playlist/PlaylistView.kt
@@ -76,7 +76,13 @@ fun PlaylistView(
         MediaItemLibraryDialog(
             items = mediaItemLibrary,
             onAddClick = { selectedItems ->
-                player.addMediaItems(selectedItems.map { it.toMediaItem() })
+                val items = selectedItems.map { it.toMediaItem() }
+                // Because CastPlayer doesn't support addMediaItems when empty.
+                if (player.mediaItemCount == 0) {
+                    player.setMediaItems(items)
+                } else {
+                    player.addMediaItems(items)
+                }
             },
             onDismissRequest = {
                 addItemDialogState = false

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcaseViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcaseViewModel.kt
@@ -14,9 +14,6 @@ import ch.srgssr.pillarbox.cast.PillarboxCastPlayer
 import ch.srgssr.pillarbox.cast.isCastSessionAvailableAsFlow
 import ch.srgssr.pillarbox.core.business.PillarboxExoPlayer
 import ch.srgssr.pillarbox.core.business.cast.PillarboxCastPlayer
-import ch.srgssr.pillarbox.demo.shared.data.samples.SamplesGoogle
-import ch.srgssr.pillarbox.demo.shared.data.samples.SamplesSRG
-import ch.srgssr.pillarbox.demo.shared.data.samples.SamplesUnifiedStreaming
 import ch.srgssr.pillarbox.player.PillarboxPlayer
 import ch.srgssr.pillarbox.player.extension.getCurrentMediaItems
 import kotlinx.coroutines.flow.Flow
@@ -55,19 +52,8 @@ class CastShowcaseViewModel(application: Application) : AndroidViewModel(applica
     }
 
     private fun setupPlayer(player: Player) {
-        if (player.mediaItemCount == 0) {
-            val mediaItems = listOf(
-                SamplesUnifiedStreaming.DASH_Multiple_TTML,
-                SamplesGoogle.DashH265Widevine,
-                SamplesSRG.OnDemandAudio,
-                SamplesSRG.OnDemandAudioMP3,
-                SamplesSRG.OnDemandHorizontalVideo,
-                SamplesSRG.DvrVideo,
-            ).map { it.toMediaItem() }
-            player.setMediaItems(mediaItems)
-            player.prepare()
-            player.play()
-        }
+        player.prepare()
+        player.play()
         listItems = player.getCurrentMediaItems()
         player.addListener(itemTracking)
     }


### PR DESCRIPTION
# Pull request

## Description

Media3 CastPlayer doesn't support AddMediaItems when the player doesn't have any items.

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
