### PR TITLE
Add a state to manage Picture-in-Picture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,7 @@
 # Overview
 
 [![Last release](https://img.shields.io/github/v/release/SRGSSR/pillarbox-android?label=Release)](https://github.com/SRGSSR/pillarbox-android/releases)
-[![Android min SDK](https://img.shields.io/badge/Android-21%2B-34A853)](https://github.com/SRGSSR/pillarbox-android)
+[![Android min SDK](https://img.shields.io/badge/Android-24%2B-34A853)](https://github.com/SRGSSR/pillarbox-android)
 [![Build status](https://img.shields.io/github/actions/workflow/status/SRGSSR/pillarbox-android/quality.yml?label=Build)](https://github.com/SRGSSR/pillarbox-android/actions/workflows/quality.yml)
 [![License](https://img.shields.io/github/license/SRGSSR/pillarbox-android?label=License)](https://github.com/SRGSSR/pillarbox-android/blob/main/LICENSE)
 

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/SimplePlayerViewModel.kt
@@ -32,6 +32,8 @@ import ch.srgssr.pillarbox.player.notification.PillarboxMediaDescriptionAdapter
 import ch.srgssr.pillarbox.player.session.PillarboxMediaSession
 import ch.srgssr.pillarbox.player.utils.StringUtil
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 private const val NotificationId = 2025
 
@@ -51,15 +53,12 @@ class SimplePlayerViewModel(application: Application) : AndroidViewModel(applica
         .build()
     private val notificationManager: PlayerNotificationManager
 
-    /**
-     * Picture in picture enabled
-     */
-    val pictureInPictureEnabled = MutableStateFlow(false)
+    private val _pictureInPictureRatio = MutableStateFlow(Rational(1, 1))
 
     /**
      * Picture in picture aspect ratio
      */
-    var pictureInPictureRatio = MutableStateFlow(Rational(1, 1))
+    val pictureInPictureRatio = _pictureInPictureRatio.asStateFlow()
 
     init {
         notificationManager = PlayerNotificationManager.Builder(application, NotificationId, "Pillarbox now playing")
@@ -135,7 +134,7 @@ class SimplePlayerViewModel(application: Application) : AndroidViewModel(applica
     }
 
     override fun onVideoSizeChanged(videoSize: VideoSize) {
-        pictureInPictureRatio.value = videoSize.toRational()
+        _pictureInPictureRatio.update { videoSize.toRational() }
     }
 
     override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/controls/PlayerBottomToolbar.kt
@@ -4,6 +4,7 @@
  */
 package ch.srgssr.pillarbox.demo.ui.player.controls
 
+import android.app.Activity
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
@@ -48,8 +49,9 @@ import ch.srgssr.pillarbox.demo.shared.R as sharedR
  * @param onShuffleClick The action to perform when the shuffle button is clicked. `null` to hide the button.
  * @param repeatMode The repeat mode.
  * @param onRepeatClick The action to perform when the repeat button is clicked. `null` to hide the button.
- * @param pictureInPictureEnabled Whether picture in picture is enabled.
- * @param onPictureInPictureClick The action to perform when the picture in picture button is clicked. `null` to hide the button.
+ * @param isPictureInPictureEnabled Whether Picture-in-Picture is enabled.
+ * @param isInPictureInPicture Whether the [Activity] is currently in Picture-in-Picture mode.
+ * @param onPictureInPictureClick The Picture-in-Picture button action.
  * @param fullScreenEnabled Whether fullscreen is enabled.
  * @param onFullscreenClick The action to perform when the fullscreen button is clicked. `null` to hide the button.
  * @param onSettingsClick The action to perform when the settings button is clicked. `null` to hide the button.
@@ -61,8 +63,9 @@ fun PlayerBottomToolbar(
     onShuffleClick: (() -> Unit)?,
     repeatMode: @Player.RepeatMode Int,
     onRepeatClick: (() -> Unit)?,
-    pictureInPictureEnabled: Boolean,
-    onPictureInPictureClick: (() -> Unit)?,
+    isPictureInPictureEnabled: Boolean,
+    isInPictureInPicture: Boolean,
+    onPictureInPictureClick: () -> Unit,
     fullScreenEnabled: Boolean,
     onFullscreenClick: (() -> Unit)?,
     onSettingsClick: () -> Unit,
@@ -70,6 +73,7 @@ fun PlayerBottomToolbar(
     Row(modifier = modifier) {
         CompositionLocalProvider(LocalContentColor provides Color.White) {
             ToggleableIconButton(
+                enabled = true,
                 checked = shuffleEnabled,
                 icon = if (shuffleEnabled) Icons.Default.ShuffleOn else Icons.Default.Shuffle,
                 contentDestination = stringResource(R.string.shuffle),
@@ -77,6 +81,7 @@ fun PlayerBottomToolbar(
             )
 
             ToggleableIconButton(
+                enabled = true,
                 checked = repeatMode != Player.REPEAT_MODE_OFF,
                 icon = when (repeatMode) {
                     Player.REPEAT_MODE_OFF -> Icons.Default.Repeat
@@ -91,13 +96,15 @@ fun PlayerBottomToolbar(
             Spacer(modifier = Modifier.weight(1f))
 
             ToggleableIconButton(
-                checked = pictureInPictureEnabled,
+                enabled = isPictureInPictureEnabled,
+                checked = isInPictureInPicture,
                 icon = Icons.Default.PictureInPicture,
                 contentDestination = stringResource(R.string.picture_in_picture),
                 onCheckedChange = onPictureInPictureClick,
             )
 
             ToggleableIconButton(
+                enabled = true,
                 checked = fullScreenEnabled,
                 icon = if (fullScreenEnabled) Icons.Default.FullscreenExit else Icons.Default.Fullscreen,
                 contentDestination = stringResource(R.string.fullscreen),
@@ -116,6 +123,7 @@ fun PlayerBottomToolbar(
 
 @Composable
 private fun ToggleableIconButton(
+    enabled: Boolean,
     checked: Boolean,
     icon: ImageVector,
     contentDestination: String,
@@ -125,6 +133,7 @@ private fun ToggleableIconButton(
         IconToggleButton(
             checked = checked,
             onCheckedChange = { onCheckedChange?.invoke() },
+            enabled = enabled,
         ) {
             Icon(
                 imageVector = icon,
@@ -139,7 +148,7 @@ private fun ToggleableIconButton(
 private fun PlayerBottomToolbarPreview() {
     var shuffleEnabled by remember { mutableStateOf(false) }
     var repeatMode by remember { mutableIntStateOf(Player.REPEAT_MODE_OFF) }
-    var pictureInPictureEnabled by remember { mutableStateOf(false) }
+    var isInPictureInPicture by remember { mutableStateOf(false) }
     var fullscreenEnabled by remember { mutableStateOf(false) }
 
     PillarboxTheme {
@@ -157,8 +166,9 @@ private fun PlayerBottomToolbarPreview() {
                         else -> error("Unrecognized repeat mode $repeatMode")
                     }
                 },
-                pictureInPictureEnabled = pictureInPictureEnabled,
-                onPictureInPictureClick = { pictureInPictureEnabled = !pictureInPictureEnabled },
+                isPictureInPictureEnabled = true,
+                isInPictureInPicture = isInPictureInPicture,
+                onPictureInPictureClick = { isInPictureInPicture = !isInPictureInPicture },
                 fullScreenEnabled = fullscreenEnabled,
                 onFullscreenClick = { fullscreenEnabled = !fullscreenEnabled },
                 onSettingsClick = {},

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/state/PictureInPictureButtonState.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/player/state/PictureInPictureButtonState.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) SRG SSR. All rights reserved.
+ * License information is available from the LICENSE file.
+ */
+package ch.srgssr.pillarbox.demo.ui.player.state
+
+import android.app.Activity
+import android.app.PictureInPictureParams
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
+import androidx.annotation.RequiresApi
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.core.app.PictureInPictureModeChangedInfo
+import androidx.core.util.Consumer
+
+/**
+ * Creates a [PictureInPictureButtonState] that is remembered across compositions.
+ *
+ * It is recommended to use [rememberPictureInPictureButtonState] with [PictureInPictureParams] for
+ * Android O and above for more control over the Picture-in-Picture behavior.
+ *
+ * @return A [PictureInPictureButtonState] instance.
+ */
+@Composable
+fun rememberPictureInPictureButtonState(): PictureInPictureButtonState {
+    val activity = LocalActivity.current as ComponentActivity
+    val pictureInPictureButtonState = remember(activity) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Log.w("PictureInPictureButtonState", "Consider migrating to rememberPictureInPictureButtonState(PictureInPictureParams)")
+        }
+
+        PictureInPictureButtonStateBase(activity)
+    }
+
+    DisposableEffect(activity) {
+        pictureInPictureButtonState.startObserving()
+
+        onDispose {
+            pictureInPictureButtonState.stopObserving()
+        }
+    }
+
+    return pictureInPictureButtonState
+}
+
+/**
+ * Creates a [PictureInPictureButtonState] that is remembered across compositions.
+ *
+ * @param pictureInPictureParamsProvider A provider to get the parameters to use when entering Picture-in-Picture mode.
+ * @return A [PictureInPictureButtonState] instance.
+ */
+@Composable
+@RequiresApi(Build.VERSION_CODES.O)
+fun rememberPictureInPictureButtonState(pictureInPictureParamsProvider: () -> PictureInPictureParams): PictureInPictureButtonState {
+    val activity = LocalActivity.current as ComponentActivity
+    val pictureInPictureParamsProvider by rememberUpdatedState(pictureInPictureParamsProvider)
+    val pictureInPictureButtonState = remember(activity, pictureInPictureParamsProvider) {
+        PictureInPictureButtonStateApi26(activity, pictureInPictureParamsProvider)
+    }
+
+    DisposableEffect(activity, pictureInPictureParamsProvider) {
+        pictureInPictureButtonState.startObserving()
+
+        onDispose {
+            pictureInPictureButtonState.stopObserving()
+        }
+    }
+
+    return pictureInPictureButtonState
+}
+
+/**
+ * State that holds all interactions to correctly deal with a UI component representing a Picture-in-Picture button.
+ */
+interface PictureInPictureButtonState {
+    /**
+     * Whether Picture-in-Picture is available.
+     */
+    val isEnabled: Boolean
+
+    /**
+     * Whether the [Activity] is currently in Picture-in-Picture mode.
+     */
+    val isInPictureInPicture: Boolean
+
+    /**
+     * Enter Picture-in-Picture mode.
+     */
+    fun onClick()
+
+    /**
+     * Start observing the [Activity]'s [PictureInPictureModeChangedInfo] events.
+     */
+    fun startObserving()
+
+    /**
+     * Stop observing the [Activity]'s [PictureInPictureModeChangedInfo] events.
+     */
+    fun stopObserving()
+}
+
+private open class PictureInPictureButtonStateBase(
+    private val activity: ComponentActivity,
+) : PictureInPictureButtonState {
+    private val pictureInPictureObserver = Consumer<PictureInPictureModeChangedInfo> { changedInfo ->
+        isInPictureInPicture = changedInfo.isInPictureInPictureMode
+    }
+
+    override val isEnabled: Boolean
+        get() = activity.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
+
+    override var isInPictureInPicture by mutableStateOf(activity.isInPictureInPictureMode)
+        private set
+
+    override fun onClick() {
+        @Suppress("DEPRECATION")
+        activity.enterPictureInPictureMode()
+    }
+
+    override fun startObserving() {
+        activity.addOnPictureInPictureModeChangedListener(pictureInPictureObserver)
+    }
+
+    override fun stopObserving() {
+        activity.removeOnPictureInPictureModeChangedListener(pictureInPictureObserver)
+    }
+}
+
+@RequiresApi(Build.VERSION_CODES.O)
+private class PictureInPictureButtonStateApi26(
+    private val activity: ComponentActivity,
+    private val pictureInPictureParamsProvider: () -> PictureInPictureParams,
+) : PictureInPictureButtonStateBase(activity) {
+    override fun onClick() {
+        activity.enterPictureInPictureMode(pictureInPictureParamsProvider())
+    }
+}

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/MediaControllerActivity.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/MediaControllerActivity.kt
@@ -5,14 +5,11 @@
 package ch.srgssr.pillarbox.demo.ui.showcases.integrations
 
 import android.app.PictureInPictureParams
-import android.content.pm.PackageManager
-import android.content.res.Configuration
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -28,6 +25,7 @@ import ch.srgssr.pillarbox.analytics.SRGAnalytics
 import ch.srgssr.pillarbox.demo.DemoPageView
 import ch.srgssr.pillarbox.demo.trackPagView
 import ch.srgssr.pillarbox.demo.ui.player.DemoPlayerView
+import ch.srgssr.pillarbox.demo.ui.player.state.rememberPictureInPictureButtonState
 import ch.srgssr.pillarbox.demo.ui.theme.PillarboxTheme
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -67,48 +65,25 @@ class MediaControllerActivity : ComponentActivity() {
         }
     }
 
-    private fun isPictureInPicturePossible(): Boolean {
-        return packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
-    }
-
     @Composable
     private fun MainView(player: Player) {
-        val onPictureInPictureClick: (() -> Unit)? = if (isPictureInPicturePossible()) this::startPictureInPicture else null
-        val pictureInPictureEnabled by controllerViewModel.pictureInPictureEnabled.collectAsState()
+        val pictureInPictureButtonState = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            rememberPictureInPictureButtonState {
+                PictureInPictureParams.Builder()
+                    .setAspectRatio(controllerViewModel.pictureInPictureRatio.value)
+                    .build()
+            }
+        } else {
+            rememberPictureInPictureButtonState()
+        }
+
         DemoPlayerView(
             player = player,
-            pictureInPictureEnabled = pictureInPictureEnabled,
-            onPictureInPictureClick = onPictureInPictureClick,
-            displayPlaylist = true
+            isPictureInPictureEnabled = pictureInPictureButtonState.isEnabled,
+            isInPictureInPicture = pictureInPictureButtonState.isInPictureInPicture,
+            onPictureInPictureClick = pictureInPictureButtonState::onClick,
+            displayPlaylist = true,
         )
-    }
-
-    private fun startPictureInPicture() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val params = PictureInPictureParams.Builder()
-                .setAspectRatio(controllerViewModel.pictureInPictureRatio.value)
-                .build()
-            enterPictureInPictureMode(params)
-        } else {
-            @Suppress("DEPRECATION")
-            enterPictureInPictureMode()
-        }
-    }
-
-    @RequiresApi(Build.VERSION_CODES.O)
-    override fun onPictureInPictureModeChanged(
-        isInPictureInPictureMode: Boolean,
-        newConfig: Configuration
-    ) {
-        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
-        controllerViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {
-        super.onConfigurationChanged(newConfig)
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.N_MR1) {
-            controllerViewModel.pictureInPictureEnabled.value = isInPictureInPictureMode
-        }
     }
 
     override fun onResume() {

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/MediaControllerViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/MediaControllerViewModel.kt
@@ -14,7 +14,6 @@ import ch.srgssr.pillarbox.player.session.PillarboxMediaController
 import ch.srgssr.pillarbox.player.videoSizeAsFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -41,15 +40,10 @@ class MediaControllerViewModel(application: Application) : AndroidViewModel(appl
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
     /**
-     * Picture in picture enabled
-     */
-    val pictureInPictureEnabled = MutableStateFlow(false)
-
-    /**
      * Picture in picture aspect ratio
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    var pictureInPictureRatio = player.filterNotNull().flatMapLatest { mediaBrowser ->
+    val pictureInPictureRatio = player.filterNotNull().flatMapLatest { mediaBrowser ->
         mediaBrowser.videoSizeAsFlow().map { it.toRational() }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), RATIONAL_ONE)
 }

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserViewModel.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/ui/showcases/integrations/auto/MediaBrowserViewModel.kt
@@ -14,7 +14,6 @@ import ch.srgssr.pillarbox.player.session.PillarboxMediaBrowser
 import ch.srgssr.pillarbox.player.videoSizeAsFlow
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.filterNotNull
@@ -41,15 +40,10 @@ class MediaBrowserViewModel(application: Application) : AndroidViewModel(applica
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), null)
 
     /**
-     * Picture in picture enabled
-     */
-    val pictureInPictureEnabled = MutableStateFlow(false)
-
-    /**
      * Picture in picture aspect ratio
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    var pictureInPictureRatio = player.filterNotNull().flatMapLatest { mediaBrowser ->
+    val pictureInPictureRatio = player.filterNotNull().flatMapLatest { mediaBrowser ->
         mediaBrowser.videoSizeAsFlow().map { it.toRational() }
     }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(), RATIONAL_ONE)
 }


### PR DESCRIPTION
# Pull request

## Description

This PR introduces a state object to handle the Picture-in-Picture state and interactions, following the approach used in Media3's `ui-compose` module.

## Changes made

- Introduce a `PictureInPictureButtonState`.
- Update demo players that support Picture-in-Picture to use `PictureInPictureButtonState`.
- Update `DemoPlayer` to always display the Picture-in-Picture button. But it can be disabled if Picture-in-Picture is not supported. This follows what Media3 is doing in its Compose demo.
- Update the Readme to reflect the recent min SDK change.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).