### PR TITLE
Integrate shuffle/repeat modes inside the demo player

### DIFF
--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerActivity.kt
@@ -111,12 +111,12 @@ class SimplePlayerActivity : ComponentActivity(), ServiceConnection {
 
     @Composable
     private fun MainContent(player: Player) {
-        val pictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
-        val pictureInPicture by playerViewModel.pictureInPictureEnabled.collectAsState()
+        val onPictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
+        val pictureInPictureEnabled by playerViewModel.pictureInPictureEnabled.collectAsState()
         DemoPlayerView(
             player = player,
-            pictureInPicture = pictureInPicture,
-            pictureInPictureClick = pictureInPictureClick,
+            pictureInPictureEnabled = pictureInPictureEnabled,
+            onPictureInPictureClick = onPictureInPictureClick,
             displayPlaylist = layoutStyle == LAYOUT_PLAYLIST,
         )
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
@@ -4,69 +4,164 @@
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Fullscreen
 import androidx.compose.material.icons.filled.FullscreenExit
 import androidx.compose.material.icons.filled.PictureInPicture
+import androidx.compose.material.icons.filled.Repeat
+import androidx.compose.material.icons.filled.RepeatOn
+import androidx.compose.material.icons.filled.RepeatOneOn
 import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Shuffle
+import androidx.compose.material.icons.filled.ShuffleOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconToggleButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
-import ch.srgssr.pillarbox.demo.shared.R
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.media3.common.Player
+import ch.srgssr.pillarbox.demo.R
+import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
+import ch.srgssr.pillarbox.demo.shared.R as sharedR
 
 /**
  * Player bottom toolbar that contains Picture in Picture and fullscreen buttons.
  *
- * @param fullScreenEnabled if fullscreen is enabled
- * @param modifier The modifier to be applied to the layout.
- * @param fullScreenClicked action when fullscreen button is clicked
- * @param pictureInPictureClicked action when picture in picture is clicked
- * @param optionClicked action when settings is clicked
+ * @param modifier The [Modifier] to apply to the layout.
+ * @param shuffleEnabled Whether the shuffle mode is enabled.
+ * @param onShuffleClick The action to perform when the shuffle button is clicked. `null` to hide the button.
+ * @param repeatMode The repeat mode.
+ * @param onRepeatClick The action to perform when the repeat button is clicked. `null` to hide the button.
+ * @param pictureInPictureEnabled Whether picture in picture is enabled.
+ * @param onPictureInPictureClick The action to perform when the picture in picture button is clicked. `null` to hide the button.
+ * @param fullScreenEnabled Whether fullscreen is enabled.
+ * @param onFullscreenClick The action to perform when the fullscreen button is clicked. `null` to hide the button.
+ * @param onSettingsClick The action to perform when the settings button is clicked. `null` to hide the button.
  */
 @Composable
 fun PlayerBottomToolbar(
-    fullScreenEnabled: Boolean,
     modifier: Modifier = Modifier,
-    fullScreenClicked: () -> Unit,
-    pictureInPictureClicked: (() -> Unit)?,
-    optionClicked: () -> Unit,
+    shuffleEnabled: Boolean,
+    onShuffleClick: (() -> Unit)?,
+    repeatMode: @Player.RepeatMode Int,
+    onRepeatClick: (() -> Unit)?,
+    pictureInPictureEnabled: Boolean,
+    onPictureInPictureClick: (() -> Unit)?,
+    fullScreenEnabled: Boolean,
+    onFullscreenClick: (() -> Unit)?,
+    onSettingsClick: () -> Unit,
 ) {
     Row(modifier = modifier) {
-        pictureInPictureClicked?.let {
-            IconButton(onClick = it) {
+        CompositionLocalProvider(LocalContentColor provides Color.White) {
+            ToggleableIconButton(
+                checked = shuffleEnabled,
+                icon = if (shuffleEnabled) Icons.Default.ShuffleOn else Icons.Default.Shuffle,
+                contentDestination = stringResource(R.string.shuffle),
+                onCheckedChange = onShuffleClick,
+            )
+
+            ToggleableIconButton(
+                checked = repeatMode != Player.REPEAT_MODE_OFF,
+                icon = when (repeatMode) {
+                    Player.REPEAT_MODE_OFF -> Icons.Default.Repeat
+                    Player.REPEAT_MODE_ONE -> Icons.Default.RepeatOneOn
+                    Player.REPEAT_MODE_ALL -> Icons.Default.RepeatOn
+                    else -> error("Unrecognized repeat mode $repeatMode")
+                },
+                contentDestination = stringResource(R.string.repeat_mode),
+                onCheckedChange = onRepeatClick,
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            ToggleableIconButton(
+                checked = pictureInPictureEnabled,
+                icon = Icons.Default.PictureInPicture,
+                contentDestination = stringResource(R.string.picture_in_picture),
+                onCheckedChange = onPictureInPictureClick,
+            )
+
+            ToggleableIconButton(
+                checked = fullScreenEnabled,
+                icon = if (fullScreenEnabled) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
+                contentDestination = stringResource(R.string.fullscreen),
+                onCheckedChange = onFullscreenClick,
+            )
+
+            IconButton(onClick = onSettingsClick) {
                 Icon(
-                    tint = Color.White,
-                    imageVector = Icons.Default.PictureInPicture,
-                    contentDescription = "Picture in picture"
+                    imageVector = Icons.Default.Settings,
+                    contentDescription = stringResource(sharedR.string.settings),
                 )
             }
         }
+    }
+}
 
-        IconButton(onClick = fullScreenClicked) {
-            if (fullScreenEnabled) {
-                Icon(
-                    tint = Color.White,
-                    imageVector = Icons.Default.FullscreenExit,
-                    contentDescription = "Exit fullscreen"
-                )
-            } else {
-                Icon(
-                    tint = Color.White,
-                    imageVector = Icons.Default.Fullscreen,
-                    contentDescription = "Enter fullscreen"
-                )
-            }
-        }
-
-        IconButton(onClick = optionClicked) {
+@Composable
+private fun ToggleableIconButton(
+    checked: Boolean,
+    icon: ImageVector,
+    contentDestination: String,
+    onCheckedChange: (() -> Unit)?,
+) {
+    AnimatedVisibility(visible = onCheckedChange != null) {
+        IconToggleButton(
+            checked = checked,
+            onCheckedChange = { onCheckedChange?.invoke() },
+        ) {
             Icon(
-                tint = Color.White,
-                imageVector = Icons.Default.Settings,
-                contentDescription = stringResource(R.string.settings)
+                imageVector = icon,
+                contentDescription = contentDestination,
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PlayerBottomToolbarPreview() {
+    var shuffleEnabled by remember { mutableStateOf(false) }
+    var repeatMode by remember { mutableIntStateOf(Player.REPEAT_MODE_OFF) }
+    var pictureInPictureEnabled by remember { mutableStateOf(false) }
+    var fullscreenEnabled by remember { mutableStateOf(false) }
+
+    PillarboxTheme {
+        Surface {
+            PlayerBottomToolbar(
+                modifier = Modifier.background(Color.Black),
+                shuffleEnabled = shuffleEnabled,
+                onShuffleClick = { shuffleEnabled = !shuffleEnabled },
+                repeatMode = repeatMode,
+                onRepeatClick = {
+                    repeatMode = when (repeatMode) {
+                        Player.REPEAT_MODE_OFF -> Player.REPEAT_MODE_ONE
+                        Player.REPEAT_MODE_ONE -> Player.REPEAT_MODE_ALL
+                        Player.REPEAT_MODE_ALL -> Player.REPEAT_MODE_OFF
+                        else -> error("Unrecognized repeat mode $repeatMode")
+                    }
+                },
+                pictureInPictureEnabled = pictureInPictureEnabled,
+                onPictureInPictureClick = { pictureInPictureEnabled = !pictureInPictureEnabled },
+                fullScreenEnabled = fullscreenEnabled,
+                onFullscreenClick = { fullscreenEnabled = !fullscreenEnabled },
+                onSettingsClick = {},
             )
         }
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/MediaControllerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/MediaControllerActivity.kt
@@ -76,12 +76,12 @@ class MediaControllerActivity : ComponentActivity() {
 
     @Composable
     private fun MainView(player: Player) {
-        val pictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
-        val pictureInPicture by controllerViewModel.pictureInPictureEnabled.collectAsState()
+        val onPictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
+        val pictureInPictureEnabled by controllerViewModel.pictureInPictureEnabled.collectAsState()
         DemoPlayerView(
             player = player,
-            pictureInPicture = pictureInPicture,
-            pictureInPictureClick = pictureInPictureClick,
+            pictureInPictureEnabled = pictureInPictureEnabled,
+            onPictureInPictureClick = onPictureInPictureClick,
             displayPlaylist = true
         )
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserActivity.kt
@@ -76,12 +76,12 @@ class MediaBrowserActivity : ComponentActivity() {
 
     @Composable
     private fun MainView(player: Player) {
-        val pictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
-        val pictureInPicture by browserViewModel.pictureInPictureEnabled.collectAsState()
+        val onPictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
+        val pictureInPictureEnabled by browserViewModel.pictureInPictureEnabled.collectAsState()
         DemoPlayerView(
             player = player,
-            pictureInPicture = pictureInPicture,
-            pictureInPictureClick = pictureInPictureClick,
+            pictureInPictureEnabled = pictureInPictureEnabled,
+            onPictureInPictureClick = onPictureInPictureClick,
             displayPlaylist = true
         )
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/playlists/CustomPlaybackSettingsShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/playlists/CustomPlaybackSettingsShowcase.kt
@@ -4,49 +4,26 @@
  */
 package ch.srgssr.pillarbox.demo.ui.showcases.playlists
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.indication
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material3.DropdownMenu
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.CollectionInfo
-import androidx.compose.ui.semantics.CollectionItemInfo
-import androidx.compose.ui.semantics.collectionInfo
-import androidx.compose.ui.semantics.collectionItemInfo
-import androidx.compose.ui.semantics.selected
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.DpOffset
 import androidx.lifecycle.compose.LifecycleResumeEffect
-import androidx.media3.common.Player
 import ch.srgssr.pillarbox.demo.R
 import ch.srgssr.pillarbox.demo.shared.data.Playlist
 import ch.srgssr.pillarbox.demo.shared.di.PlayerModule
@@ -54,7 +31,7 @@ import ch.srgssr.pillarbox.demo.ui.player.DemoPlayerView
 import ch.srgssr.pillarbox.demo.ui.theme.paddings
 
 /**
- * Showcase allowing the user to change the repeat mode and decide if the current media item should pause when it ends.
+ * Showcase allowing the user to decide if the current media item should pause when it ends.
  *
  * @param playlist The [Playlist] to play.
  * @param modifier The [Modifier] to apply to the layout.
@@ -73,107 +50,9 @@ fun CustomPlaybackSettingsShowcase(
         }
     }
 
-    val repeatModes = listOf(
-        Player.REPEAT_MODE_OFF to stringResource(R.string.repeat_mode_off),
-        Player.REPEAT_MODE_ONE to stringResource(R.string.repeat_mode_one),
-        Player.REPEAT_MODE_ALL to stringResource(R.string.repeat_mode_all),
-    )
-
     var pauseAtEndOfItem by remember { mutableStateOf(player.pauseAtEndOfMediaItems) }
 
     Column(modifier = modifier) {
-        Box {
-            var menuOffset by remember { mutableStateOf(DpOffset.Zero) }
-            var showRepeatModeMenu by remember { mutableStateOf(false) }
-            var selectedRepeatModeIndex by remember {
-                mutableIntStateOf(
-                    repeatModes.indexOfFirst { (repeatMode, _) ->
-                        repeatMode == player.repeatMode
-                    }
-                )
-            }
-
-            val interactionSource = remember { MutableInteractionSource() }
-
-            Row(
-                modifier = Modifier
-                    .semantics(mergeDescendants = true) {}
-                    .fillMaxWidth()
-                    .pointerInput(Unit) {
-                        detectTapGestures(
-                            onPress = {
-                                val pressInteraction = PressInteraction.Press(it)
-
-                                interactionSource.emit(pressInteraction)
-
-                                menuOffset = DpOffset(
-                                    x = it.x.toDp(),
-                                    y = (it.y - size.height).toDp(),
-                                )
-                                showRepeatModeMenu = true
-
-                                if (tryAwaitRelease()) {
-                                    interactionSource.emit(PressInteraction.Release(pressInteraction))
-                                } else {
-                                    interactionSource.emit(PressInteraction.Cancel(pressInteraction))
-                                }
-                            }
-                        )
-                    }
-                    .indication(
-                        interactionSource = interactionSource,
-                        indication = LocalIndication.current,
-                    )
-                    .minimumInteractiveComponentSize()
-                    .padding(horizontal = MaterialTheme.paddings.baseline),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Text(text = stringResource(R.string.repeat_mode))
-
-                Text(text = repeatModes[selectedRepeatModeIndex].second)
-            }
-
-            DropdownMenu(
-                expanded = showRepeatModeMenu,
-                onDismissRequest = { showRepeatModeMenu = false },
-                modifier = Modifier.semantics {
-                    collectionInfo = CollectionInfo(rowCount = repeatModes.size, columnCount = 1)
-                },
-                offset = menuOffset,
-            ) {
-                repeatModes.forEachIndexed { index, (repeatMode, repeatModeLabel) ->
-                    val isSelected = index == selectedRepeatModeIndex
-
-                    DropdownMenuItem(
-                        text = { Text(text = repeatModeLabel) },
-                        onClick = {
-                            selectedRepeatModeIndex = index
-                            player.repeatMode = repeatMode
-                            showRepeatModeMenu = false
-                        },
-                        modifier = Modifier.semantics {
-                            selected = isSelected
-                            collectionItemInfo = CollectionItemInfo(
-                                rowIndex = index,
-                                rowSpan = 1,
-                                columnIndex = 1,
-                                columnSpan = 1,
-                            )
-                        },
-                        leadingIcon = {
-                            AnimatedVisibility(isSelected) {
-                                Icon(
-                                    imageVector = Icons.Default.Check,
-                                    contentDescription = null,
-                                )
-                            }
-                        }
-                    )
-                }
-            }
-        }
-
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/pillarbox-demo/src/main/res/values/strings.xml
+++ b/pillarbox-demo/src/main/res/values/strings.xml
@@ -6,7 +6,6 @@
     <string name="app_name">Pillarbox Demo</string>
     <string name="playlists">Playlists</string>
     <string name="add_to_playlist">Add to playlist</string>
-    <string name="toggle_shuffle">Toggle shuffle</string>
     <string name="clear_playlist">Clear playlist</string>
     <string name="empty_playlist">Empty playlist</string>
     <string name="remove">Remove</string>
@@ -36,10 +35,10 @@
     <string name="start_given_time_example">Start at given time (10min)</string>
     <string name="video_360">360°</string>
     <string name="showcase_playback_settings">Custom playback settings</string>
+    <string name="shuffle">Shuffle</string>
     <string name="repeat_mode">Repeat mode</string>
-    <string name="repeat_mode_off">off</string>
-    <string name="repeat_mode_one">one</string>
-    <string name="repeat_mode_all">all</string>
+    <string name="picture_in_picture">Picture in Picture</string>
+    <string name="fullscreen">Fullscreen</string>
     <string name="pause_end_media_items">Pause at end of media items</string>
     <string name="chapters">Chapters</string>
     <string name="thumbnail">Thumbnail</string>

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -155,6 +155,21 @@ fun Player.shuffleModeEnabledAsFlow(): Flow<Boolean> = callbackFlow {
 }
 
 /**
+ * Collects the [repeat mode][Player.getRepeatMode] as a [Flow].
+ *
+ * @return A [Flow] emitting the repeat mode.
+ */
+fun Player.repeatModeAsFlow(): Flow<@Player.RepeatMode Int> = callbackFlow {
+    val listener = object : Listener {
+        override fun onRepeatModeChanged(repeatMode: @Player.RepeatMode Int) {
+            trySend(repeatMode)
+        }
+    }
+    trySend(repeatMode)
+    addPlayerListener(player = this@repeatModeAsFlow, listener)
+}
+
+/**
  * Collects the [media item count][Player.getMediaItemCount] as a [Flow].
  *
  * @return A [Flow] emitting the media item count.

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/PlayerCommands.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/extension/PlayerCommands.kt
@@ -2,6 +2,8 @@
  * Copyright (c) SRG SSR. All rights reserved.
  * License information is available from the LICENSE file.
  */
+@file:Suppress("TooManyFunctions")
+
 package ch.srgssr.pillarbox.player.extension
 
 import androidx.media3.common.MediaItem
@@ -86,4 +88,22 @@ fun Player.Commands.canSetTrackSelectionParameters(): Boolean {
  */
 fun Player.Commands.canSpeedAndPitch(): Boolean {
     return contains(Player.COMMAND_SET_SPEED_AND_PITCH)
+}
+
+/**
+ * Checks if the player can set the shuffle mode of the current [MediaItem].
+ *
+ * @return Whether the player can set the shuffle mode.
+ */
+fun Player.Commands.canSetShuffleMode(): Boolean {
+    return contains(Player.COMMAND_SET_SHUFFLE_MODE)
+}
+
+/**
+ * Checks if the player can set the repeat mode of the current [MediaItem].
+ *
+ * @return Whether the player can set the repeat mode.
+ */
+fun Player.Commands.canSetRepeatMode(): Boolean {
+    return contains(Player.COMMAND_SET_REPEAT_MODE)
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPlayerCallbackFlow.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/TestPlayerCallbackFlow.kt
@@ -235,6 +235,26 @@ class TestPlayerCallbackFlow {
     }
 
     @Test
+    fun testRepeatMode() = runTest {
+        every { player.repeatMode } returns Player.REPEAT_MODE_OFF
+
+        val fakePlayer = PlayerListenerCommander(player)
+        fakePlayer.repeatModeAsFlow().test {
+            fakePlayer.onRepeatModeChanged(Player.REPEAT_MODE_ALL)
+            fakePlayer.onRepeatModeChanged(Player.REPEAT_MODE_OFF)
+            fakePlayer.onRepeatModeChanged(Player.REPEAT_MODE_ONE)
+            fakePlayer.onRepeatModeChanged(Player.REPEAT_MODE_OFF)
+
+            assertEquals(Player.REPEAT_MODE_OFF, awaitItem(), "initial state")
+            assertEquals(Player.REPEAT_MODE_ALL, awaitItem())
+            assertEquals(Player.REPEAT_MODE_OFF, awaitItem())
+            assertEquals(Player.REPEAT_MODE_ONE, awaitItem())
+            assertEquals(Player.REPEAT_MODE_OFF, awaitItem())
+            ensureAllEventsConsumed()
+        }
+    }
+
+    @Test
     fun testPlaybackSpeed() = runTest {
         val initialPlaybackRate = 1.5f
         val initialParameters: PlaybackParameters = PlaybackParameters.DEFAULT.withSpeed(initialPlaybackRate)

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/extension/PlayerCommandsTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/extension/PlayerCommandsTest.kt
@@ -150,4 +150,34 @@ class PlayerCommandsTest {
         assertFalse(player.availableCommands.canSpeedAndPitch())
         assertTrue(player.availableCommands.canSpeedAndPitch())
     }
+
+    @Test
+    fun `can set shuffle mode`() {
+        val player = mockk<Player> {
+            every { availableCommands } returnsMany listOf(
+                Commands.Builder().build(),
+                Commands.Builder().addAll(Player.COMMAND_STOP).build(),
+                Commands.Builder().addAll(Player.COMMAND_STOP, Player.COMMAND_SET_SHUFFLE_MODE).build()
+            )
+        }
+
+        assertFalse(player.availableCommands.canSetShuffleMode())
+        assertFalse(player.availableCommands.canSetShuffleMode())
+        assertTrue(player.availableCommands.canSetShuffleMode())
+    }
+
+    @Test
+    fun `can set repeat mode`() {
+        val player = mockk<Player> {
+            every { availableCommands } returnsMany listOf(
+                Commands.Builder().build(),
+                Commands.Builder().addAll(Player.COMMAND_STOP).build(),
+                Commands.Builder().addAll(Player.COMMAND_STOP, Player.COMMAND_SET_REPEAT_MODE).build()
+            )
+        }
+
+        assertFalse(player.availableCommands.canSetRepeatMode())
+        assertFalse(player.availableCommands.canSetRepeatMode())
+        assertTrue(player.availableCommands.canSetRepeatMode())
+    }
 }

--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/extension/ComposablePlayer.kt
@@ -48,6 +48,7 @@ import ch.srgssr.pillarbox.player.mediaItemCountAsFlow
 import ch.srgssr.pillarbox.player.playWhenReadyAsFlow
 import ch.srgssr.pillarbox.player.playbackStateAsFlow
 import ch.srgssr.pillarbox.player.playerErrorAsFlow
+import ch.srgssr.pillarbox.player.repeatModeAsFlow
 import ch.srgssr.pillarbox.player.shuffleModeEnabledAsFlow
 import ch.srgssr.pillarbox.player.videoSizeAsFlow
 import kotlinx.coroutines.flow.map
@@ -170,6 +171,19 @@ fun Player.shuffleModeEnabledAsState(): State<Boolean> {
         shuffleModeEnabledAsFlow()
     }
     return flow.collectAsState(initial = shuffleModeEnabled)
+}
+
+/**
+ * Observe the [Player.getRepeatMode] property as a [State].
+ *
+ * @return A [State] that represents the repeat mode.
+ */
+@Composable
+fun Player.repeatModeAsState(): State<@Player.RepeatMode Int> {
+    val flow = remember(this) {
+        repeatModeAsFlow()
+    }
+    return flow.collectAsState(initial = repeatMode).asIntState()
 }
 
 /**


### PR DESCRIPTION
# Pull request

## Description

This PR integrates the shuffle and repeat modes inside the demo player toolbar.

## Changes made

- Update the demo player toolbar to optionally display shuffle and repeat buttons.
- Remove the shuffle button from the playlist view.
- Update the playlist view to display the "Add" and "Remove all" buttons as FABs.
- Remove the repeat mode toggle from `CustomPlaybackSettingsShowcase`.
- Add a new `Player.repeatModeAsFlow()`.
- Add a new `Player.Commands.canSetShuffleMode()`.
- Add a new `Player.Commands.canSetRepeatMode()`.
- Add a new `Player.repeatModeAsState()`.

## Screenshots

| Description | Dark mode | Light mode |
|-----|-----|-----|
| Playlist view | ![Screenshot_20250523_162751](https://github.com/user-attachments/assets/5b9a279e-17f0-4048-990e-7becfeb5a280) | ![Screenshot_20250523_162806](https://github.com/user-attachments/assets/0f0cb8d9-2cd2-4a1b-b385-f1c6ffcb401d) |
| `CustomPlaybackSettingsShowcase` | ![Screenshot_20250523_162828](https://github.com/user-attachments/assets/73d18644-d795-462a-bfcb-2ec4070aabb8) | ![Screenshot_20250523_162837](https://github.com/user-attachments/assets/7f929e9d-c18b-444d-903b-f594bfe1d293) |

## Checklist

- [x] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).