### PR TITLE
Take the repeat mode into consideration when defining the available commands

### DIFF
--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -34,7 +34,6 @@ import ch.srgssr.pillarbox.cast.extension.getAvailableCommands
 import ch.srgssr.pillarbox.cast.extension.getContentDurationMs
 import ch.srgssr.pillarbox.cast.extension.getContentPositionMs
 import ch.srgssr.pillarbox.cast.extension.getCurrentMediaItemIndex
-import ch.srgssr.pillarbox.cast.extension.getMediaIdFromIndex
 import ch.srgssr.pillarbox.cast.extension.getPlaybackRate
 import ch.srgssr.pillarbox.cast.extension.getPlaybackState
 import ch.srgssr.pillarbox.cast.extension.getRepeatMode
@@ -260,7 +259,7 @@ class PillarboxCastPlayer internal constructor(
         if (mediaQueueItems.size == 1) {
             queueAppendItem(mediaQueueItems[0], null)
         } else {
-            val insertBeforeId = getMediaIdFromIndex(index)
+            val insertBeforeId = mediaQueue.itemIdAtIndex(index)
             queueInsertItems(mediaQueueItems.toTypedArray(), insertBeforeId, null)
         }
     }
@@ -268,7 +267,7 @@ class PillarboxCastPlayer internal constructor(
     override fun handleRemoveMediaItems(fromIndex: Int, toIndex: Int) = withRemoteClient {
         Log.d(TAG, "handleRemoveMediaItems [$fromIndex -> $toIndex[")
         if (toIndex - fromIndex == 1) {
-            queueRemoveItem(getMediaIdFromIndex(fromIndex), null)
+            queueRemoveItem(mediaQueue.itemIdAtIndex(fromIndex), null)
         } else {
             val itemsToRemove = mediaQueue.itemIds.asList().subList(fromIndex, toIndex)
             queueRemoveItems(itemsToRemove.toIntArray(), null)
@@ -278,11 +277,11 @@ class PillarboxCastPlayer internal constructor(
     override fun handleMoveMediaItems(fromIndex: Int, toIndex: Int, newIndex: Int) = withRemoteClient {
         Log.d(TAG, "handleMoveMediaItems [$fromIndex $toIndex[ => $newIndex")
         if (toIndex - fromIndex == 1) {
-            val itemId = getMediaIdFromIndex(fromIndex)
+            val itemId = mediaQueue.itemIdAtIndex(fromIndex)
             queueMoveItemToNewIndex(itemId, newIndex, null)
         } else {
             val itemsIdToMove = mediaQueue.itemIds.asList().subList(fromIndex, toIndex)
-            val insertBeforeId = getMediaIdFromIndex(newIndex + (toIndex - fromIndex))
+            val insertBeforeId = mediaQueue.itemIdAtIndex(newIndex + (toIndex - fromIndex))
             queueReorderItems(itemsIdToMove.toIntArray(), insertBeforeId, null)
         }
     }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
@@ -5,6 +5,10 @@
 package ch.srgssr.pillarbox.demo.ui.player.controls
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -70,13 +74,6 @@ fun PlayerBottomToolbar(
     Row(modifier = modifier) {
         CompositionLocalProvider(LocalContentColor provides Color.White) {
             ToggleableIconButton(
-                checked = shuffleEnabled,
-                icon = if (shuffleEnabled) Icons.Default.ShuffleOn else Icons.Default.Shuffle,
-                contentDestination = stringResource(R.string.shuffle),
-                onCheckedChange = onShuffleClick,
-            )
-
-            ToggleableIconButton(
                 checked = repeatMode != Player.REPEAT_MODE_OFF,
                 icon = when (repeatMode) {
                     Player.REPEAT_MODE_OFF -> Icons.Default.Repeat
@@ -86,6 +83,13 @@ fun PlayerBottomToolbar(
                 },
                 contentDestination = stringResource(R.string.repeat_mode),
                 onCheckedChange = onRepeatClick,
+            )
+
+            ToggleableIconButton(
+                checked = shuffleEnabled,
+                icon = if (shuffleEnabled) Icons.Default.ShuffleOn else Icons.Default.Shuffle,
+                contentDestination = stringResource(R.string.shuffle),
+                onCheckedChange = onShuffleClick,
             )
 
             Spacer(modifier = Modifier.weight(1f))
@@ -119,9 +123,15 @@ private fun ToggleableIconButton(
     checked: Boolean,
     icon: ImageVector,
     contentDestination: String,
+    modifier: Modifier = Modifier,
     onCheckedChange: (() -> Unit)?,
 ) {
-    AnimatedVisibility(visible = onCheckedChange != null) {
+    AnimatedVisibility(
+        visible = onCheckedChange != null,
+        modifier = modifier,
+        enter = fadeIn() + scaleIn(),
+        exit = scaleOut() + fadeOut(),
+    ) {
         IconToggleButton(
             checked = checked,
             onCheckedChange = { onCheckedChange?.invoke() },


### PR DESCRIPTION
# Pull request

## Description

This PR updates the implementation of `RemoteMediaClient.getAvailableCommands()` to take the repeat mode into consideration when defining if the `COMMAND_SEEK_TO_PREVIOUS` and `COMMAND_SEEK_TO_NEXT` commands are available.

## Changes made

- Update `RemoteMediaClient.getAvailableCommands()` to use the repeat mode to define available commands.
- Improve animation in `PlayerBottomToolbar` when buttons become (un)available.
- Inline `RemoteMediaClient.getMediaIdFromIndex()`, since it holds little logic.
- Add new tests.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).