### PR TITLE
Only set listeners when there are senders connected

### DIFF
--- a/pillarbox-cast-receiver/build.gradle.kts
+++ b/pillarbox-cast-receiver/build.gradle.kts
@@ -14,11 +14,15 @@ dependencies {
     implementation(project(":pillarbox-cast"))
     api(project(":pillarbox-player"))
 
-    implementation(libs.androidx.media3.common)
+    implementation(libs.androidx.annotation)
+    api(libs.androidx.media3.cast)
+    api(libs.androidx.media3.common)
+    api(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)
     implementation(libs.play.services.cast)
     api(libs.play.services.cast.tv)
 
+    testImplementation(libs.androidx.test.core)
     testImplementation(libs.androidx.test.ext.junit)
     testImplementation(libs.junit)
     testImplementation(libs.kotlin.test)

--- a/pillarbox-demo-tv/build.gradle.kts
+++ b/pillarbox-demo-tv/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.media3.cast)
     implementation(libs.androidx.media3.common)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.navigation.common)


### PR DESCRIPTION
# Pull request

## Description

This PR updates `PillarboxCastReceiverPlayer` to only set listeners when there are senders connected.

## Changes made

> Please list the specific changes made in this pull request.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).