### PR TITLE
Improve service

### DIFF
--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -50,6 +50,13 @@
             android:launchMode="singleTask"
             android:supportsPictureInPicture="true" />
         <activity
+            android:name=".ui.showcases.integrations.auto.MediaBrowserActivity"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|smallestScreenSize"
+            android:exported="true"
+            android:launchMode="singleTask"
+            android:supportsPictureInPicture="true" />
+
+        <activity
             android:name=".ui.showcases.integrations.MediaControllerActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|smallestScreenSize"
             android:exported="true"

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -64,6 +64,7 @@
             android:name=".service.DemoMediaSessionService"
             android:exported="true"
             android:foregroundServiceType="mediaPlayback"
+            android:stopWithTask="true"
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaSessionService" />
@@ -74,6 +75,7 @@
             android:name=".service.DemoMediaLibraryService"
             android:enabled="true"
             android:exported="true"
+            android:stopWithTask="true"
             android:foregroundServiceType="mediaPlayback"
             tools:ignore="ExportedService">
             <intent-filter>

--- a/pillarbox-demo/src/main/AndroidManifest.xml
+++ b/pillarbox-demo/src/main/AndroidManifest.xml
@@ -1,4 +1,7 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Copyright (c) SRG SSR. All rights reserved.
+  ~ License information is available from the LICENSE file.
+  -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
@@ -82,8 +85,8 @@
             android:name=".service.DemoMediaLibraryService"
             android:enabled="true"
             android:exported="true"
-            android:stopWithTask="true"
             android:foregroundServiceType="mediaPlayback"
+            android:stopWithTask="true"
             tools:ignore="ExportedService">
             <intent-filter>
                 <action android:name="androidx.media3.session.MediaLibraryService" />

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/service/DemoMediaLibraryService.kt
@@ -14,7 +14,7 @@ import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaSession
 import ch.srgssr.pillarbox.demo.shared.data.DemoBrowser
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
-import ch.srgssr.pillarbox.demo.ui.showcases.integrations.MediaControllerActivity
+import ch.srgssr.pillarbox.demo.ui.showcases.integrations.auto.MediaBrowserActivity
 import ch.srgssr.pillarbox.player.session.PillarboxMediaLibraryService
 import ch.srgssr.pillarbox.player.session.PillarboxMediaLibrarySession
 import ch.srgssr.pillarbox.player.session.PillarboxMediaSession
