### PR TITLE
Always broadcast a valid duration

### DIFF
--- a/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxMediaCommandCallback.kt
+++ b/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxMediaCommandCallback.kt
@@ -246,7 +246,7 @@ internal class PillarboxMediaCommandCallback(
             } else {
                 mediaStatusModifier.liveSeekableRange = null
             }
-            val duration = if (player.duration == C.TIME_UNSET) null else window.durationMs
+            val duration = if (window.durationMs == C.TIME_UNSET) null else window.durationMs
             mediaStatusModifier.mediaInfoModifier?.streamDuration = duration
 
             if (player.currentMediaItemIndex != C.INDEX_UNSET && player.mediaItemCount > 0) {


### PR DESCRIPTION
## Description

The goal of this PR is to always broadcast a valid duration. It fixes #1172 

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
