### PR TITLE
SRGAssetLoader handles PlayPlus endpoints

### DIFF
--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingService.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingService.kt
@@ -8,7 +8,7 @@ import ch.srgssr.pillarbox.core.business.integrationlayer.service.IlHost
 import java.net.URLEncoder
 
 /**
- * Service used to get a scaled image URL. This only works for SRG images.
+ * Service used to get a scaled image URL. This only works for SRG and PlayPlus images.
  *
  * @param ilHost Base URL of the service.
  */
@@ -20,7 +20,14 @@ internal class ImageScalingService(
         imageUrl: String,
     ): String {
         val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8.name())
+        return when (ilHost) {
+            IlHost.PROD, IlHost.STAGE, IlHost.TEST -> {
+                "${ilHost.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=960"
+            }
 
-        return "${ilHost.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=960"
+            else -> {
+                "https://img.playplus.ch?src=$encodedImageUrl&imwidth=1080"
+            }
+        }
     }
 }

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/IlHost.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/integrationlayer/service/IlHost.kt
@@ -12,20 +12,34 @@ package ch.srgssr.pillarbox.core.business.integrationlayer.service
 enum class IlHost(val baseHostUrl: String) {
 
     /**
-     * The base URL for the production environment.
+     * The base URL for the integration layer production environment.
      */
     PROD(baseHostUrl = "https://il.srgssr.ch"),
 
     /**
-     * The base URL for the test environment.
+     * The base URL for the integration layer test environment.
      */
     TEST(baseHostUrl = "https://il-test.srgssr.ch"),
 
     /**
-     * The base URL for the stage environment.
+     * The base URL for the integration layer stage environment.
      */
     STAGE(baseHostUrl = "https://il-stage.srgssr.ch"),
 
+    /**
+     * The base URL for the PlayPlus production environment.
+     */
+    PLAY_PLUS_PRODUCTION(baseHostUrl = "https://api.playplus.ch"),
+
+    /**
+     * The base URL for the PlayPlus integration environment.
+     */
+    PLAY_PLUS_INTEGRATION(baseHostUrl = "https://api.int.playplus.ch"),
+
+    /**
+     * The base URL for the PlayPlus development environment.
+     */
+    PLAY_PLUS_DEVELOPMENT(baseHostUrl = "https://api.dev.playplus.ch"),
     ;
 
     companion object {

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/ChapterAdapter.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/ChapterAdapter.kt
@@ -11,12 +11,15 @@ import ch.srgssr.pillarbox.core.business.integrationlayer.data.Chapter
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaComposition
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.MediaType
 import ch.srgssr.pillarbox.core.business.integrationlayer.data.Type
+import ch.srgssr.pillarbox.core.business.integrationlayer.service.IlHost
 import ch.srgssr.pillarbox.player.asset.timeRange.Chapter as TimeRangeChapter
 
 internal object ChapterAdapter {
-    private val imageScalingService = ImageScalingService()
 
-    fun toChapter(chapter: Chapter): TimeRangeChapter {
+    fun toChapter(
+        chapter: Chapter,
+        ilHost: IlHost = IlHost.PROD,
+    ): TimeRangeChapter {
         requireNotNull(chapter.fullLengthMarkIn)
         requireNotNull(chapter.fullLengthMarkOut)
         return TimeRangeChapter(
@@ -25,13 +28,16 @@ internal object ChapterAdapter {
             end = chapter.fullLengthMarkOut,
             mediaMetadata = MediaMetadata.Builder()
                 .setTitle(chapter.title)
-                .setArtworkUri(imageScalingService.getScaledImageUrl(chapter.imageUrl).toUri())
+                .setArtworkUri(ImageScalingService(ilHost).getScaledImageUrl(chapter.imageUrl).toUri())
                 .setDescription(chapter.lead)
                 .build()
         )
     }
 
-    fun getChapters(mediaComposition: MediaComposition): List<TimeRangeChapter> {
+    fun getChapters(
+        mediaComposition: MediaComposition,
+        ilHost: IlHost = IlHost.PROD,
+    ): List<TimeRangeChapter> {
         val mainChapter = mediaComposition.mainChapter
         if (mainChapter.mediaType == MediaType.AUDIO || mainChapter.type != Type.EPISODE) return emptyList()
         return mediaComposition.listChapter
@@ -46,7 +52,7 @@ internal object ChapterAdapter {
                 it.fullLengthUrn == mainChapter.urn
             }
             .map {
-                toChapter(it)
+                toChapter(it, ilHost)
             }
             .sortedBy { it.start }
             .toList()

--- a/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/SRGAssetLoader.kt
+++ b/pillarbox-core-business/src/main/java/ch/srgssr/pillarbox/core/business/source/SRGAssetLoader.kt
@@ -159,6 +159,7 @@ class SRGAssetLoader internal constructor(
         val mediaSource = chapter.spriteSheet?.let {
             MergingMediaSource(contentMediaSource, SpriteSheetMediaSource(it, loadingMediaItem, spriteSheetLoader, spriteSheetLoaderCoroutineContext))
         } ?: contentMediaSource
+        val ilHost = mediaItem.localConfiguration!!.uri.toIlUrl().host
         return Asset(
             mediaSource = mediaSource,
             trackersData = trackerData.toMediaItemTrackerData(),
@@ -167,7 +168,7 @@ class SRGAssetLoader internal constructor(
             }.build(),
             pillarboxMetadata = PillarboxMetadata(
                 blockedTimeRanges = SegmentAdapter.getBlockedTimeRanges(chapter.listSegment),
-                chapters = ChapterAdapter.getChapters(result),
+                chapters = ChapterAdapter.getChapters(result, ilHost),
                 credits = TimeIntervalAdapter.getCredits(chapter.timeIntervalList)
             ),
         )

--- a/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingServiceTest.kt
+++ b/pillarbox-core-business/src/test/java/ch/srgssr/pillarbox/core/business/integrationlayer/ImageScalingServiceTest.kt
@@ -45,4 +45,40 @@ class ImageScalingServiceTest {
 
         assertEquals("${host.baseHostUrl}/images/?imageUrl=$encodedImageUrl&format=webp&width=960", scaledImageUrl)
     }
+
+    @Test
+    fun getScaledImageUrlPlayPlusProduction() {
+        val host = IlHost.PLAY_PLUS_PRODUCTION
+        val imageUrl = "https://www.rts.ch/2022/10/06/17/32/13444418.image/4x5"
+
+        val imageScalingService = ImageScalingService(host)
+        val scaledImageUrl = imageScalingService.getScaledImageUrl(imageUrl)
+        val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8)
+
+        assertEquals("https://img.playplus.ch?src=$encodedImageUrl&imwidth=1080", scaledImageUrl)
+    }
+
+    @Test
+    fun getScaledImageUrlPlayPlusIntegration() {
+        val host = IlHost.PLAY_PLUS_INTEGRATION
+        val imageUrl = "https://www.rts.ch/2022/10/06/17/32/13444418.image/4x5"
+
+        val imageScalingService = ImageScalingService(host)
+        val scaledImageUrl = imageScalingService.getScaledImageUrl(imageUrl)
+        val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8)
+
+        assertEquals("https://img.playplus.ch?src=$encodedImageUrl&imwidth=1080", scaledImageUrl)
+    }
+
+    @Test
+    fun getScaledImageUrlPlayPlusDevelopment() {
+        val host = IlHost.PLAY_PLUS_DEVELOPMENT
+        val imageUrl = "https://www.rts.ch/2022/10/06/17/32/13444418.image/4x5"
+
+        val imageScalingService = ImageScalingService(host)
+        val scaledImageUrl = imageScalingService.getScaledImageUrl(imageUrl)
+        val encodedImageUrl = URLEncoder.encode(imageUrl, Charsets.UTF_8)
+
+        assertEquals("https://img.playplus.ch?src=$encodedImageUrl&imwidth=1080", scaledImageUrl)
+    }
 }

--- a/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
+++ b/pillarbox-demo-shared/src/main/java/ch/srgssr/pillarbox/demo/shared/di/PlayerModule.kt
@@ -56,9 +56,9 @@ object PlayerModule {
 
     private fun IlHost.toDataProviderIlHost(forceSAM: Boolean): DataProviderIlHost {
         return when (this) {
-            IlHost.PROD -> if (forceSAM) DataProviderIlHost.PROD_SAM else DataProviderIlHost.PROD
             IlHost.STAGE -> if (forceSAM) DataProviderIlHost.STAGE_SAM else DataProviderIlHost.STAGE
             IlHost.TEST -> if (forceSAM) DataProviderIlHost.TEST_SAM else DataProviderIlHost.TEST
+            else -> if (forceSAM) DataProviderIlHost.PROD_SAM else DataProviderIlHost.PROD
         }
     }
 


### PR DESCRIPTION
## Description

The goal of this PR is to introduce playplus `MediaCompositoin` to `pillarbox-core-business`.

## Changes made

- Add PlayPlus `IlHost`

> [!IMPORTANT]
> Library doesn't provide headers supported by PlayPlus hosts. They have to be setup with the http client you choose.  For e

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
