### PR TITLE
Use non-deprecated methods

### DIFF
--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/settings/PlayerSettingsViewModel.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/ui/player/settings/PlayerSettingsViewModel.kt
@@ -249,7 +249,7 @@ class PlayerSettingsViewModel(
      * Reset the subtitles.
      */
     fun resetSubtitles() {
-        player.setAutoTextTrack(application)
+        player.setAutoTextTrack()
     }
 
     /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/TrackSelectionParameters.kt
@@ -126,16 +126,15 @@ fun TrackSelectionParameters.disableVideoTrack(): TrackSelectionParameters {
 /**
  * Returns a copy of this [TrackSelectionParameters] with default settings for text tracks.
  *
- * @param context The [Context].
  * @return A new [TrackSelectionParameters] instance with default settings for text tracks.
  */
-fun TrackSelectionParameters.defaultTextTrack(context: Context): TrackSelectionParameters {
+fun TrackSelectionParameters.defaultTextTrack(): TrackSelectionParameters {
     return buildUpon()
         .clearOverridesOfType(C.TRACK_TYPE_TEXT)
         .setIgnoredTextSelectionFlags(0)
         .setPreferredTextLanguage(null)
         .setPreferredTextRoleFlags(0)
-        .setPreferredTextLanguageAndRoleFlagsToCaptioningManagerSettings(context)
+        .setPreferredTextLanguageAndRoleFlagsToCaptioningManagerSettings()
         .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
         .build()
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracks/PlayerExtensions.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracks/PlayerExtensions.kt
@@ -82,11 +82,9 @@ fun Player.setAutoAudioTrack(context: Context) {
 
 /**
  * Sets the track selection to automatically select the default text track.
- *
- * @param context The [Context].
  */
-fun Player.setAutoTextTrack(context: Context) {
-    trackSelectionParameters = trackSelectionParameters.defaultTextTrack(context)
+fun Player.setAutoTextTrack() {
+    trackSelectionParameters = trackSelectionParameters.defaultTextTrack()
 }
 
 /**


### PR DESCRIPTION
# Pull request

## Description

Stop using depreciated methods. TrackSelectionParameters doesn't needs Context.

What can we do with the `setPreferredAudioRoleFlagsToAccessibilityManagerSettings` ? It is very complicated to enhanced a custom `TrackSelector` with a custom `TrackSelectionParameters`.

## Changes made

- Remove `Context` parameters where needed

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
