### PR TITLE
Fix monitoring allway sending  no assetUrl

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/monitoring/Monitoring.kt
@@ -205,7 +205,7 @@ internal class Monitoring(
     }
 
     private fun setAssetUrlForEventTime(eventTime: AnalyticsListener.EventTime, loadEventInfo: LoadEventInfo, mediaLoadData: MediaLoadData) {
-        if (eventTime.timeline.isEmpty || mediaLoadData.dataType != C.DATA_TYPE_MEDIA || mediaLoadData.dataType != C.DATA_TYPE_MANIFEST) return
+        if (eventTime.timeline.isEmpty || (mediaLoadData.dataType != C.DATA_TYPE_MEDIA && mediaLoadData.dataType != C.DATA_TYPE_MANIFEST)) return
         val session = sessionManager.getSessionFromEventTime(eventTime) ?: return
         sessionHolders[session.sessionId]?.let { holder ->
             if (holder.assetUrl == null) holder.assetUrl = loadEventInfo.uri.toString()


### PR DESCRIPTION
## Description

Fix monitoring not sending asset url on session start.

## Changes made

 - Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
