### PR TITLE
Use currentTime from loadRequest instead of startTime from queueData

### DIFF
--- a/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxCastReceiverPlayer.kt
+++ b/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxCastReceiverPlayer.kt
@@ -284,7 +284,7 @@ class PillarboxCastReceiverPlayer(
             mediaStatusModifier.clear()
 
             loadRequest.queueData?.let { queueData ->
-                val positionMs = if (queueData.startTime < 0) C.TIME_UNSET else queueData.startTime
+                val positionMs = if (loadRequest.currentTime < 0) C.TIME_UNSET else loadRequest.currentTime
                 val startIndex = if (queueData.startIndex < 0) C.INDEX_UNSET else queueData.startIndex
                 setMediaItems(queueData.items.orEmpty().map(mediaItemConverter::toMediaItem), startIndex, positionMs)
             } ?: loadRequest.mediaInfo?.let { mediaInfo ->


### PR DESCRIPTION
## Description

This PR fixes an issue with the Android Cast Receiver that was unable to start playback at the correct position.

## Changes made

- The `loadRequest.currentTime` has been used  instead of `queueData.startTime`.

## Checklist

- [x] APIs have been properly documented (if relevant).
- [x] The documentation has been updated (if relevant).
- [x] New unit tests have been written (if relevant).
- [x] The demo has been updated (if relevant).
