### PR TITLE
Fix missing event when reaching the end of a credit

### DIFF
--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     api(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
 
+    testImplementation(project(":pillarbox-core-business"))
     testImplementation(project(":pillarbox-player-testutils"))
 
     testImplementation(libs.androidx.media3.test.utils)

--- a/pillarbox-player/build.gradle.kts
+++ b/pillarbox-player/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     api(libs.okhttp)
     implementation(libs.okhttp.logging.interceptor)
 
-    testImplementation(project(":pillarbox-core-business"))
     testImplementation(project(":pillarbox-player-testutils"))
 
     testImplementation(libs.androidx.media3.test.utils)

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -20,7 +20,6 @@ import ch.srgssr.pillarbox.player.analytics.metrics.PlaybackMetrics
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
 import ch.srgssr.pillarbox.player.asset.timeRange.Credit
-import ch.srgssr.pillarbox.player.asset.timeRange.TimeRange
 import ch.srgssr.pillarbox.player.extension.getBlockedTimeRangeOrNull
 import ch.srgssr.pillarbox.player.extension.getMediaItemTrackerDataOrNull
 import ch.srgssr.pillarbox.player.extension.getPlaybackSpeed
@@ -128,8 +127,8 @@ class PillarboxExoPlayer internal constructor(
         }
         get() = analyticsTracker.enabled
 
-    private val blockedTimeRangeTracker = BlockedTimeRangeTracker(this::notifyTimeRangeChanged)
-    private val mediaMetadataTracker = PillarboxMediaMetaDataTracker(this::notifyTimeRangeChanged)
+    private val blockedTimeRangeTracker = BlockedTimeRangeTracker(this::notifyBlockedTimeRangeChanged)
+    private val mediaMetadataTracker = PillarboxMediaMetaDataTracker(this::notifyChapterChanged, this::notifyCreditChanged)
 
     init {
         mediaMetadataTracker.setPlayer(this)
@@ -294,22 +293,22 @@ class PillarboxExoPlayer internal constructor(
         return currentTracks.getBlockedTimeRangeOrNull()
     }
 
-    private fun notifyTimeRangeChanged(timeRange: TimeRange?) {
-        when (timeRange) {
-            is Chapter? -> listeners.sendEvent(PillarboxPlayer.EVENT_CHAPTER_CHANGED) { listener ->
-                listener.onChapterChanged(timeRange)
-            }
+    private fun notifyBlockedTimeRangeChanged(blockedTimeRange: BlockedTimeRange) {
+        listeners.sendEvent(PillarboxPlayer.EVENT_BLOCKED_TIME_RANGE_REACHED) { listener ->
+            listener.onBlockedTimeRangeReached(blockedTimeRange)
+        }
+        handleBlockedTimeRange(blockedTimeRange)
+    }
 
-            is Credit? -> listeners.sendEvent(PillarboxPlayer.EVENT_CREDIT_CHANGED) { listener ->
-                listener.onCreditChanged(timeRange)
-            }
+    private fun notifyChapterChanged(chapter: Chapter?) {
+        listeners.sendEvent(PillarboxPlayer.EVENT_CHAPTER_CHANGED) { listener ->
+            listener.onChapterChanged(chapter)
+        }
+    }
 
-            is BlockedTimeRange -> {
-                listeners.sendEvent(PillarboxPlayer.EVENT_BLOCKED_TIME_RANGE_REACHED) { listener ->
-                    listener.onBlockedTimeRangeReached(timeRange)
-                }
-                handleBlockedTimeRange(timeRange)
-            }
+    private fun notifyCreditChanged(credit: Credit?) {
+        listeners.sendEvent(PillarboxPlayer.EVENT_CREDIT_CHANGED) { listener ->
+            listener.onCreditChanged(credit)
         }
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/BlockedTimeRangeTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/BlockedTimeRangeTracker.kt
@@ -9,12 +9,11 @@ import androidx.media3.common.Tracks
 import androidx.media3.exoplayer.PlayerMessage
 import ch.srgssr.pillarbox.player.PillarboxExoPlayer
 import ch.srgssr.pillarbox.player.asset.timeRange.BlockedTimeRange
-import ch.srgssr.pillarbox.player.asset.timeRange.TimeRange
 import ch.srgssr.pillarbox.player.asset.timeRange.firstOrNullAtPosition
 import ch.srgssr.pillarbox.player.extension.getBlockedTimeRangeOrNull
 
 internal class BlockedTimeRangeTracker(
-    private val callback: (TimeRange?) -> Unit
+    private val callback: (BlockedTimeRange) -> Unit
 ) : Player.Listener {
     private val playerMessages = mutableListOf<PlayerMessage>()
     private var timeRanges: List<BlockedTimeRange>? = null

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/PillarboxMediaMetaDataTracker.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/tracker/PillarboxMediaMetaDataTracker.kt
@@ -16,7 +16,10 @@ import ch.srgssr.pillarbox.player.asset.timeRange.firstOrNullAtPosition
 import ch.srgssr.pillarbox.player.extension.chapters
 import ch.srgssr.pillarbox.player.extension.credits
 
-internal class PillarboxMediaMetaDataTracker(private val callback: (TimeRange?) -> Unit) : Player.Listener {
+internal class PillarboxMediaMetaDataTracker(
+    private val onChapterChange: (Chapter?) -> Unit,
+    private val onCreditChange: (Credit?) -> Unit,
+) : Player.Listener {
     private var currentChapterTracker: Tracker<Chapter>? = null
     private var currentCreditTracker: Tracker<Credit>? = null
     private lateinit var player: PillarboxExoPlayer
@@ -51,10 +54,10 @@ internal class PillarboxMediaMetaDataTracker(private val callback: (TimeRange?) 
                 clear()
                 mediaItem?.mediaMetadata?.let { mediaMetadata ->
                     mediaMetadata.chapters?.let {
-                        currentChapterTracker = Tracker(player = player, timeRanges = it, callback = callback)
+                        currentChapterTracker = Tracker(player = player, timeRanges = it, callback = onChapterChange)
                     }
                     mediaMetadata.credits?.let {
-                        currentCreditTracker = Tracker(player = player, timeRanges = it, callback = callback)
+                        currentCreditTracker = Tracker(player = player, timeRanges = it, callback = onCreditChange)
                     }
                 }
             }
@@ -79,14 +82,14 @@ internal class PillarboxMediaMetaDataTracker(private val callback: (TimeRange?) 
         mediaMetadata.chapters?.let {
             if (currentChapterTracker?.timeRanges != it) {
                 currentChapterTracker?.clear()
-                currentChapterTracker = Tracker(player = player, timeRanges = it, callback = callback)
+                currentChapterTracker = Tracker(player = player, timeRanges = it, callback = onChapterChange)
             }
         }
 
         mediaMetadata.credits?.let {
             if (currentCreditTracker?.timeRanges != it) {
                 currentCreditTracker?.clear()
-                currentCreditTracker = Tracker(player = player, timeRanges = it, callback = callback)
+                currentCreditTracker = Tracker(player = player, timeRanges = it, callback = onCreditChange)
             }
         }
     }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
@@ -4,18 +4,52 @@
  */
 package ch.srgssr.pillarbox.player
 
+import android.os.Looper
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.test.utils.FakeClock
+import androidx.media3.test.utils.robolectric.TestPlayerRunHelper.advance
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.srgssr.pillarbox.core.business.SRG
+import ch.srgssr.pillarbox.core.business.SRGMediaItem
+import ch.srgssr.pillarbox.player.asset.timeRange.Chapter
+import ch.srgssr.pillarbox.player.asset.timeRange.Credit
+import io.mockk.clearAllMocks
+import io.mockk.justRun
+import io.mockk.mockk
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
-/**
- * Tests inspired by https://github.com/androidx/media/blob/839c4a90f2ab36e48be73e1b5e907f3283dce72e/libraries/common/src/test/java/androidx/media3/common/ForwardingSimpleBasePlayerTest.java#L60-L78
- */
 @RunWith(AndroidJUnit4::class)
 class PillarboxExoPlayerTest {
+    private lateinit var player: ExoPlayer
 
+    @BeforeTest
+    fun setup() {
+        player = PillarboxExoPlayer(ApplicationProvider.getApplicationContext(), SRG) {
+            disableMonitoring()
+            clock(FakeClock(true))
+            loadControl(PillarboxTestLoadControl())
+        }
+        player.prepare()
+        player.play()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        player.release()
+        shadowOf(Looper.getMainLooper()).idle()
+        clearAllMocks()
+    }
+
+    /**
+     * Tests inspired by https://github.com/androidx/media/blob/839c4a90f2ab36e48be73e1b5e907f3283dce72e/libraries/common/src/test/java/androidx/media3/common/ForwardingSimpleBasePlayerTest.java#L60-L78
+     */
     @Test
     fun `check that all default methods are implemented`() {
         val defaultMethods = ExoPlayer::class.java.declaredMethods.filter { it.isDefault }
@@ -24,5 +58,50 @@ class PillarboxExoPlayerTest {
             val parameters = method.parameterTypes
             assertEquals(PillarboxExoPlayer::class.java, PillarboxExoPlayer::class.java.getDeclaredMethod(name, *parameters).declaringClass)
         }
+    }
+
+    @Test
+    fun `check that chapters are reported`() {
+        val chapters = mutableListOf<Chapter?>()
+        val mockListener = mockk<PillarboxPlayer.Listener>(relaxed = true) {
+            justRun { onChapterChanged(captureNullable(chapters)) }
+        }
+
+        player.setMediaItem(SRGMediaItem(MEDIA_URN))
+        player.addListener(mockListener)
+
+        advance(player).untilPosition(0, MEDIA_DURATION)
+
+        assertEquals(8, chapters.size)
+        assertEquals("urn:rts:video:15533242", chapters[0]?.id)
+        assertNull(chapters[1])
+        assertEquals("urn:rts:video:15533244", chapters[2]?.id)
+        assertNull(chapters[3])
+        assertEquals("urn:rts:video:15533246", chapters[4]?.id)
+        assertNull(chapters[5])
+        assertEquals("urn:rts:video:15533248", chapters[6]?.id)
+        assertNull(chapters[7])
+    }
+
+    @Test
+    fun `check that credits are reported`() {
+        val credits = mutableListOf<Credit?>()
+        val mockListener = mockk<PillarboxPlayer.Listener>(relaxed = true) {
+            justRun { onCreditChanged(captureNullable(credits)) }
+        }
+
+        player.setMediaItem(SRGMediaItem(MEDIA_URN))
+        player.addListener(mockListener)
+
+        advance(player).untilPosition(0, MEDIA_DURATION)
+
+        assertEquals(2, credits.size)
+        assertEquals(Credit.Closing(1601320L, 1605800L), credits[0])
+        assertNull(credits[1])
+    }
+
+    private companion object {
+        private const val MEDIA_DURATION = 1613760L
+        private const val MEDIA_URN = "urn:rts:video:15532586"
     }
 }

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/BlockedTimeRangeTrackerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/tracker/BlockedTimeRangeTrackerTest.kt
@@ -97,17 +97,9 @@ private class BlockedAssetLoader(context: Context) : AssetLoader(DefaultMediaSou
     override suspend fun loadAsset(mediaItem: MediaItem): Asset {
         val itemBuilder = mediaItem.buildUpon()
         val listBlockedTimeRanges = when (mediaItem.mediaId) {
-            MEDIA_ONE_SEGMENT.mediaId -> {
-                listOf(SEGMENT)
-            }
-
-            MEDIA_START_BLOCKED_SEGMENT.mediaId -> {
-                listOf(START_SEGMENT, SEGMENT)
-            }
-
-            else -> {
-                emptyList()
-            }
+            MEDIA_ONE_SEGMENT.mediaId -> listOf(SEGMENT)
+            MEDIA_START_BLOCKED_SEGMENT.mediaId -> listOf(START_SEGMENT, SEGMENT)
+            else -> emptyList()
         }
         return Asset(
             mediaSource = mediaSourceFactory.createMediaSource(itemBuilder.build()),


### PR DESCRIPTION
# Pull request

## Description

Currently, when reaching the end of a credit, we call `PillarboxExoPlayer.notifyTimeRangeChanged(null)`, where `notifyTimeRangeChanged()` takes a `TimeRange`.
However, when passing `null`, we don't know what kind of time range we should handle. This means that we never call `PillarboxPlayer.Listener.onCreditChanged()`.
This PR fixes that by splitting `notifyTimeRangeChanged()` in three distinct methods: `notifyBlockedTimeRangeChanged()`, `notifyChapterChange()`, and `notifyCreditChange()`.

## Changes made

- Self-explanatory.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).