@@ -43,7 +43,7 @@ class DemoMediaLibraryService : PillarboxMediaLibraryService() {
     }
 
     override fun sessionActivity(): PendingIntent {
-        val intent = Intent(applicationContext, MediaControllerActivity::class.java)
+        val intent = Intent(applicationContext, MediaBrowserActivity::class.java)
         val flags = PendingIntentUtils.appendImmutableFlagIfNeeded(PendingIntent.FLAG_UPDATE_CURRENT)
         return PendingIntent.getActivity(
             applicationContext,

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
@@ -206,7 +206,7 @@ fun ShowcasesHome(navController: NavController) {
 
             DemoListItemView(
                 title = stringResource(R.string.auto),
-                modifier = itemModifier(2),
+                modifier = itemModifier(3),
                 onClick = {
                     val intent = Intent(context, MediaBrowserActivity::class.java)
                     context.startActivity(intent)
@@ -217,7 +217,7 @@ fun ShowcasesHome(navController: NavController) {
 
             DemoListItemView(
                 title = stringResource(R.string.google_cast),
-                modifier = itemModifier(3),
+                modifier = itemModifier(4),
                 onClick = {
                     navController.navigate(NavigationRoutes.CastShowcase)
                 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/ShowcasesHome.kt
@@ -33,6 +33,7 @@ import ch.srgssr.pillarbox.demo.ui.components.DemoListItemView
 import ch.srgssr.pillarbox.demo.ui.components.DemoListSectionView
 import ch.srgssr.pillarbox.demo.ui.player.SimplePlayerActivity
 import ch.srgssr.pillarbox.demo.ui.showcases.integrations.MediaControllerActivity
+import ch.srgssr.pillarbox.demo.ui.showcases.integrations.auto.MediaBrowserActivity
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
@@ -193,10 +194,21 @@ fun ShowcasesHome(navController: NavController) {
             HorizontalDivider()
 
             DemoListItemView(
-                title = stringResource(R.string.auto),
+                title = stringResource(R.string.media_controller),
                 modifier = itemModifier(2),
                 onClick = {
                     val intent = Intent(context, MediaControllerActivity::class.java)
+                    context.startActivity(intent)
+                }
+            )
+
+            HorizontalDivider()
+
+            DemoListItemView(
+                title = stringResource(R.string.auto),
+                modifier = itemModifier(2),
+                onClick = {
+                    val intent = Intent(context, MediaBrowserActivity::class.java)
                     context.startActivity(intent)
                 }
             )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserActivity.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.ui.showcases.integrations.auto
+
+import android.app.PictureInPictureParams
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.os.Build
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.flowWithLifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.media3.common.Player
+import ch.srgssr.pillarbox.analytics.SRGAnalytics
+import ch.srgssr.pillarbox.demo.DemoPageView
+import ch.srgssr.pillarbox.demo.trackPagView
+import ch.srgssr.pillarbox.demo.ui.player.DemoPlayerView
+import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+
+/**
+ * Media controller activity that handles a MediaBrowserService to play content with Android Auto.
+ *
+ * Using official guides for background playback at https://developer.android.com/guide/topics/media/media3/getting-started/playing-in-background
+ *
+ * @constructor Create empty Media controller activity
+ */
+class MediaBrowserActivity : ComponentActivity() {
+    private val controllerViewModel: MediaBrowserViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            lifecycleScope.launch {
+                controllerViewModel.pictureInPictureRatio.flowWithLifecycle(lifecycle, Lifecycle.State.CREATED).collectLatest {
+                    val params = PictureInPictureParams.Builder()
+                        .setAspectRatio(it)
+                        .build()
+                    setPictureInPictureParams(params)
+                }
+            }
+        }
+
+        setContent {
+            PillarboxTheme {
+                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
+                    val mediaBrowser by controllerViewModel.player.collectAsState()
+                    mediaBrowser?.let { player ->
+                        MainView(player = player)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun isPictureInPicturePossible(): Boolean {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            return packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+        }
+        return false
+    }
+
+    @Composable
+    private fun MainView(player: Player) {
+        val pictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
+        val pictureInPicture by controllerViewModel.pictureInPictureEnabled.collectAsState()
+        DemoPlayerView(
+            player = player,
+            pictureInPicture = pictureInPicture,
+            pictureInPictureClick = pictureInPictureClick,
+            displayPlaylist = true
+        )
+    }
+
+    private fun startPictureInPicture() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val params = PictureInPictureParams.Builder()
+                .setAspectRatio(controllerViewModel.pictureInPictureRatio.value)
+                .build()
+            enterPictureInPictureMode(params)
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            @Suppress("DEPRECATION")
+            enterPictureInPictureMode()
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: Configuration
+    ) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        controllerViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {
+        super.onConfigurationChanged(newConfig)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) return
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            controllerViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        SRGAnalytics.trackPagView(DemoPageView("media browser player", levels = listOf("app", "pillarbox")))
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserActivity.kt
@@ -40,13 +40,13 @@ import kotlinx.coroutines.launch
  * @constructor Create empty Media controller activity
  */
 class MediaBrowserActivity : ComponentActivity() {
-    private val controllerViewModel: MediaBrowserViewModel by viewModels()
+    private val browserViewModel: MediaBrowserViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             lifecycleScope.launch {
-                controllerViewModel.pictureInPictureRatio.flowWithLifecycle(lifecycle, Lifecycle.State.CREATED).collectLatest {
+                browserViewModel.pictureInPictureRatio.flowWithLifecycle(lifecycle, Lifecycle.State.CREATED).collectLatest {
                     val params = PictureInPictureParams.Builder()
                         .setAspectRatio(it)
                         .build()
@@ -58,7 +58,7 @@ class MediaBrowserActivity : ComponentActivity() {
         setContent {
             PillarboxTheme {
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
-                    val mediaBrowser by controllerViewModel.player.collectAsState()
+                    val mediaBrowser by browserViewModel.player.collectAsState()
                     mediaBrowser?.let { player ->
                         MainView(player = player)
                     }
@@ -77,7 +77,7 @@ class MediaBrowserActivity : ComponentActivity() {
     @Composable
     private fun MainView(player: Player) {
         val pictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
-        val pictureInPicture by controllerViewModel.pictureInPictureEnabled.collectAsState()
+        val pictureInPicture by browserViewModel.pictureInPictureEnabled.collectAsState()
         DemoPlayerView(
             player = player,
             pictureInPicture = pictureInPicture,
@@ -89,7 +89,7 @@ class MediaBrowserActivity : ComponentActivity() {
     private fun startPictureInPicture() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val params = PictureInPictureParams.Builder()
-                .setAspectRatio(controllerViewModel.pictureInPictureRatio.value)
+                .setAspectRatio(browserViewModel.pictureInPictureRatio.value)
                 .build()
             enterPictureInPictureMode(params)
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -104,14 +104,14 @@ class MediaBrowserActivity : ComponentActivity() {
         newConfig: Configuration
     ) {
         super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
-        controllerViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
+        browserViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
         super.onConfigurationChanged(newConfig)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) return
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            controllerViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
+            browserViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
         }
     }
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserViewModel.kt
@@ -2,15 +2,15 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
-package ch.srgssr.pillarbox.demo.ui.showcases.integrations
+package ch.srgssr.pillarbox.demo.ui.showcases.integrations.auto
 
 import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import ch.srgssr.pillarbox.demo.service.DemoMediaSessionService
+import ch.srgssr.pillarbox.demo.service.DemoMediaLibraryService
 import ch.srgssr.pillarbox.player.extension.RATIONAL_ONE
 import ch.srgssr.pillarbox.player.extension.toRational
-import ch.srgssr.pillarbox.player.session.PillarboxMediaController
+import ch.srgssr.pillarbox.player.session.PillarboxMediaBrowser
 import ch.srgssr.pillarbox.player.videoSizeAsFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
@@ -23,17 +23,17 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
 /**
- * Media controller view model
+ * Media browser view model
  *
  * @param application
  */
-class MediaControllerViewModel(application: Application) : AndroidViewModel(application) {
+class MediaBrowserViewModel(application: Application) : AndroidViewModel(application) {
 
     /**
      * Player
      */
     val player = callbackFlow {
-        val mediaBrowser = PillarboxMediaController.Builder(application, DemoMediaSessionService::class.java).build()
+        val mediaBrowser = PillarboxMediaBrowser.Builder(application, DemoMediaLibraryService::class.java).build()
         trySend(mediaBrowser)
         awaitClose {
             mediaBrowser.release()

--- a/pillarbox-demo/src/main/res/values/strings.xml
+++ b/pillarbox-demo/src/main/res/values/strings.xml
@@ -15,7 +15,8 @@
     <string name="layouts">Layouts</string>
     <string name="story">Story</string>
     <string name="simple_player">Simple</string>
-    <string name="auto">MediaController (Android Auto)</string>
+    <string name="auto">MediaBrowser (Android Auto)</string>
+    <string name="media_controller">MediaSession service</string>
     <string name="adaptive">Resizable player</string>
     <string name="player_swap">Multi player</string>
     <string name="misc">Misc</string>

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
@@ -5,7 +5,6 @@
 package ch.srgssr.pillarbox.player.session
 
 import android.app.PendingIntent
-import android.content.Intent
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSession.ControllerInfo
@@ -36,6 +35,7 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  *     android:name=".service.DemoMediaLibraryService"
  *     android:enabled="true"
  *     android:exported="true"
+ *     android:stopWithTask="true"
  *     android:foregroundServiceType="mediaPlayback">
  *     <intent-filter>
  *         <action android:name="androidx.media3.session.MediaLibraryService" />
@@ -56,11 +56,6 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  */
 abstract class PillarboxMediaLibraryService : MediaLibraryService() {
     private var mediaSession: PillarboxMediaLibrarySession? = null
-
-    /**
-     * Release on task removed
-     */
-    var releaseOnTaskRemoved = true
 
     /**
      * Set player to use with this Service.
@@ -99,9 +94,8 @@ abstract class PillarboxMediaLibraryService : MediaLibraryService() {
 
     /**
      * Release the player and the MediaSession.
-     * The [mediaSession] is set to null after this call
-     *
-     * called automatically in [onDestroy] and [onTaskRemoved] is [releaseOnTaskRemoved] = true
+     * The [mediaSession] is set to null after this call.
+     * Called automatically in [onDestroy]
      */
     open fun release() {
         mediaSession?.run {
@@ -112,18 +106,7 @@ abstract class PillarboxMediaLibraryService : MediaLibraryService() {
     }
 
     override fun onDestroy() {
-        release()
         super.onDestroy()
-    }
-
-    /**
-     * We choose to stop playback when user remove application from the tasks
-     */
-    override fun onTaskRemoved(rootIntent: Intent?) {
-        super.onTaskRemoved(rootIntent)
-        if (releaseOnTaskRemoved) {
-            release()
-            stopSelf()
-        }
+        release()
     }
 }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
@@ -5,7 +5,6 @@
 package ch.srgssr.pillarbox.player.session
 
 import android.app.PendingIntent
-import android.content.Intent
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
 import ch.srgssr.pillarbox.player.PillarboxPlayer
@@ -32,6 +31,7 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
  * <service
  *     android:name=".service.DemoMediaSessionService"
  *     android:exported="true"
+ *     android:stopWithTask="true"
  *     android:foregroundServiceType="mediaPlayback">
  *     <intent-filter>
  *         <action android:name="androidx.media3.session.MediaSessionService" />
@@ -52,11 +52,6 @@ import ch.srgssr.pillarbox.player.utils.PendingIntentUtils
 @Suppress("MemberVisibilityCanBePrivate")
 abstract class PillarboxMediaSessionService : MediaSessionService() {
     private var mediaSession: PillarboxMediaSession? = null
-
-    /**
-     * Release on task removed
-     */
-    var releaseOnTaskRemoved = true
 
     /**
      * Set player to use with this Service.
@@ -91,15 +86,14 @@ abstract class PillarboxMediaSessionService : MediaSessionService() {
     open fun sessionActivity(): PendingIntent? = PendingIntentUtils.getDefaultPendingIntent(this)
 
     override fun onDestroy() {
-        release()
         super.onDestroy()
+        release()
     }
 
     /**
      * Release the player and the MediaSession.
      * The [mediaSession] is set to null after this call
-     *
-     * called automatically in [onDestroy] and [onTaskRemoved] is [releaseOnTaskRemoved] = true
+     * Called automatically in [onDestroy]
      */
     open fun release() {
         mediaSession?.run {
@@ -113,16 +107,5 @@ abstract class PillarboxMediaSessionService : MediaSessionService() {
     // this request.
     override fun onGetSession(controllerInfo: MediaSession.ControllerInfo): MediaSession? {
         return mediaSession?.mediaSession
-    }
-
-    /**
-     * We choose to stop playback when user remove application from the tasks
-     */
-    override fun onTaskRemoved(rootIntent: Intent?) {
-        super.onTaskRemoved(rootIntent)
-        if (releaseOnTaskRemoved) {
-            release()
-            stopSelf()
-        }
     }
 }


### PR DESCRIPTION
# Pull request

## Description

The goal of this PR is to use default task removing from Android instead of  handle it inside the customs Pillarbox classes.

Integrators have to update the service definition inside the manifest with `android:stopWithTask="true"`

## Changes made

- Add showcase that use a `MediaSessionService`.
- Remove `onTaskRemoved` that can be configured inside the manifest.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
