### PR TITLE
Update to Gradle 8.14.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
# Pull request

## Description

This PR updates Gradle to the latest version (8.14.3). The release notes are available [here](https://docs.gradle.org/8.14.3/release-notes.html).

<img width="567" alt="Screenshot 2025-07-09 at 10 43 50" src="https://github.com/user-attachments/assets/52521804-0f32-4ae2-acde-ccbc75ee6761" />

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).