### PR TITLE
Initialize analytics for DemoTV too

### DIFF
--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/DemoApplication.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/DemoApplication.kt
@@ -9,6 +9,11 @@ import android.widget.Toast
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import ch.srgssr.pillarbox.analytics.AnalyticsConfig
+import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
+import ch.srgssr.pillarbox.analytics.SourceKey
+import ch.srgssr.pillarbox.analytics.UserConsent
+import ch.srgssr.pillarbox.analytics.comscore.ComScoreUserConsent
 import ch.srgssr.pillarbox.player.network.PillarboxOkHttp
 import coil3.ImageLoader
 import coil3.PlatformContext
@@ -38,6 +43,20 @@ class DemoApplication : Application(), SingletonImageLoader.Factory {
             }
         })
         ProcessLifecycleOwner.get().lifecycle.addObserver(MyLifecycleObserver())
+
+        // Defaults values
+        val initialUserConsent = UserConsent(
+            comScore = ComScoreUserConsent.UNKNOWN,
+            commandersActConsentServices = emptyList()
+        )
+        val config = AnalyticsConfig(
+            vendor = AnalyticsConfig.Vendor.SRG,
+            nonLocalizedApplicationName = "Pillarbox",
+            appSiteName = "pillarbox-demo-android",
+            sourceKey = SourceKey.DEVELOPMENT,
+            userConsent = initialUserConsent
+        )
+        initSRGAnalytics(config = config)
     }
 
     @OptIn(ExperimentalCoilApi::class)


### PR DESCRIPTION
## Description

The goal of this PR is to initialize SRG Analytics for the Demo TV.

## Changes made

- Initialize SRGAnalytics

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
