### PR TITLE
Don't restore saved state if they aren't saved initially

### DIFF
--- a/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/SmoothProgressTrackerState.kt
+++ b/pillarbox-ui/src/main/java/ch/srgssr/pillarbox/ui/SmoothProgressTrackerState.kt
@@ -68,6 +68,7 @@ class SmoothProgressTrackerState(
     override fun onFinished() {
         startChanging = false
         simpleProgressTrackerState.onFinished()
+        if (!player.isSeekParametersAvailable) return
         player.trackSelectionParameters = storedTrackSelectionParameters
         player.smoothSeekingEnabled = storedSmoothSeeking
         player.setSeekParameters(storedSeekParameters)


### PR DESCRIPTION
## Description

Fix `SmoothProgressTrackerState` restoring previous player state even when there is no need to restore them.

https://github.com/SRGSSR/pillarbox-documentation/issues/162

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
