### PR TITLE
Update `ComScoreTrackerIntegrationTest` to properly handle live video for radio show

### DIFF
--- a/pillarbox-core-business/src/test/assets/media-compositions.json
+++ b/pillarbox-core-business/src/test/assets/media-compositions.json
@@ -1,109 +1,403 @@
 [
-    {
-        "chapterUrn": "urn:rts:audio:3262363",
-        "episode": {
-            "publishedDate": "2024-10-15T15:51:18+02:00",
-            "imageTitle": "RTS Couleur 3 en direct",
-            "imageUrl": "https://img.rts.ch/articles/2024/image/6uz53b-28609823.image",
-            "title": "RTS Couleur 3 en direct",
-            "id": "e293edd5-8599-3b27-ad67-e74691654311"
-        },
-        "show": {},
-        "channel": {},
-        "chapterList": [
-            {
-                "id": "3262363",
-                "mediaType": "AUDIO",
-                "vendor": "RTS",
-                "urn": "urn:rts:audio:3262363",
-                "title": "RTS Couleur 3 en direct",
-                "imageUrl": "https://img.rts.ch/articles/2024/image/6uz53b-28609823.image",
-                "imageTitle": "RTS Couleur 3 en direct",
-                "type": "LIVESTREAM",
-                "date": "2024-10-15T15:51:18+02:00",
-                "duration": 0,
-                "playableAbroad": true,
-                "displayable": true,
-                "position": -1,
-                "noEmbed": false,
-                "analyticsMetadata": {},
-                "eventData": "$bc111a1b3094a64c$3a7f358a795927d5574bf3c2f92a4887e1f16b5537eb505462492f05e4f879b1721cb51d6a9226edbbfa014cb1ed95a98cdf3124b0941bd2167f08b78a52f02fef2398654f36c35310efdc6fa5e36f2a5ad0e5c5640dab6c3bd0212b252237c63c70e1c6b50172506a4b0334f6a0dffa9eff39d9b626b5b4d02e979ac2ad5fefed9731d21bbc437c8339041b8674e159c7a867321c6579db6082d721e248a6b95fb0a37600b95c25511d4c7f23a93d9da3b649a642846d2dbc2eed056dbacffd707f6dc267a82dee0d91694f7553801a75bb7b002b4a95c1ac071e45a9fe8c378e399e7a6d68e526d96e609e0e8a1b58884bab792aba79ad1c60a11b014b9865450b718e40746802df3fa5da2d0a97f6eeba51c25636d9e79320f07c2189d8084428a69b7557db3718c4dcabf3330ca2478509a6604247f72e6b2a05f8f3b9fb9cd8bba7ce1ac23962ddb3c56771abd86bcb587da9b1f2324f6dcbf9bbb0dce4b02e3dcf25121a910d20abcfcd170368c3cb147b52b85238f5e5af3d5556ce55d018fe2cb1dc4390f180c1c16b4d4c6ff2368c3b333d2249fe5fa674ebb9b612",
-                "resourceList": [
-                    {
-                        "url": "https://stxt-audiostreaming.akamaized.net/hls/live/2117380/couleur3/master.m3u8",
-                        "quality": "HD",
-                        "protocol": "HLS-DVR",
-                        "encoding": "H264",
-                        "mimeType": "application/x-mpegURL",
-                        "presentation": "DEFAULT",
-                        "streaming": "HLS",
-                        "dvr": true,
-                        "live": true,
-                        "mediaContainer": "MPEG2_TS",
-                        "audioCodec": "AAC",
-                        "videoCodec": "H264",
-                        "tokenType": "NONE",
-                        "analyticsMetadata": {
-                            "media_url": "https://stxt-audiostreaming.akamaized.net/hls/live/2117380/couleur3/master.m3u8",
-                            "media_streaming_quality": "HD",
-                            "media_special_format": "DEFAULT"
-                        },
-                        "streamOffset": 55000
-                    },
-                    {
-                        "url": "https://stream.srg-ssr.ch/srgssr/couleur3/mp3/128",
-                        "quality": "HD",
-                        "protocol": "HTTPS",
-                        "encoding": "MP3",
-                        "mimeType": "audio/mpeg",
-                        "presentation": "DEFAULT",
-                        "streaming": "PROGRESSIVE",
-                        "dvr": false,
-                        "live": true,
-                        "mediaContainer": "NONE",
-                        "audioCodec": "MP3",
-                        "videoCodec": "NONE",
-                        "tokenType": "NONE",
-                        "analyticsMetadata": {
-                            "media_url": "https://stream.srg-ssr.ch/srgssr/couleur3/mp3/128",
-                            "media_streaming_quality": "HD",
-                            "media_special_format": "DEFAULT"
-                        }
-                    }
-                ]
+  {
+    "chapterUrn": "urn:rts:audio:3262363",
+    "episode": {
+      "publishedDate": "2024-10-15T15:51:18+02:00",
+      "imageTitle": "RTS Couleur 3 en direct",
+      "imageUrl": "https://img.rts.ch/articles/2024/image/6uz53b-28609823.image",
+      "title": "RTS Couleur 3 en direct",
+      "id": "e293edd5-8599-3b27-ad67-e74691654311"
+    },
+    "show": {},
+    "channel": {},
+    "chapterList": [
+      {
+        "id": "3262363",
+        "mediaType": "AUDIO",
+        "vendor": "RTS",
+        "urn": "urn:rts:audio:3262363",
+        "title": "RTS Couleur 3 en direct",
+        "imageUrl": "https://img.rts.ch/articles/2024/image/6uz53b-28609823.image",
+        "imageTitle": "RTS Couleur 3 en direct",
+        "type": "LIVESTREAM",
+        "date": "2024-10-15T15:51:18+02:00",
+        "duration": 0,
+        "playableAbroad": true,
+        "displayable": true,
+        "position": -1,
+        "noEmbed": false,
+        "analyticsMetadata": {},
+        "eventData": "$bc111a1b3094a64c$3a7f358a795927d5574bf3c2f92a4887e1f16b5537eb505462492f05e4f879b1721cb51d6a9226edbbfa014cb1ed95a98cdf3124b0941bd2167f08b78a52f02fef2398654f36c35310efdc6fa5e36f2a5ad0e5c5640dab6c3bd0212b252237c63c70e1c6b50172506a4b0334f6a0dffa9eff39d9b626b5b4d02e979ac2ad5fefed9731d21bbc437c8339041b8674e159c7a867321c6579db6082d721e248a6b95fb0a37600b95c25511d4c7f23a93d9da3b649a642846d2dbc2eed056dbacffd707f6dc267a82dee0d91694f7553801a75bb7b002b4a95c1ac071e45a9fe8c378e399e7a6d68e526d96e609e0e8a1b58884bab792aba79ad1c60a11b014b9865450b718e40746802df3fa5da2d0a97f6eeba51c25636d9e79320f07c2189d8084428a69b7557db3718c4dcabf3330ca2478509a6604247f72e6b2a05f8f3b9fb9cd8bba7ce1ac23962ddb3c56771abd86bcb587da9b1f2324f6dcbf9bbb0dce4b02e3dcf25121a910d20abcfcd170368c3cb147b52b85238f5e5af3d5556ce55d018fe2cb1dc4390f180c1c16b4d4c6ff2368c3b333d2249fe5fa674ebb9b612",
+        "resourceList": [
+          {
+            "url": "https://stxt-audiostreaming.akamaized.net/hls/live/2117380/couleur3/master.m3u8",
+            "quality": "HD",
+            "protocol": "HLS-DVR",
+            "encoding": "H264",
+            "mimeType": "application/x-mpegURL",
+            "presentation": "DEFAULT",
+            "streaming": "HLS",
+            "dvr": true,
+            "live": true,
+            "mediaContainer": "MPEG2_TS",
+            "audioCodec": "AAC",
+            "videoCodec": "H264",
+            "tokenType": "NONE",
+            "analyticsMetadata": {
+              "media_url": "https://stxt-audiostreaming.akamaized.net/hls/live/2117380/couleur3/master.m3u8",
+              "media_streaming_quality": "HD",
+              "media_special_format": "DEFAULT"
+            },
+            "streamOffset": 55000
+          },
+          {
+            "url": "https://stream.srg-ssr.ch/srgssr/couleur3/mp3/128",
+            "quality": "HD",
+            "protocol": "HTTPS",
+            "encoding": "MP3",
+            "mimeType": "audio/mpeg",
+            "presentation": "DEFAULT",
+            "streaming": "PROGRESSIVE",
+            "dvr": false,
+            "live": true,
+            "mediaContainer": "NONE",
+            "audioCodec": "MP3",
+            "videoCodec": "NONE",
+            "tokenType": "NONE",
+            "analyticsMetadata": {
+              "media_url": "https://stream.srg-ssr.ch/srgssr/couleur3/mp3/128",
+              "media_streaming_quality": "HD",
+              "media_special_format": "DEFAULT"
             }
+          }
+        ]
+      }
+    ],
+    "topicList": [],
+    "analyticsData": {
+      "ns_st_pr": "RTS Couleur 3 en direct",
+      "ns_st_ddt": "2024-10-15",
+      "ns_st_tdt": "2024-10-15",
+      "ns_st_tm": "15:51",
+      "ns_st_tep": "*null",
+      "ns_st_stc": "*null",
+      "ns_st_tpr": "1"
+    },
+    "analyticsMetadata": {
+      "media_episode_id": "e293edd5-8599-3b27-ad67-e74691654311",
+      "media_show_id": "1",
+      "media_show": "RTS Couleur 3",
+      "media_episode": "RTS Couleur 3 en direct",
+      "media_is_livestream": "true",
+      "media_full_length": "full",
+      "media_enterprise_units": "RTS",
+      "media_content_group": "",
+      "media_channel_id": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "media_channel_name": "RTS Couleur 3",
+      "media_since_publication_d": "278",
+      "media_since_publication_h": "6691",
+      "media_thumbnail": "https://img.rts.ch/articles/2024/image/6uz53b-28609823.image",
+      "media_publication_date": "2024-10-15",
+      "media_publication_time": "15:51:18",
+      "media_publication_datetime": "2024-10-15T15:51:18+02:00",
+      "media_tv_date": "2024-10-15",
+      "media_tv_time": "15:51:18",
+      "media_is_web_only": "false",
+      "media_signlanguage_on": "false"
+    }
+  },
+  {
+    "chapterUrn": "urn:rts:video:8841634-radio",
+    "episode": {
+      "publishedDate": "2025-01-29T17:13:10+01:00",
+      "imageTitle": "RTS Couleur 3 en direct",
+      "imageUrl": "https://img.rts.ch/articles/2024/image/o29he-28663338.image",
+      "title": "RTS Couleur 3 en direct",
+      "id": "25427f19-96bf-39c1-ad8b-f7bd31489c8f"
+    },
+    "show": {
+      "id": "bade447d-095f-3ab4-a647-08938e96a929",
+      "vendor": "RTS",
+      "transmission": "TV",
+      "urn": "urn:rts:show:tv:bade447d-095f-3ab4-a647-08938e96a929",
+      "title": "RTS Couleur 3",
+      "imageUrl": "https://il.srgssr.ch/image-service/dynamic/271449.jpg",
+      "imageTitle": "RTS Couleur 3",
+      "posterImageUrl": "https://il.srgssr.ch/image-service/dynamic/4d02e478.jpg",
+      "posterImageIsFallbackUrl": true,
+      "podcastImageUrl": "https://il.srgssr.ch/image-service/dynamic/8278255.jpg",
+      "podcastImageIsFallbackUrl": true,
+      "primaryChannelId": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "primaryChannelUrn": "urn:rts:channel:radio:8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "numberOfEpisodes": 1,
+      "allowIndexing": false
+    },
+    "channel": {
+      "id": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "vendor": "RTS",
+      "urn": "urn:rts:channel:radio:8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "title": "RTS Couleur 3",
+      "imageUrl": "https://img.rts.ch/articles/2020/image/9gpl81-26142286.image",
+      "imageUrlRaw": "https://il.srgssr.ch/image-service/dynamic/a9f904.svg",
+      "imageTitle": "RTS Couleur 3",
+      "transmission": "RADIO"
+    },
+    "chapterList": [
+      {
+        "id": "8841634",
+        "mediaType": "VIDEO",
+        "vendor": "RTS",
+        "urn": "urn:rts:video:8841634-radio",
+        "title": "RTS Couleur 3 en direct",
+        "imageUrl": "https://img.rts.ch/articles/2024/image/o29he-28663338.image",
+        "imageTitle": "RTS Couleur 3 en direct",
+        "type": "LIVESTREAM",
+        "date": "2025-01-29T17:13:10+01:00",
+        "duration": 0,
+        "playableAbroad": true,
+        "displayable": true,
+        "position": -1,
+        "noEmbed": false,
+        "analyticsMetadata": {
+          "media_urn": "urn:rts:video:8841634-radio",
+          "media_segment_length": "0",
+          "media_episode_length": "0",
+          "media_segment_id": "8841634",
+          "media_type": "Video",
+          "media_duration_category": "infinit.livestream",
+          "media_segment": "Livestream",
+          "media_is_geoblocked": "false",
+          "media_sub_set_id": "LIVESTREAM",
+          "media_signlanguage_on": "false"
+        },
+        "eventData": "$8090f0787104ab73$f4203fba70a1af531279b9e3e14643843e7c376dad19f9b2e8bb7a49a167585b8bab4e2389d353ad3872064c2d02aae91da8da16d52422a20935b4673b3655e70ea1359d32c0b34b43ced48f9dedb700946cec8abc2e01fd3992b525ca10e3376f18f5c34c68b3720d3cbaaaec0941179ca764953924453f78b716c34f57b3209aa09535a22190d3bcf5f7ee9ab26b95eeef9050964b76fbe6fa9bdc910ac492a3aa339397878803320c90ce7a4c7ce90080d7b2a14af3dd68a2ee278c0ccf8a6711c289aae9d6f30adb49c0c66efac63435d15373029957735e726878665b75f6910839ed626cac88692142812286456b403bf821b5c17944350cb0017c7a2b695d8cee0403e200960e92e097be7e34b5663a9bf881632108084e812ff895991f2b38d8eba12263a097121479e487db8ec2992636bf6bef5189c52937fef30f3cc4f49255185df9e245217028bbeb7de4443688b3eae0bef0f0f19d30cc2c8d7b7267c757db1be4258ad218de48a97af12d4bdf66433042e2f6d70ba7a2fa9918484a61e97abe25066df8124a86fa35a2294bf831320b4421ba5b2b1a6e192a",
+        "resourceList": [
+          {
+            "url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8",
+            "quality": "HD",
+            "protocol": "HLS-DVR",
+            "encoding": "H264",
+            "mimeType": "application/x-mpegURL",
+            "presentation": "DEFAULT",
+            "streaming": "HLS",
+            "dvr": true,
+            "live": true,
+            "mediaContainer": "MPEG2_TS",
+            "audioCodec": "AAC",
+            "videoCodec": "H264",
+            "tokenType": "NONE",
+            "analyticsMetadata": {
+              "media_url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8",
+              "media_streaming_quality": "HD",
+              "media_special_format": "DEFAULT"
+            },
+            "streamOffset": 30000
+          },
+          {
+            "url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
+            "quality": "HD",
+            "protocol": "HLS",
+            "encoding": "H264",
+            "mimeType": "application/x-mpegURL",
+            "presentation": "DEFAULT",
+            "streaming": "HLS",
+            "dvr": false,
+            "live": true,
+            "mediaContainer": "MPEG2_TS",
+            "audioCodec": "AAC",
+            "videoCodec": "H264",
+            "tokenType": "NONE",
+            "analyticsMetadata": {
+              "media_url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
+              "media_streaming_quality": "HD",
+              "media_special_format": "DEFAULT"
+            }
+          }
         ],
-        "topicList": [],
+        "aspectRatio": "16:9"
+      }
+    ],
+    "topicList": [],
+    "analyticsData": {
+      "ns_st_pr": "RTS Couleur 3 en direct",
+      "ns_st_ddt": "2025-01-29",
+      "ns_st_tdt": "2025-01-29",
+      "ns_st_tm": "17:13",
+      "ns_st_tep": "*null",
+      "ns_st_stc": "*null",
+      "ns_st_tpr": "1"
+    },
+    "analyticsMetadata": {
+      "media_episode_id": "25427f19-96bf-39c1-ad8b-f7bd31489c8f",
+      "media_show_id": "1",
+      "media_show": "RTS Couleur 3",
+      "media_episode": "RTS Couleur 3 en direct",
+      "media_is_livestream": "true",
+      "media_full_length": "full",
+      "media_enterprise_units": "RTS",
+      "media_content_group": "",
+      "media_channel_id": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "media_channel_name": "RTS Couleur 3",
+      "media_since_publication_d": "211",
+      "media_since_publication_h": "5080",
+      "media_thumbnail": "https://img.rts.ch/articles/2024/image/o29he-28663338.image",
+      "media_publication_date": "2025-01-29",
+      "media_publication_time": "17:13:10",
+      "media_publication_datetime": "2025-01-29T17:13:10+01:00",
+      "media_tv_date": "2025-01-29",
+      "media_tv_time": "17:13:10",
+      "media_is_web_only": "false",
+      "media_signlanguage_on": "false"
+    }
+  },
+  {
+    "chapterUrn": "urn:rts:video:8841634-tv",
+    "episode": {
+      "publishedDate": "2025-01-29T17:13:10+01:00",
+      "imageTitle": "RTS Couleur 3 en direct",
+      "imageUrl": "https://img.rts.ch/articles/2024/image/o29he-28663338.image",
+      "title": "RTS Couleur 3 en direct",
+      "id": "25427f19-96bf-39c1-ad8b-f7bd31489c8f"
+    },
+    "show": {
+      "id": "bade447d-095f-3ab4-a647-08938e96a929",
+      "vendor": "RTS",
+      "transmission": "TV",
+      "urn": "urn:rts:show:tv:bade447d-095f-3ab4-a647-08938e96a929",
+      "title": "RTS Couleur 3",
+      "imageUrl": "https://il.srgssr.ch/image-service/dynamic/271449.jpg",
+      "imageTitle": "RTS Couleur 3",
+      "posterImageUrl": "https://il.srgssr.ch/image-service/dynamic/4d02e478.jpg",
+      "posterImageIsFallbackUrl": true,
+      "podcastImageUrl": "https://il.srgssr.ch/image-service/dynamic/8278255.jpg",
+      "podcastImageIsFallbackUrl": true,
+      "primaryChannelId": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "primaryChannelUrn": "urn:rts:channel:radio:8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "numberOfEpisodes": 1,
+      "allowIndexing": false
+    },
+    "channel": {
+      "id": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "vendor": "RTS",
+      "urn": "urn:rts:channel:radio:8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "title": "RTS Couleur 3",
+      "imageUrl": "https://img.rts.ch/articles/2020/image/9gpl81-26142286.image",
+      "imageUrlRaw": "https://il.srgssr.ch/image-service/dynamic/a9f904.svg",
+      "imageTitle": "RTS Couleur 3",
+      "transmission": "RADIO"
+    },
+    "chapterList": [
+      {
+        "id": "8841634",
+        "mediaType": "VIDEO",
+        "vendor": "RTS",
+        "urn": "urn:rts:video:8841634-tv",
+        "title": "RTS Couleur 3 en direct",
+        "imageUrl": "https://img.rts.ch/articles/2024/image/o29he-28663338.image",
+        "imageTitle": "RTS Couleur 3 en direct",
+        "type": "LIVESTREAM",
+        "date": "2025-01-29T17:13:10+01:00",
+        "duration": 0,
+        "playableAbroad": true,
+        "displayable": true,
+        "position": -1,
+        "noEmbed": false,
         "analyticsData": {
-            "ns_st_pr": "RTS Couleur 3 en direct",
-            "ns_st_ddt": "2024-10-15",
-            "ns_st_tdt": "2024-10-15",
-            "ns_st_tm": "15:51",
-            "ns_st_tep": "*null",
-            "ns_st_stc": "*null",
-            "ns_st_tpr": "1"
+          "ns_st_ep": "Livestream",
+          "ns_st_ci": "3608506",
+          "ns_st_cl": "0",
+          "ns_st_ct": "vc13"
         },
         "analyticsMetadata": {
-            "media_episode_id": "e293edd5-8599-3b27-ad67-e74691654311",
-            "media_show_id": "1",
-            "media_show": "RTS Couleur 3",
-            "media_episode": "RTS Couleur 3 en direct",
-            "media_is_livestream": "true",
-            "media_full_length": "full",
-            "media_enterprise_units": "RTS",
-            "media_content_group": "",
-            "media_channel_id": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
-            "media_channel_name": "RTS Couleur 3",
-            "media_since_publication_d": "278",
-            "media_since_publication_h": "6691",
-            "media_thumbnail": "https://img.rts.ch/articles/2024/image/6uz53b-28609823.image",
-            "media_publication_date": "2024-10-15",
-            "media_publication_time": "15:51:18",
-            "media_publication_datetime": "2024-10-15T15:51:18+02:00",
-            "media_tv_date": "2024-10-15",
-            "media_tv_time": "15:51:18",
-            "media_is_web_only": "false",
-            "media_signlanguage_on": "false"
-        }
+          "media_urn": "urn:rts:video:8841634-tv",
+          "media_segment_length": "0",
+          "media_episode_length": "0",
+          "media_segment_id": "8841634",
+          "media_type": "Video",
+          "media_duration_category": "infinit.livestream",
+          "media_segment": "Livestream",
+          "media_is_geoblocked": "false",
+          "media_sub_set_id": "LIVESTREAM",
+          "media_signlanguage_on": "false"
+        },
+        "eventData": "$8090f0787104ab73$f4203fba70a1af531279b9e3e14643843e7c376dad19f9b2e8bb7a49a167585b8bab4e2389d353ad3872064c2d02aae91da8da16d52422a20935b4673b3655e70ea1359d32c0b34b43ced48f9dedb700946cec8abc2e01fd3992b525ca10e3376f18f5c34c68b3720d3cbaaaec0941179ca764953924453f78b716c34f57b3209aa09535a22190d3bcf5f7ee9ab26b95eeef9050964b76fbe6fa9bdc910ac492a3aa339397878803320c90ce7a4c7ce90080d7b2a14af3dd68a2ee278c0ccf8a6711c289aae9d6f30adb49c0c66efac63435d15373029957735e726878665b75f6910839ed626cac88692142812286456b403bf821b5c17944350cb0017c7a2b695d8cee0403e200960e92e097be7e34b5663a9bf881632108084e812ff895991f2b38d8eba12263a097121479e487db8ec2992636bf6bef5189c52937fef30f3cc4f49255185df9e245217028bbeb7de4443688b3eae0bef0f0f19d30cc2c8d7b7267c757db1be4258ad218de48a97af12d4bdf66433042e2f6d70ba7a2fa9918484a61e97abe25066df8124a86fa35a2294bf831320b4421ba5b2b1a6e192a",
+        "resourceList": [
+          {
+            "url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8",
+            "quality": "HD",
+            "protocol": "HLS-DVR",
+            "encoding": "H264",
+            "mimeType": "application/x-mpegURL",
+            "presentation": "DEFAULT",
+            "streaming": "HLS",
+            "dvr": true,
+            "live": true,
+            "mediaContainer": "MPEG2_TS",
+            "audioCodec": "AAC",
+            "videoCodec": "H264",
+            "tokenType": "NONE",
+            "analyticsMetadata": {
+              "media_url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8",
+              "media_streaming_quality": "HD",
+              "media_special_format": "DEFAULT"
+            },
+            "streamOffset": 30000
+          },
+          {
+            "url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
+            "quality": "HD",
+            "protocol": "HLS",
+            "encoding": "H264",
+            "mimeType": "application/x-mpegURL",
+            "presentation": "DEFAULT",
+            "streaming": "HLS",
+            "dvr": false,
+            "live": true,
+            "mediaContainer": "MPEG2_TS",
+            "audioCodec": "AAC",
+            "videoCodec": "H264",
+            "tokenType": "NONE",
+            "analyticsMetadata": {
+              "media_url": "https://rtsc3video.akamaized.net/hls/live/2042837/c3video/3/playlist.m3u8?dw=0",
+              "media_streaming_quality": "HD",
+              "media_special_format": "DEFAULT"
+            }
+          }
+        ],
+        "aspectRatio": "16:9"
+      }
+    ],
+    "topicList": [],
+    "analyticsData": {
+      "ns_st_pr": "RTS Couleur 3 en direct",
+      "ns_st_ddt": "2025-01-29",
+      "ns_st_tdt": "2025-01-29",
+      "ns_st_tm": "17:13",
+      "ns_st_tep": "*null",
+      "ns_st_stc": "*null",
+      "ns_st_tpr": "1"
+    },
+    "analyticsMetadata": {
+      "media_episode_id": "25427f19-96bf-39c1-ad8b-f7bd31489c8f",
+      "media_show_id": "1",
+      "media_show": "RTS Couleur 3",
+      "media_episode": "RTS Couleur 3 en direct",
+      "media_is_livestream": "true",
+      "media_full_length": "full",
+      "media_enterprise_units": "RTS",
+      "media_content_group": "",
+      "media_channel_id": "8ceb28d9b3f1dd876d1df1780f908578cbefc3d7",
+      "media_channel_name": "RTS Couleur 3",
+      "media_since_publication_d": "211",
+      "media_since_publication_h": "5080",
+      "media_thumbnail": "https://img.rts.ch/articles/2024/image/o29he-28663338.image",
+      "media_publication_date": "2025-01-29",
+      "media_publication_time": "17:13:10",
+      "media_publication_datetime": "2025-01-29T17:13:10+01:00",
+      "media_tv_date": "2025-01-29",
+      "media_tv_time": "17:13:10",
+      "media_is_web_only": "false",
+      "media_signlanguage_on": "false"
     }
+  }
 ]

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/commandersact/CommandersActTrackerIntegrationTest.kt
@@ -934,7 +934,7 @@ class CommandersActTrackerIntegrationTest {
     private companion object {
         private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/4dcba1d3-8cc8-3667-a7d2-b3b92c4243d9/master.m3u8"
         private const val URN_AUDIO = "urn:rts:audio:13598743"
-        private const val URN_LIVE_DVR_VIDEO = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_VIDEO
+        private const val URN_LIVE_DVR_VIDEO = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_VIDEO_TV
         private const val URN_NOT_LIVE_VIDEO = "urn:rts:video:8806923"
         private const val URN_VOD_SHORT = "urn:rts:video:13444428"
         private const val URN_LIVE_DVR_AUDIO = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_AUDIO

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTrackerIntegrationTest.kt
@@ -81,7 +81,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `player prepared and playing, changing media item`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.playWhenReady = true
 
@@ -124,9 +124,20 @@ class ComScoreTrackerIntegrationTest {
     }
 
     @Test
+    fun `live video for radio show don't send any analytics`() {
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_RADIO))
+        player.prepare()
+        player.playWhenReady = true
+
+        TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
+
+        verify { streamingAnalytics wasNot Called }
+    }
+
+    @Test
     @Ignore("SurfaceView/SurfaceHolder not implemented in Robolectric")
     fun `surface size changed`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.playWhenReady = true
 
@@ -181,7 +192,7 @@ class ComScoreTrackerIntegrationTest {
     // region Live media
     @Test
     fun `live - player prepared but not playing`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
 
         TestPlayerRunHelper.runUntilPlaybackState(player, Player.STATE_READY)
@@ -198,7 +209,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared and playing`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.playWhenReady = true
 
@@ -218,7 +229,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared, playing and paused`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.playWhenReady = true
 
@@ -244,7 +255,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared, playing, paused, playing again`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.playWhenReady = true
 
@@ -276,7 +287,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared, playing and stopped`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.playWhenReady = true
 
@@ -302,7 +313,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared, playing and seeking`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.playWhenReady = true
 
@@ -329,7 +340,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared and seek`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.seekTo(3.minutes.inWholeMilliseconds)
 
@@ -348,7 +359,7 @@ class ComScoreTrackerIntegrationTest {
 
     @Test
     fun `live - player prepared and stopped`() {
-        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO))
+        player.setMediaItem(SRGMediaItem(URN_LIVE_DVR_VIDEO_TV))
         player.prepare()
         player.stop()
 
@@ -674,7 +685,8 @@ class ComScoreTrackerIntegrationTest {
 
     private companion object {
         private const val URL = "https://rts-vod-amd.akamaized.net/ww/14970442/4dcba1d3-8cc8-3667-a7d2-b3b92c4243d9/master.m3u8"
-        private const val URN_LIVE_DVR_VIDEO = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_VIDEO
+        private const val URN_LIVE_DVR_VIDEO_RADIO = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_VIDEO_RADIO
+        private const val URN_LIVE_DVR_VIDEO_TV = LocalMediaCompositionWithFallbackService.URN_LIVE_DVR_VIDEO_TV
         private const val URN_NOT_LIVE_VIDEO = "urn:rts:video:8806923"
     }
 }

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/utils/LocalMediaCompositionWithFallbackService.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/utils/LocalMediaCompositionWithFallbackService.kt
@@ -26,14 +26,15 @@ internal class LocalMediaCompositionWithFallbackService(
         val urn = uri.lastPathSegment
         val mediaComposition = mediaCompositions.firstOrNull { it.chapterUrn == urn }
         return if (mediaComposition != null) {
-            runCatching { mediaComposition }
+            Result.success(mediaComposition)
         } else {
             fallbackService.fetchMediaComposition(uri)
         }
     }
 
     companion object {
-        const val URN_LIVE_DVR_VIDEO = "urn:rts:video:8841634"
+        const val URN_LIVE_DVR_VIDEO_RADIO = "urn:rts:video:8841634-radio"
+        const val URN_LIVE_DVR_VIDEO_TV = "urn:rts:video:8841634-tv"
         const val URN_LIVE_DVR_AUDIO = "urn:rts:audio:3262363"
     }
 }


### PR DESCRIPTION
# Pull request

## Description

Video streams for a radio show should no longer send analytics to ComScore. This PR updates `ComScoreTrackerIntegrationTest` to ensure that we correctly follow this rule.

## Changes made

- Update `media-composition.json` to include two new media compositions:
  - One for live video with DVR for a radio show.
  - One for live video with DVR for a TV show.
Both have the same information, except for the `analyticsData` field. I've kept the same URN in both cases but suffixed it with either `-radio` or `-tv`.
- Add a test case to `ComScoreTrackerIntegrationTest` to ensure that we don't send any analytics to ComScore for a live video with DVR for a radio show.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).