### PR TITLE
Don't disable trackers on player tv

### DIFF
--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/PlayerActivity.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/ui/player/PlayerActivity.kt
@@ -102,7 +102,6 @@ class PlayerActivity : ComponentActivity() {
             }
             player.apply {
                 prepare()
-                trackingEnabled = false
                 playWhenReady = true
             }
         }


### PR DESCRIPTION
## Description

Don't disable trackers when starting playback inside the Player TV demo.

## Changes made

- Self-explanatory

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
