### PR TITLE
Increase service image requested size to 960

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingService.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingService.kt
@@ -21,6 +21,6 @@ internal class ImageScalingService(
     ): String {
         val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8.name())
 
-        return "${ilHost.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=480"
+        return "${ilHost.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=960"
     }
 }

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingServiceTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingServiceTest.kt
@@ -19,7 +19,7 @@ class ImageScalingServiceTest {
         val scaledImageUrl = imageScalingService.getScaledImageUrl(imageUrl)
         val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8)
 
-        assertEquals("${host.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=480", scaledImageUrl)
+        assertEquals("${host.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=960", scaledImageUrl)
     }
 
     @Test
@@ -31,7 +31,7 @@ class ImageScalingServiceTest {
         val scaledImageUrl = imageScalingService.getScaledImageUrl(imageUrl)
         val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8)
 
-        assertEquals("${host.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=480", scaledImageUrl)
+        assertEquals("${host.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=960", scaledImageUrl)
     }
 
     @Test
@@ -43,6 +43,6 @@ class ImageScalingServiceTest {
         val scaledImageUrl = imageScalingService.getScaledImageUrl(imageUrl)
         val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8)
 
-        assertEquals("${host.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=480", scaledImageUrl)
+        assertEquals("${host.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=960", scaledImageUrl)
     }
 }


### PR DESCRIPTION
# Pull request

## Description

Increase image size requested to the integration image service.

## Changes made
 
- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
