### PR TITLE
Add media3 compose ui as public dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -91,6 +91,13 @@ dependencyAnalysis {
             }
         }
 
+        project(":pillarbox-ui") {
+            onUnusedDependencies {
+                exclude(libs.androidx.media3.ui)
+                exclude(libs.androidx.media3.ui.compose)
+            }
+        }
+
         project(":pillarbox-player") {
             onUnusedDependencies {
                 // These dependencies are not used directly, but automatically used by libs.androidx.media3.exoplayer

--- a/pillarbox-ui/build.gradle.kts
+++ b/pillarbox-ui/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     api(libs.androidx.media3.common)
     api(libs.androidx.media3.exoplayer)
     api(libs.androidx.media3.ui)
+    api(libs.androidx.media3.ui.compose)
     implementation(libs.guava)
     implementation(libs.kotlinx.coroutines.core)
 


### PR DESCRIPTION
## Description

As an Integrator I want to be able to use media3 compose ui component without the need to import manually media3 dependency to avoid version conflict.

## Changes made

- Media3 compose ui is a maven dependency

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
