### PR TITLE
Add ordering of the playlist in the TV demo

### DIFF
--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/PlaylistDrawer.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/compose/playlist/PlaylistDrawer.kt
@@ -48,6 +48,7 @@ fun NavigationDrawerScope.PlaylistDrawer(
                 onEditClick = {
                     navController.navigate(PlaylistRoutes.Edit)
                 },
+                onItemMoved = player::moveMediaItem,
             )
         }
 


### PR DESCRIPTION
# Pull request

## Description

This PR adds the ability to sort the items of the playlist to the TV demo.

## Changes made

- Add a long-click event to each item of the playlist to start the move action.
- When going up or down, the item is moved accordingly.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).