### PR TITLE
1025 improve initial playlist

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/MediaQueueTracker.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/MediaQueueTracker.kt
@@ -29,7 +29,7 @@ internal class MediaQueueTracker(
 
     init {
         mediaQueue.registerCallback(this)
-        update()
+        // update()
     }
 
     fun release() {
@@ -43,13 +43,13 @@ internal class MediaQueueTracker(
         mediaStatus.queueItems.forEach {
             mapFetchedMediaQueueItem[it.itemId] = it
         }
-        listCastItemData = mediaQueue.itemIds.map { itemId ->
-            CastItemData(itemId, mapFetchedMediaQueueItem[itemId])
+        if (mediaStatus.queueItemCount != mediaQueue.itemCount) {
+            fetchAllIfIsNeeded()
         }
-        invalidateState()
+        update()
     }
 
-    private fun update() {
+    private fun fetchAllIfIsNeeded() {
         val itemIds = mediaQueue.itemIds
         for (i in 0 until mediaQueue.itemCount) {
             val itemId = itemIds[i]
@@ -58,8 +58,11 @@ internal class MediaQueueTracker(
                 mapFetchedMediaQueueItem[itemId] = it
             }
         }
-        lastItemIds = itemIds
-        listCastItemData = itemIds.map { itemId ->
+    }
+
+    private fun update() {
+        lastItemIds = mediaQueue.itemIds
+        listCastItemData = lastItemIds.map { itemId ->
             CastItemData(itemId, mapFetchedMediaQueueItem[itemId])
         }
         invalidateState()
@@ -93,6 +96,7 @@ internal class MediaQueueTracker(
                 mapFetchedMediaQueueItem[it.itemId] = it
             }
         }
+        fetchAllIfIsNeeded()
     }
 
     override fun itemsRemovedAtIndexes(indexes: IntArray) {

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/MediaQueueTracker.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/MediaQueueTracker.kt
@@ -6,6 +6,7 @@ package ch.srgssr.pillarbox.cast
 
 import android.util.Log
 import com.google.android.gms.cast.MediaQueueItem
+import com.google.android.gms.cast.MediaStatus
 import com.google.android.gms.cast.framework.media.MediaQueue
 
 internal data class CastItemData(val id: Int, val item: MediaQueueItem?)
@@ -35,6 +36,17 @@ internal class MediaQueueTracker(
         mediaQueue.unregisterCallback(this)
         mapFetchedMediaQueueItem.clear()
         listCastItemData = emptyList()
+    }
+
+    fun updateWithMediaStatus(mediaStatus: MediaStatus) {
+        Log.d(TAG, "updateWithMediaStatus ${mediaStatus.queueItems.map { it.itemId }}")
+        mediaStatus.queueItems.forEach {
+            mapFetchedMediaQueueItem[it.itemId] = it
+        }
+        listCastItemData = mediaQueue.itemIds.map { itemId ->
+            CastItemData(itemId, mapFetchedMediaQueueItem[itemId])
+        }
+        invalidateState()
     }
 
     private fun update() {

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -483,6 +483,7 @@ class PillarboxCastPlayer internal constructor(
                     " duration = ${remoteMediaClient?.mediaStatus?.mediaInfo?.streamDuration?.milliseconds}"
             )
             positionSupplier.position = remoteMediaClient?.getContentPositionMs() ?: 0
+            remoteMediaClient?.mediaStatus?.let { playlistTracker?.updateWithMediaStatus(it) }
             invalidateState()
         }
 

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -484,7 +484,6 @@ class PillarboxCastPlayer internal constructor(
                     " duration = ${remoteMediaClient?.mediaStatus?.mediaInfo?.streamDuration?.milliseconds}"
             )
             positionSupplier.position = remoteMediaClient?.getContentPositionMs() ?: 0
-            remoteMediaClient?.mediaStatus?.let { playlistTracker?.updateWithMediaStatus(it) }
             invalidateState()
         }
 
@@ -493,8 +492,8 @@ class PillarboxCastPlayer internal constructor(
         }
 
         override fun onQueueStatusUpdated() {
-            Log.d(TAG, "onQueueStatusUpdated ${remoteMediaClient?.mediaQueue?.itemCount}")
-            invalidateState()
+            Log.d(TAG, "onQueueStatusUpdated ${remoteMediaClient?.mediaQueue?.itemCount} ${remoteMediaClient?.mediaStatus?.queueItemCount}")
+            remoteMediaClient?.mediaStatus?.let { playlistTracker?.updateWithMediaStatus(it) }
         }
 
         override fun onPreloadStatusUpdated() {

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -223,6 +223,7 @@ class PillarboxCastPlayer internal constructor(
         if (mediaItems.isNotEmpty()) {
             val mediaQueueItems = mediaItems.map(mediaItemConverter::toMediaQueueItem)
             val startPosition = if (startPositionMs == C.TIME_UNSET) MediaInfo.UNKNOWN_START_ABSOLUTE_TIME else startPositionMs
+            val startIndex = if (startIndex == C.INDEX_UNSET) 0 else startIndex
             queueLoad(mediaQueueItems.toTypedArray(), startIndex, getCastRepeatMode(repeatMode), startPosition, null)
         } else {
             clearMediaItems()


### PR DESCRIPTION
# Pull request

## Description

Load faster MediaItem from the Cast receiver and load directly all items if the receiver send all items inside the media status.

## Changes made

- MediaQueueTracker fetches items only when needed

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
