### PR TITLE
1264 refactoring pillarbox listener

### DIFF
--- a/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxCastReceiverPlayer.kt
+++ b/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxCastReceiverPlayer.kt
@@ -131,6 +131,14 @@ class PillarboxCastReceiverPlayer(
         player.setImageOutput(imageOutput)
     }
 
+    override fun addListener(listener: PillarboxPlayer.Listener) {
+        player.addListener(listener)
+    }
+
+    override fun removeListener(listener: PillarboxPlayer.Listener) {
+        player.removeListener(listener)
+    }
+
     override fun getCurrentMetrics(): PlaybackMetrics? {
         return player.getCurrentMetrics()
     }

--- a/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxCastReceiverPlayer.kt
+++ b/pillarbox-cast-receiver/src/main/java/ch/srgssr/pillarbox/cast/receiver/PillarboxCastReceiverPlayer.kt
@@ -298,6 +298,10 @@ class PillarboxCastReceiverPlayer(
         player.release()
     }
 
+    override fun getAudioSessionId(): Int {
+        return player.audioSessionId
+    }
+
     override fun getSecondaryRenderer(index: Int): Renderer? {
         return player.getSecondaryRenderer(index)
     }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -336,6 +336,7 @@ class PillarboxCastPlayer internal constructor(
     }
 
     override fun handleRelease(): ListenableFuture<*> {
+        listeners.release()
         if (isMediaRouter2Available()) {
             mediaRouter?.release()
         }

--- a/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
+++ b/pillarbox-cast/src/main/java/ch/srgssr/pillarbox/cast/PillarboxCastPlayer.kt
@@ -27,6 +27,7 @@ import androidx.media3.common.TrackSelectionOverride
 import androidx.media3.common.TrackSelectionParameters
 import androidx.media3.common.Tracks
 import androidx.media3.common.util.Clock
+import androidx.media3.common.util.ListenerSet
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.analytics.DefaultAnalyticsCollector
 import androidx.media3.exoplayer.image.ImageOutput
@@ -125,6 +126,11 @@ class PillarboxCastPlayer internal constructor(
     private val positionSupplier = PosSupplier(0)
     private val sessionListener = SessionListener()
     private val analyticsCollector = DefaultAnalyticsCollector(clock).apply { addListener(EventLogger()) }
+
+    private val listeners: ListenerSet<PillarboxPlayer.Listener> = ListenerSet(applicationLooper, Clock.DEFAULT) { listener, flags ->
+        listener.onEvents(this, Player.Events(flags))
+    }
+
     private val mediaRouter = if (isMediaRouter2Available()) MediaRouter2Wrapper(context) else null
 
     /**
@@ -203,6 +209,16 @@ class PillarboxCastPlayer internal constructor(
     override fun setScrubbingModeEnabled(scrubbingModeEnabled: Boolean) = Unit
 
     override fun setImageOutput(imageOutput: ImageOutput?) = Unit
+
+    override fun addListener(listener: PillarboxPlayer.Listener) {
+        super.addListener(listener)
+        listeners.add(listener)
+    }
+
+    override fun removeListener(listener: PillarboxPlayer.Listener) {
+        super.removeListener(listener)
+        listeners.remove(listener)
+    }
 
     /**
      * Returns whether a cast session is available.

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxExoPlayer.kt
@@ -165,18 +165,22 @@ class PillarboxExoPlayer internal constructor(
         }
     }
 
+    override fun addListener(listener: PillarboxPlayer.Listener) {
+        exoPlayer.addListener(listener)
+        listeners.add(listener)
+    }
+
+    override fun removeListener(listener: PillarboxPlayer.Listener) {
+        exoPlayer.removeListener(listener)
+        listeners.remove(listener)
+    }
+
     override fun addListener(listener: Player.Listener) {
         exoPlayer.addListener(listener)
-        if (listener is PillarboxPlayer.Listener) {
-            listeners.add(listener)
-        }
     }
 
     override fun removeListener(listener: Player.Listener) {
         exoPlayer.removeListener(listener)
-        if (listener is PillarboxPlayer.Listener) {
-            listeners.remove(listener)
-        }
     }
 
     private fun handleBlockedTimeRange(timeRange: BlockedTimeRange) {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -176,8 +176,18 @@ interface PillarboxPlayer : Player {
      */
     fun isScrubbingModeEnabled(): Boolean
 
+    /**
+     * Register a [Listener] to the player.
+     * It also call [Player.addListener]
+     * @see [Player.addListener]
+     */
     fun addListener(listener: Listener)
 
+    /**
+     * Unregister a [Listener] from the player.
+     * It also call [Player.removeListener]
+     * @see [Player.removeListener]
+     */
     fun removeListener(listener: Listener)
 
     companion object {

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PillarboxPlayer.kt
@@ -176,6 +176,10 @@ interface PillarboxPlayer : Player {
      */
     fun isScrubbingModeEnabled(): Boolean
 
+    fun addListener(listener: Listener)
+
+    fun removeListener(listener: Listener)
+
     companion object {
 
         /**

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/PlayerCallbackFlow.kt
@@ -562,6 +562,13 @@ private suspend fun <T> ProducerScope<T>.addPlayerListener(player: Player, liste
     }
 }
 
+private suspend fun <T> ProducerScope<T>.addPlayerListener(player: PillarboxPlayer, listener: PillarboxPlayer.Listener) {
+    player.addListener(listener)
+    awaitClose {
+        player.removeListener(listener)
+    }
+}
+
 /**
  * The default interval between [Flow] emissions.
  */

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaController.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaController.kt
@@ -400,18 +400,22 @@ open class PillarboxMediaController internal constructor() : PillarboxPlayer {
         return mediaController.applicationLooper
     }
 
+    override fun addListener(listener: PillarboxPlayer.Listener) {
+        mediaController.addListener(listener)
+        listeners.add(listener)
+    }
+
+    override fun removeListener(listener: PillarboxPlayer.Listener) {
+        mediaController.addListener(listener)
+        listeners.add(listener)
+    }
+
     override fun addListener(listener: Player.Listener) {
         mediaController.addListener(listener)
-        if (listener is PillarboxPlayer.Listener) {
-            listeners.add(listener)
-        }
     }
 
     override fun removeListener(listener: Player.Listener) {
         mediaController.removeListener(listener)
-        if (listener is PillarboxPlayer.Listener) {
-            listeners.remove(listener)
-        }
     }
 
     override fun setMediaItems(mediaItems: List<MediaItem>) {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PillarboxExoPlayerTest.kt
@@ -34,7 +34,7 @@ import kotlin.time.Duration.Companion.minutes
 
 @RunWith(AndroidJUnit4::class)
 class PillarboxExoPlayerTest {
-    private lateinit var player: ExoPlayer
+    private lateinit var player: PillarboxExoPlayer
 
     @BeforeTest
     fun setup() {

--- a/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
+++ b/pillarbox-player/src/test/java/ch/srgssr/pillarbox/player/PlayerCallbackFlowTest.kt
@@ -8,7 +8,6 @@ import android.os.Looper
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.test.utils.robolectric.TestPlayerRunHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import app.cash.turbine.test
@@ -27,7 +26,7 @@ import kotlin.time.Duration.Companion.milliseconds
 
 @RunWith(AndroidJUnit4::class)
 class PlayerCallbackFlowTest {
-    private lateinit var player: ExoPlayer
+    private lateinit var player: PillarboxExoPlayer
 
     @BeforeTest
     fun setUp() {


### PR DESCRIPTION
## Description

The goal of this PR is to be able to handle `PillarboxPlayer.Listener` when it is not possible to overrides `Player.addListener` like `ForwardingSimpleBasePlayer`.

## Changes made

- Add `PillarboxPlayer.addListener`and `PillarboxPlayer.removeListener`.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
