### PR TITLE
Add commandersAct platform_id and vector_id

### DIFF
--- a/pillarbox-analytics/docs/README.md
+++ b/pillarbox-analytics/docs/README.md
@@ -32,6 +32,7 @@ class MyApplication : Application() {
         val config = AnalyticsConfig(
             vendor = AnalyticsConfig.Vendor.SRG,
             appSiteName = "Your AppSiteName here",
+            platformId = "Your platform id",
             sourceKey = SourceKey.DEVELOPMENT,
             nonLocalizedApplicationName = "Your non-localized AppSiteName here",
         )
@@ -57,6 +58,7 @@ val userConsent = UserConsent(
 val config = AnalyticsConfig(
     vendor = AnalyticsConfig.Vendor.SRG,
     appSiteName = "Your AppSiteName here",
+    platformId = "Your platform id",
     sourceKey = SourceKey.DEVELOPMENT,
     nonLocalizedApplicationName = "Your non-localized AppSiteName here",
     userConsent = userConsent,

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
@@ -17,7 +17,7 @@ import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
  * @property appSiteName The name of the app/site being tracked, given by the analytics team.
  * @property sourceKey The CommandersAct source key. Production apps should use [SourceKey.PRODUCTION], and apps in development should use
  * [SourceKey.DEVELOPMENT].
- * @property platformId Unique ID of the platform (e.g. playplus, srfweb, srfnewsapp, etc.)
+ * @property platformId Unique ID of the platform defined at https://srgssr-ch.atlassian.net/wiki/spaces/RN/pages/2655846518/Reference+tables#Platform_i,
  * @property nonLocalizedApplicationName The non-localized name of the application. By default, the application name defined in the manifest is used.
  * @property userConsent The user consent to transmit to ComScore and Commanders Act.
  * @property comScorePersistentLabels The initial persistent labels for ComScore analytics.

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/AnalyticsConfig.kt
@@ -17,6 +17,7 @@ import ch.srgssr.pillarbox.analytics.SRGAnalytics.initSRGAnalytics
  * @property appSiteName The name of the app/site being tracked, given by the analytics team.
  * @property sourceKey The CommandersAct source key. Production apps should use [SourceKey.PRODUCTION], and apps in development should use
  * [SourceKey.DEVELOPMENT].
+ * @property platformId Unique ID of the platform (e.g. playplus, srfweb, srfnewsapp, etc.)
  * @property nonLocalizedApplicationName The non-localized name of the application. By default, the application name defined in the manifest is used.
  * @property userConsent The user consent to transmit to ComScore and Commanders Act.
  * @property comScorePersistentLabels The initial persistent labels for ComScore analytics.
@@ -27,6 +28,7 @@ data class AnalyticsConfig(
     val vendor: Vendor,
     val appSiteName: String,
     val sourceKey: SourceKey,
+    val platformId: String,
     val nonLocalizedApplicationName: String? = null,
     val userConsent: UserConsent = UserConsent(),
     val comScorePersistentLabels: Map<String, String>? = null,

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActLabels.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActLabels.kt
@@ -11,6 +11,7 @@ package ch.srgssr.pillarbox.analytics.commandersact
  */
 @Suppress("UndocumentedPublicProperty")
 enum class CommandersActLabels(val label: String) {
+
     // Event keys
     EVENT_VALUE("event_value"),
     EVENT_TYPE("event_type"),
@@ -34,5 +35,5 @@ enum class CommandersActLabels(val label: String) {
     PAGE_ID("page_id"),
     PAGE_VERSION("page_version"),
     ITEM_POSITION_IN_SECTION("item_position_in section"),
-    PROFILE_ID("profile_id")
+    PROFILE_ID("profile_id"),
 }

--- a/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrg.kt
+++ b/pillarbox-analytics/src/main/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrg.kt
@@ -22,13 +22,15 @@ import com.tagcommander.lib.serverside.schemas.TCDevice
  * @param tcServerSide TCServiceSide to use.
  * @param config analytics config.
  * @param navigationDevice The navigation device.
+ * @param vectorId The vector id, https://srgssr-ch.atlassian.net/wiki/spaces/RN/pages/2655846518/Reference+tables#Vector_id
  *
  * @constructor
  */
 internal class CommandersActSrg(
     private val tcServerSide: TCServerSide,
     private val config: AnalyticsConfig,
-    navigationDevice: String
+    navigationDevice: String,
+    vectorId: String,
 ) : CommandersAct {
 
     init {
@@ -42,6 +44,8 @@ internal class CommandersActSrg(
         tcServerSide.addPermanentData(APP_LIBRARY_VERSION, "${BuildConfig.VERSION_NAME}  ${BuildConfig.BUILD_DATE}")
         tcServerSide.addPermanentData(NAVIGATION_APP_SITE_NAME, config.appSiteName)
         tcServerSide.addPermanentData(NAVIGATION_DEVICE, navigationDevice)
+        tcServerSide.addPermanentData(VECTOR_ID, vectorId)
+        tcServerSide.addPermanentData(PLATFORM_ID, config.platformId)
 
         setConsentServices(config.userConsent.commandersActConsentServices)
         setProfileIdentifier(config.profileIdentifier)
@@ -53,7 +57,8 @@ internal class CommandersActSrg(
     ) : this(
         tcServerSide = TCServerSide(SITE_SRG, config.sourceKey.key, appContext),
         config = config,
-        navigationDevice = appContext.getString(R.string.tc_analytics_device)
+        navigationDevice = appContext.getString(R.string.tc_analytics_device),
+        vectorId = appContext.getString(R.string.tc_vector_id)
     ) {
         workaroundUniqueIdV4Tov5()
     }
@@ -141,5 +146,8 @@ internal class CommandersActSrg(
         private const val APP_LIBRARY_VERSION = "app_library_version"
         private const val NAVIGATION_APP_SITE_NAME = "navigation_app_site_name"
         private const val NAVIGATION_DEVICE = "navigation_device"
+
+        private const val PLATFORM_ID = "platform_id"
+        private const val VECTOR_ID = "vector_id"
     }
 }

--- a/pillarbox-analytics/src/main/res/values-television/analytics.xml
+++ b/pillarbox-analytics/src/main/res/values-television/analytics.xml
@@ -4,4 +4,5 @@
   -->
 <resources>
     <string name="tc_analytics_device" translatable="false">tvbox</string>
+    <string name="tc_vector_id" translatable="false">tv.android</string>
 </resources>

--- a/pillarbox-analytics/src/main/res/values/analytics.xml
+++ b/pillarbox-analytics/src/main/res/values/analytics.xml
@@ -4,4 +4,5 @@
   -->
 <resources>
     <string name="tc_analytics_device" translatable="false">phone</string>
+    <string name="tc_vector_id" translatable="false">mobile.android</string>
 </resources>

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/SRGAnalyticsSingletonTest.kt
@@ -8,6 +8,7 @@ import android.app.Application
 import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import ch.srgssr.pillarbox.analytics.commandersact.TestUtils
 import com.comscore.Analytics
 import io.mockk.clearAllMocks
 import io.mockk.mockkStatic
@@ -19,11 +20,7 @@ import kotlin.test.Test
 
 @RunWith(AndroidJUnit4::class)
 class SRGAnalyticsSingletonTest {
-    private val config = AnalyticsConfig(
-        vendor = AnalyticsConfig.Vendor.SRG,
-        appSiteName = "pillarbox-test-android",
-        sourceKey = SourceKey.DEVELOPMENT
-    )
+    private val config = TestUtils.analyticsConfig
 
     private lateinit var context: Context
 

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrgTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/CommandersActSrgTest.kt
@@ -27,7 +27,10 @@ class CommandersActSrgTest {
     private val analyticsConfig = TestUtils.analyticsConfig
 
     private val commandersAct: CommandersActSrg by lazy {
-        CommandersActSrg(config = analyticsConfig, appContext = ApplicationProvider.getApplicationContext())
+        CommandersActSrg(
+            config = analyticsConfig,
+            appContext = ApplicationProvider.getApplicationContext()
+        )
     }
 
     @Test
@@ -42,6 +45,20 @@ class CommandersActSrgTest {
     fun `navigation device is phone`() {
         val actual = commandersAct.getPermanentDataLabel("navigation_device")
         assertEquals("phone", actual)
+    }
+
+    @Test
+    @Config(qualifiers = "television")
+    fun `vector id is tv android`() {
+        val actual = commandersAct.getPermanentDataLabel("vector_id")
+        assertEquals("tv.android", actual)
+    }
+
+    @Test
+    @Config
+    fun `vector id is mobile android`() {
+        val actual = commandersAct.getPermanentDataLabel("vector_id")
+        assertEquals("mobile.android", actual)
     }
 
     @Test
@@ -74,7 +91,7 @@ class CommandersActSrgTest {
     @Test
     fun `sendEvent() with CommandersActEvent`() {
         val serverSide = mockk<TCServerSide>(relaxed = true)
-        val commandersAct = CommandersActSrg(tcServerSide = serverSide, config = analyticsConfig, "tests")
+        val commandersAct = createCommandersAct(serverSide)
         val eventSlot = slot<TCEvent>()
 
         commandersAct.sendEvent(CommandersActEvent(name = "dummy"))
@@ -89,7 +106,7 @@ class CommandersActSrgTest {
     @Test
     fun `sendPageView() with CommandersActPageView`() {
         val serverSide = mockk<TCServerSide>(relaxed = true)
-        val commandersAct = CommandersActSrg(tcServerSide = serverSide, config = analyticsConfig, "tests")
+        val commandersAct = createCommandersAct(serverSide)
         val eventSlot = slot<TCEvent>()
 
         commandersAct.sendPageView(
@@ -116,7 +133,7 @@ class CommandersActSrgTest {
     @Test
     fun `sendTcMediaEvent() with TCMediaEvent`() {
         val serverSide = mockk<TCServerSide>(relaxed = true)
-        val commandersAct = CommandersActSrg(tcServerSide = serverSide, config = analyticsConfig, "tests")
+        val commandersAct = createCommandersAct(serverSide)
         val eventSlot = slot<TCEvent>()
 
         commandersAct.sendTcMediaEvent(TCMediaEvent(eventType = MediaEventType.Eof, assets = emptyMap()))
@@ -148,4 +165,11 @@ class CommandersActSrgTest {
         assertEquals(legacyUniqueId, TCDevice.getInstance().sdkID)
         assertEquals(legacyUniqueId, TCUser.getInstance().anonymous_id)
     }
+
+    private fun createCommandersAct(serverSide: TCServerSide): CommandersActSrg = CommandersActSrg(
+        tcServerSide = serverSide,
+        config = analyticsConfig,
+        navigationDevice = "phone",
+        vectorId = "mobile.android"
+    )
 }

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TestUtils.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/commandersact/TestUtils.kt
@@ -11,6 +11,7 @@ object TestUtils {
     val analyticsConfig = AnalyticsConfig(
         vendor = AnalyticsConfig.Vendor.SRG,
         appSiteName = "pillarbox-test-android",
-        sourceKey = SourceKey.DEVELOPMENT
+        sourceKey = SourceKey.DEVELOPMENT,
+        platformId = "pillarbox"
     )
 }

--- a/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
+++ b/pillarbox-analytics/src/test/java/ch/srgssr/pillarbox/analytics/comscore/ComScoreSrgTest.kt
@@ -8,7 +8,7 @@ import android.content.Context
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import ch.srgssr.pillarbox.analytics.AnalyticsConfig
-import ch.srgssr.pillarbox.analytics.SourceKey
+import ch.srgssr.pillarbox.analytics.commandersact.TestUtils
 import com.comscore.Analytics
 import com.comscore.PublisherConfiguration
 import io.mockk.clearAllMocks
@@ -25,11 +25,7 @@ import kotlin.test.Test
 
 @RunWith(AndroidJUnit4::class)
 class ComScoreSrgTest {
-    private val config = AnalyticsConfig(
-        vendor = AnalyticsConfig.Vendor.SRG,
-        appSiteName = "pillarbox-test-android",
-        sourceKey = SourceKey.DEVELOPMENT
-    )
+    private val config = TestUtils.analyticsConfig
 
     private lateinit var context: Context
 

--- a/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/DemoApplication.kt
+++ b/pillarbox-demo-tv/src/main/java/ch/srgssr/pillarbox/demo/tv/DemoApplication.kt
@@ -53,6 +53,7 @@ class DemoApplication : Application(), SingletonImageLoader.Factory {
             vendor = AnalyticsConfig.Vendor.SRG,
             nonLocalizedApplicationName = "Pillarbox",
             appSiteName = "pillarbox-demo-android",
+            platformId = "pillarbox",
             sourceKey = SourceKey.DEVELOPMENT,
             userConsent = initialUserConsent
         )

--- a/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
+++ b/pillarbox-demo/src/main/java/ch/srgssr/pillarbox/demo/DemoApplication.kt
@@ -57,6 +57,7 @@ class DemoApplication : Application(), SingletonImageLoader.Factory {
             vendor = AnalyticsConfig.Vendor.SRG,
             nonLocalizedApplicationName = "Pillarbox",
             appSiteName = "pillarbox-demo-android",
+            platformId = "pillarbox",
             sourceKey = SourceKey.DEVELOPMENT,
             userConsent = initialUserConsent
         )


### PR DESCRIPTION
## Description

Add `platform_id` as new analytics configuration and computes `vector_id`.

## Changes made

- Add `platform_id` to `AnalyticsConfig'
- Compute `vector_id` as specified in the confluence page.

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
