### PR TITLE
Fix receiver crash when senders emptying the playlist

### DIFF
--- a/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxMediaCommandCallback.kt
+++ b/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxMediaCommandCallback.kt
@@ -233,33 +233,36 @@ internal class PillarboxMediaCommandCallback(
                 Player.EVENT_POSITION_DISCONTINUITY
             )
         ) {
-            mediaStatusModifier.setSupportedMediaCommandsFromAvailableCommand(player.availableCommands)
-            mediaStatusModifier.setPlaybackRateFromPlaybackParameter(player.playbackParameters)
-
-            player.currentTimeline.getWindow(player.currentMediaItemIndex, window)
-            if (player.isCurrentMediaItemLive) {
-                val liveSeekableRange = MediaLiveSeekableRange.Builder()
-                    .setIsLiveDone(false)
-                    .setIsMovingWindow(window.isDynamic)
-                    .setStartTime(0)
-                    .setEndTime(window.durationMs)
-                    .build()
-                mediaStatusModifier.liveSeekableRange = liveSeekableRange
-                mediaStatusModifier.mediaInfoModifier?.streamType = MediaInfo.STREAM_TYPE_LIVE
-                mediaStatusModifier.streamPosition = player.currentPosition
-            } else {
-                mediaStatusModifier.liveSeekableRange = null
-                mediaStatusModifier.mediaInfoModifier?.streamType = MediaInfo.STREAM_TYPE_BUFFERED
-                mediaStatusModifier.streamPosition = null
-            }
-            val duration = if (window.durationMs == C.TIME_UNSET) null else window.durationMs
-            mediaStatusModifier.mediaInfoModifier?.streamDuration = duration
-
             if (player.currentMediaItemIndex != C.INDEX_UNSET && player.mediaItemCount > 0) {
+                mediaStatusModifier.setSupportedMediaCommandsFromAvailableCommand(player.availableCommands)
+                mediaStatusModifier.setPlaybackRateFromPlaybackParameter(player.playbackParameters)
+
+                player.currentTimeline.getWindow(player.currentMediaItemIndex, window)
+                if (player.isCurrentMediaItemLive) {
+                    val liveSeekableRange = MediaLiveSeekableRange.Builder()
+                        .setIsLiveDone(false)
+                        .setIsMovingWindow(window.isDynamic)
+                        .setStartTime(0)
+                        .setEndTime(window.durationMs)
+                        .build()
+                    mediaStatusModifier.liveSeekableRange = liveSeekableRange
+                    mediaStatusModifier.mediaInfoModifier?.streamType = MediaInfo.STREAM_TYPE_LIVE
+                    mediaStatusModifier.streamPosition = player.currentPosition
+                } else {
+                    mediaStatusModifier.liveSeekableRange = null
+                    mediaStatusModifier.mediaInfoModifier?.streamType = MediaInfo.STREAM_TYPE_BUFFERED
+                    mediaStatusModifier.streamPosition = null
+                }
+
+                val duration = if (window.durationMs == C.TIME_UNSET) null else window.durationMs
+                mediaStatusModifier.mediaInfoModifier?.streamDuration = duration
+
                 val currentId = mediaQueueManager.queueItems?.get(player.currentMediaItemIndex)?.itemId
                 if (currentId != mediaQueueManager.currentItemId) {
                     mediaQueueManager.currentItemId = currentId
                 }
+            } else {
+                mediaStatusModifier.clear()
             }
             mediaManager.broadcastMediaStatus()
         }


### PR DESCRIPTION
## Description

The goal of this PR is to only update `MediaStatusModifier` when the player have at least a item.

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
