### PR TITLE
Fix `Android Lint` check on GitHub Actions

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,6 +18,15 @@ jobs:
     env:
       USERNAME: ${{ github.actor }}
       GITHUB_TOKEN: ${{ github.token }}
+    strategy:
+      matrix:
+        include:
+          - module: 'pillarbox-demo'
+            task: 'lintProdDebug'
+          - module: 'pillarbox-demo-tv'
+            task: 'lintProdDebug'
+          - module: 'pillarbox-player-testutils'
+            task: 'lintDebug'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,17 +40,13 @@ jobs:
         with:
           cache-encryption-key: ${{ secrets.GRADLE_CACHE_ENCRYPTION_KEY }}
       - name: Run Android Lint
-        run: >
-          ./gradlew
-          :pillarbox-demo:lintProdDebug
-          :pillarbox-demo-tv:lintProdDebug
-          :pillarbox-player-testutils:lintDebug
+        run: ./gradlew :${{ matrix.module }}:${{ matrix.task }}
       - name: Upload Android Lint results
         uses: github/codeql-action/upload-sarif@v3
         if: success() || failure()
         with:
-          sarif_file: build/reports/android-lint/
-          category: android-lint
+          sarif_file: build/reports/android-lint/${{ matrix.module }}.sarif
+          category: android-lint-${{ matrix.module }}
 
   detekt:
     name: Detekt


### PR DESCRIPTION
# Pull request

## Description

The `github/codeql-action/upload-sarif` GitHub Actions no longer supports uploading multiple SHARIF files for a single category.
As we were using this for the Android Lint check, this PR reworks it to use different categories for each module where we run Android Lint.
See [this](https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/) for more information.

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).