### PR TITLE
Fix deprecations

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxTrackSelector.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxTrackSelector.kt
@@ -20,7 +20,7 @@ import ch.srgssr.pillarbox.player.extension.setPreferredAudioRoleFlagsToAccessib
 fun PillarboxTrackSelector(context: Context): TrackSelector {
     return DefaultTrackSelector(
         context,
-        TrackSelectionParameters.Builder(context)
+        TrackSelectionParameters.Builder()
             .setPreferredAudioRoleFlagsToAccessibilityManagerSettings(context)
             .build(),
     )

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/analytics/PlaybackSessionManager.kt
@@ -281,6 +281,7 @@ class PlaybackSessionManager : AnalyticsListener {
         eventTime: EventTime,
         loadEventInfo: LoadEventInfo,
         mediaLoadData: MediaLoadData,
+        retryCount: Int,
     ) {
         getOrCreateSession(eventTime)
     }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
@@ -165,7 +165,7 @@ internal class Monitoring(
         }
     }
 
-    override fun onLoadStarted(eventTime: AnalyticsListener.EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
+    override fun onLoadStarted(eventTime: AnalyticsListener.EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData, retryCount: Int) {
         setAssetUrlForEventTime(eventTime, loadEventInfo, mediaLoadData)
     }
 


### PR DESCRIPTION
# Pull request

## Description

This PR follows-up on #1034 to fix a couple more deprecations.

## Changes made

- Use the `TrackSelectionParameters.Builder()` constructor that does not require a `Context`.
- Override the `AnalyticsListener`'s `onLoadStarted()` method that takes a `retryCount: Int` argument.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).