### PR TITLE
Use Media3's states in `PlayerPlaybackRow`

### DIFF
--- a/pillarbox-demo-shared/src/main/res/values/strings.xml
+++ b/pillarbox-demo-shared/src/main/res/values/strings.xml
@@ -52,6 +52,12 @@
     <string name="disabled">Disabled</string>
     <string name="skip">Skip</string>
     <string name="dropped_frames">Dropped frames</string>
+    <string name="previous_button">Previous</string>
+    <string name="fast_rewind_button">Fast rewind</string>
+    <string name="play_button">Play</string>
+    <string name="pause_button">Pause</string>
+    <string name="fast_forward_button">Fast forward</string>
+    <string name="next_button">Next</string>
     <string name="shuffle_button_on">Disable shuffle mode</string>
     <string name="shuffle_button_off">Enable shuffle mode</string>
     <string name="repeat_button_off">Current mode: repeat none. Toggle repeat mode</string>

--- a/pillarbox-demo-tv/build.gradle.kts
+++ b/pillarbox-demo-tv/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel)
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.media3.common)
+    implementation(libs.androidx.media3.ui.compose)
     implementation(libs.androidx.navigation.common)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.androidx.navigation.runtime)

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerControls.kt
@@ -78,10 +78,8 @@ fun PlayerControls(
             mediaMetadata = currentChapterMediaMetadata ?: currentMediaMetadata,
         )
         PlayerPlaybackRow(
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.Center),
-            player = player
+            player = player,
+            modifier = Modifier.align(Alignment.Center),
         )
 
         Column(

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SmoothSeekingShowcase.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/misc/SmoothSeekingShowcase.kt
@@ -83,10 +83,8 @@ fun SmoothSeekingShowcase() {
                 ExoPlayerSubtitleView(player = player)
             }
             PlayerPlaybackRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .align(Alignment.Center),
-                player = player
+                player = player,
+                modifier = Modifier.align(Alignment.Center),
             )
             PlayerTimeSlider(
                 modifier = Modifier


### PR DESCRIPTION
# Pull request

## Description

This PR updates the `PlayerPlaybackRow` component in both the `pillarbox-demo` and `pillarbox-demo-tv` applications.

## Changes made

- Use Media3's state to read and change the player state.
- Add missing content descriptions on the playback row icons.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).