### PR TITLE
Add new pillarbox-cast-receiver to the Rollback job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,6 +169,8 @@ jobs:
         run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-analytics" ${{ env.VERSION_NAME }} || true
       - name: Delete 'pillarbox-cast' from GitHub Packages
         run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-cast" ${{ env.VERSION_NAME }} || true
+      - name: Delete 'pillarbox-cast-receiver' from GitHub Packages
+        run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-cast-receiver" ${{ env.VERSION_NAME }} || true
       - name: Delete 'pillarbox-core-business' from GitHub Packages
         run: ./github/workflows/actions/delete_package.sh ${{ env.REPO_OWNER }} "ch.srgssr.pillarbox.pillarbox-core-business" ${{ env.VERSION_NAME }} || true
       - name: Delete 'pillarbox-core-business-cast' from GitHub Packages


### PR DESCRIPTION
## Description

Fix release github action that doesn't rollback `pillarbox-cast-receiver`.

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
