### PR TITLE
Fix aspect ratio when navigating between different media type

### DIFF
--- a/pillarbox-cast/build.gradle.kts
+++ b/pillarbox-cast/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
     implementation(libs.androidx.annotation)
     api(libs.androidx.media3.cast)
     api(libs.androidx.media3.common)
+    api(libs.androidx.media3.exoplayer)
     implementation(libs.guava)
     api(libs.kotlinx.coroutines.core)
 

--- a/pillarbox-demo/build.gradle.kts
+++ b/pillarbox-demo/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.media3.cast)
     implementation(libs.androidx.media3.common)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)


### PR DESCRIPTION
# Pull request

## Description

This PR fixes the wrong aspect ratio when switching between different media types (video/audio).

## Changes made

- Use a state to access the current media tracks in the `PlayerSurface`.
- Take the image track into consideration when deciding the aspect ratio in `PlayerSurface`.
- Fix some Dependency Analysis warnings.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).