### PR TITLE
1254 fix comscore notifyplay when surface is attached but player not playing

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/tracker/comscore/ComScoreTracker.kt
@@ -99,10 +99,9 @@ class ComScoreTracker internal constructor(
     }
 
     private fun notifyPlay(eventTime: AnalyticsListener.EventTime) {
-        if (!eventTime.timeline.isEmpty) {
-            eventTime.timeline.getWindow(eventTime.windowIndex, window)
-            notifyPlay(eventTime.eventPlaybackPositionMs, window)
-        }
+        if (eventTime.timeline.isEmpty) return
+        eventTime.timeline.getWindow(eventTime.windowIndex, window)
+        notifyPlay(eventTime.eventPlaybackPositionMs, window)
     }
 
     private fun notifyEnd() {


### PR DESCRIPTION
## Description

Fix ComScoreTracker sending notfiyPlay even if the player is paused when surface connect again.


## Changes made

- Avoid sending notifyPlay when surface connecting in pause

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
