### PR TITLE
Edit playlist in the TV demo

### DIFF
--- a/pillarbox-demo-tv/build.gradle.kts
+++ b/pillarbox-demo-tv/build.gradle.kts
@@ -4,6 +4,7 @@
  */
 plugins {
     alias(libs.plugins.pillarbox.android.application)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 dependencies {

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/PlayerView.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/PlayerView.kt
@@ -110,7 +110,6 @@ private enum class DrawerMode {
  * @param metricsOverlayEnabled
  * @param metricsOverlayOptions
  */
-
 @Suppress("CyclomaticComplexMethod")
 @Composable
 fun PlayerView(

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/controls/DrawerContent.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/controls/DrawerContent.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.tv.ui.player.compose.controls
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.tv.material3.LocalTextStyle
+import androidx.tv.material3.MaterialTheme
+import androidx.tv.material3.NavigationDrawerItem
+import androidx.tv.material3.NavigationDrawerScope
+import ch.srgssr.pillarbox.demo.tv.ui.theme.paddings
+
+@Composable
+internal fun DrawerContent(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    listContent: LazyListScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = MaterialTheme.paddings.baseline)
+            .padding(top = MaterialTheme.paddings.baseline),
+    ) {
+        CompositionLocalProvider(LocalTextStyle provides MaterialTheme.typography.titleMedium) {
+            title()
+        }
+
+        LazyColumn(
+            contentPadding = PaddingValues(vertical = MaterialTheme.paddings.baseline),
+            verticalArrangement = Arrangement.spacedBy(MaterialTheme.paddings.baseline),
+        ) {
+            listContent()
+        }
+    }
+}
+
+@Composable
+internal fun <T> NavigationDrawerScope.DrawerContent(
+    title: @Composable () -> Unit,
+    items: List<T>,
+    isItemSelected: (index: Int, item: T) -> Boolean,
+    modifier: Modifier = Modifier,
+    onItemClick: (index: Int, item: T) -> Unit,
+    leadingContent: @Composable (item: T) -> Unit,
+    supportingContent: @Composable (item: T) -> Unit = {},
+    content: @Composable (item: T) -> Unit,
+) {
+    DrawerContent(
+        title = title,
+        modifier = modifier,
+        listContent = {
+            itemsIndexed(items) { index, item ->
+                NavigationDrawerItem(
+                    selected = isItemSelected(index, item),
+                    onClick = { onItemClick(index, item) },
+                    leadingContent = { leadingContent(item) },
+                    supportingContent = { supportingContent(item) },
+                    content = { content(item) },
+                )
+            }
+        },
+    )
+}

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/EditPlaylist.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/EditPlaylist.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.tv.ui.player.compose.playlist
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.media3.common.MediaItem
+import androidx.tv.material3.Icon
+import androidx.tv.material3.NavigationDrawerScope
+import androidx.tv.material3.Text
+import ch.srgssr.pillarbox.demo.tv.R
+import ch.srgssr.pillarbox.demo.tv.ui.player.compose.controls.DrawerContent
+
+@Composable
+internal fun NavigationDrawerScope.EditPlaylist(
+    items: List<MediaItem>,
+    playerItems: List<MediaItem>,
+    modifier: Modifier = Modifier,
+    onAddClick: (item: MediaItem) -> Unit,
+    onRemoveClick: (index: Int) -> Unit,
+) {
+    DrawerContent(
+        title = { Text(text = stringResource(R.string.edit_playlist)) },
+        items = items,
+        isItemSelected = { _, item ->
+            item in playerItems
+        },
+        modifier = modifier,
+        onItemClick = { _, item ->
+            if (item in playerItems) {
+                onRemoveClick(playerItems.indexOf(item))
+            } else {
+                onAddClick(item)
+            }
+        },
+        leadingContent = { item ->
+            AnimatedVisibility(visible = item in playerItems) {
+                Icon(
+                    imageVector = Icons.Default.Check,
+                    contentDescription = null,
+                )
+            }
+        },
+        supportingContent = { item ->
+            if (item.mediaMetadata.description != null) {
+                Text(
+                    text = item.mediaMetadata.description.toString(),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                )
+            }
+        },
+        content = { item ->
+            Text(
+                text = item.mediaMetadata.title.toString(),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+            )
+        },
+    )
+}

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/PlaylistContent.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/PlaylistContent.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.tv.ui.player.compose.playlist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.media3.common.MediaItem
+import androidx.tv.material3.Icon
+import androidx.tv.material3.IconButton
+import androidx.tv.material3.NavigationDrawerScope
+import androidx.tv.material3.Text
+import ch.srgssr.pillarbox.demo.tv.R
+import ch.srgssr.pillarbox.demo.tv.ui.player.compose.controls.DrawerContent
+import coil3.compose.AsyncImage
+
+@Composable
+internal fun NavigationDrawerScope.PlaylistContent(
+    mediaItems: List<MediaItem>,
+    currentMediaItemIndex: Int,
+    modifier: Modifier = Modifier,
+    onItemClick: (index: Int, item: MediaItem) -> Unit,
+    onEditClick: () -> Unit,
+) {
+    DrawerContent(
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(text = stringResource(R.string.playlist))
+
+                IconButton(onClick = onEditClick) {
+                    Icon(
+                        imageVector = Icons.Default.Edit,
+                        contentDescription = stringResource(R.string.edit_playlist),
+                    )
+                }
+            }
+        },
+        items = mediaItems,
+        isItemSelected = { index, _ ->
+            index == currentMediaItemIndex
+        },
+        modifier = modifier,
+        onItemClick = onItemClick,
+        leadingContent = { item ->
+            AsyncImage(
+                model = item.mediaMetadata.artworkUri,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+            )
+        },
+        supportingContent = { item ->
+            if (item.mediaMetadata.description != null) {
+                Text(
+                    text = item.mediaMetadata.description.toString(),
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                )
+            }
+        },
+        content = { item ->
+            Text(
+                text = item.mediaMetadata.title.toString(),
+                overflow = TextOverflow.Ellipsis,
+                maxLines = 1,
+            )
+        },
+    )
+}

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/PlaylistRoutes.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/PlaylistRoutes.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.tv.ui.player.compose.playlist
+
+import kotlinx.serialization.Serializable
+
+/**
+ * All the routes used in the player's playlist drawer.
+ */
+@Serializable
+sealed interface PlaylistRoutes {
+    /**
+     * The route for the main screen of the playlist.
+     */
+    @Serializable
+    data object Main : PlaylistRoutes
+
+    /**
+     * The route for the playlist edition.
+     */
+    @Serializable
+    data object Edit : PlaylistRoutes
+}

--- a/pillarbox-demo-tv/src/main/res/values/strings.xml
+++ b/pillarbox-demo-tv/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
   -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
     <string name="app_name">Pillarbox Demo Tv</string>
+    <string name="edit_playlist">Edit playlist</string>
     <string name="loading">Loading…</string>
     <string name="no_content">No content</string>
     <string name="playlist">Playlist</string>


### PR DESCRIPTION
# Pull request

## Description

This PR adds the ability to modify the playlist from the TV demo. In particular, it allows adding and removing items from the playlist.

## Changes made

- Add a new playlist edition screen to add and remove items from the playlist.
- Create a new `DrawerContent` composable for the TV demo.

## Screenshots

| Description | Screenshot |
|--------|--------|
| Playlist content | ![Screenshot_20250514_161912](https://github.com/user-attachments/assets/6a9e43a8-9620-4a51-8344-b30096bead2f) |
| Playlist edition | ![Screenshot_20250514_161926](https://github.com/user-attachments/assets/f02b3bb2-7f53-4a2c-83e7-9026ac0f4b54) |

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).