### PR TITLE
Fix Cast icon color in the Cast showcase

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/cast/CastShowcase.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -31,6 +32,7 @@ import ch.srgssr.pillarbox.demo.shared.data.samples.SamplesUnifiedStreaming
 import ch.srgssr.pillarbox.demo.ui.player.playlist.PlaylistView
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
 import ch.srgssr.pillarbox.ui.exoplayer.ExoPlayerView
+import androidx.compose.ui.graphics.Color as ComposeColor
 
 /**
  * Showcase for cast integration
@@ -44,7 +46,7 @@ fun CastShowcase() {
             modifier = Modifier
                 .fillMaxWidth()
                 .weight(1f)
-                .background(color = androidx.compose.ui.graphics.Color.Black),
+                .background(color = ComposeColor.Black),
         ) {
             ExoPlayerView(
                 player = player,
@@ -68,6 +70,12 @@ fun CastShowcase() {
                     .addControlCategory(MediaControlIntent.CATEGORY_LIVE_VIDEO)
                     .addControlCategory(MediaControlIntent.CATEGORY_REMOTE_PLAYBACK)
                     .build(),
+                colors = IconButtonColors(
+                    containerColor = ComposeColor.Transparent,
+                    contentColor = ComposeColor.White,
+                    disabledContainerColor = ComposeColor.Transparent,
+                    disabledContentColor = ComposeColor.White,
+                ),
             )
         }
 


### PR DESCRIPTION
# Pull request

## Description

This PR fixes the Cast icon color in the Cast showcase.

| Light mode | Dark mode |
|-----|-----|
| ![Screenshot 2025-05-07 at 11 31 16](https://github.com/user-attachments/assets/a6a42348-0f27-45e5-8338-718221740987) | ![Screenshot 2025-05-07 at 11 32 42](https://github.com/user-attachments/assets/8e2c8ddf-67b7-4064-92bc-956fdc211f72) |

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).