### PR TITLE
Add androidx.media3 to Dependabot ignore list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,4 +42,5 @@ updates:
     ignore:
       - dependency-name: "com.comscore:*"
       - dependency-name: "com.google.guava:*" # Guava is updated together with AndroidX Media3
+      - dependency-name: "androidx.media3:*"
       - dependency-name: "com.tagcommander.lib:*"


### PR DESCRIPTION
## Description

Remove media3 from dependabot.

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
