### PR TITLE
Add API to setup a custom BitmapLoader with MediaSession

### DIFF
--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibraryService.kt
@@ -60,7 +60,33 @@ abstract class PillarboxMediaLibraryService : MediaLibraryService() {
     /**
      * Set player to use with this Service.
      * @param player [PillarboxPlayer] to link to this service.
-     * @param callback The [PillarboxMediaLibrarySession.Callback]
+     * @param callback The [PillarboxMediaLibrarySession.Callback].
+     * @param builder The [PillarboxMediaLibrarySession.Builder].
+     */
+    fun setPlayer(
+        player: PillarboxPlayer,
+        callback: PillarboxMediaLibrarySession.Callback,
+        builder: PillarboxMediaLibrarySession.Builder.() -> Unit,
+    ) {
+        if (this.mediaSession == null) {
+            player.setHandleAudioFocus(true)
+            mediaSession = PillarboxMediaLibrarySession.Builder(this, player, callback)
+                .apply {
+                    sessionActivity()?.let {
+                        setSessionActivity(it)
+                    }
+                }
+                .apply(builder)
+                .build()
+        } else {
+            mediaSession?.player = player
+        }
+    }
+
+    /**
+     * Set player to use with this Service.
+     * @param player [PillarboxPlayer] to link to this service.
+     * @param callback The [PillarboxMediaLibrarySession.Callback].
      * @param sessionId The ID. Must be unique among all sessions per package.
      */
     fun setPlayer(
@@ -68,18 +94,10 @@ abstract class PillarboxMediaLibraryService : MediaLibraryService() {
         callback: PillarboxMediaLibrarySession.Callback,
         sessionId: String? = null,
     ) {
-        if (this.mediaSession == null) {
-            player.setHandleAudioFocus(true)
-            mediaSession = PillarboxMediaLibrarySession.Builder(this, player, callback).apply {
-                sessionActivity()?.let {
-                    setSessionActivity(it)
-                }
-                sessionId?.let {
-                    setId(it)
-                }
-            }.build()
-        } else {
-            mediaSession?.player = player
+        setPlayer(player, callback) {
+            sessionId?.let {
+                setId(it)
+            }
         }
     }
 

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibrarySession.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibrarySession.kt
@@ -8,6 +8,7 @@ import android.app.PendingIntent
 import androidx.annotation.IntRange
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
+import androidx.media3.common.util.BitmapLoader
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaLibraryService.MediaLibrarySession
@@ -123,6 +124,7 @@ open class PillarboxMediaLibrarySession internal constructor() : PillarboxMediaS
     ) {
         private var pendingIntent: PendingIntent? = PendingIntentUtils.getDefaultPendingIntent(service)
         private var id: String? = null
+        private var bitmapLoader: BitmapLoader? = null
 
         /**
          * Set session activity
@@ -147,6 +149,17 @@ open class PillarboxMediaLibrarySession internal constructor() : PillarboxMediaS
         }
 
         /**
+         * Set bitmapLoader
+         *
+         * @param bitmapLoader The [BitmapLoader] to use.
+         * @return this builder for convenience.
+         */
+        fun setBitmapLoader(bitmapLoader: BitmapLoader): Builder {
+            this.bitmapLoader = bitmapLoader
+            return this
+        }
+
+        /**
          * Build
          *
          * @return a new [PillarboxMediaLibrarySession]
@@ -158,6 +171,7 @@ open class PillarboxMediaLibrarySession internal constructor() : PillarboxMediaS
             val mediaSession = mediaSessionBuilder.apply {
                 id?.let { setId(it) }
                 pendingIntent?.let { setSessionActivity(it) }
+                bitmapLoader?.let { setBitmapLoader(it) }
             }.build()
             pillarboxMediaSession.setMediaSession(mediaSession)
             return pillarboxMediaSession

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibrarySession.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaLibrarySession.kt
@@ -153,6 +153,7 @@ open class PillarboxMediaLibrarySession internal constructor() : PillarboxMediaS
          *
          * @param bitmapLoader The [BitmapLoader] to use.
          * @return this builder for convenience.
+         *  @see MediaLibrarySession.Builder.setBitmapLoader
          */
         fun setBitmapLoader(bitmapLoader: BitmapLoader): Builder {
             this.bitmapLoader = bitmapLoader

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSession.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSession.kt
@@ -113,6 +113,7 @@ open class PillarboxMediaSession internal constructor() {
          *
          * @param callback
          * @return this builder for convenience.
+         * @see MediaSession.Builder.setBitmapLoader
          */
         fun setCallback(callback: Callback): Builder {
             this.callback = callback

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSession.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSession.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
 import androidx.media3.common.MediaItem
+import androidx.media3.common.util.BitmapLoader
 import androidx.media3.common.util.Util
 import androidx.media3.exoplayer.image.ImageOutput
 import androidx.media3.session.MediaSession
@@ -78,6 +79,7 @@ open class PillarboxMediaSession internal constructor() {
     class Builder(context: Context, player: PillarboxPlayer) {
         private val mediaSessionBuilder = MediaSession.Builder(context, player)
         private var callback: Callback = Callback.Default
+        private var bitmapLoader: BitmapLoader? = null
 
         /**
          * Sets a [PendingIntent] to launch an [Activity][android.app.Activity] for the [MediaSession].
@@ -118,6 +120,17 @@ open class PillarboxMediaSession internal constructor() {
         }
 
         /**
+         * Set bitmapLoader
+         *
+         * @param bitmapLoader The [BitmapLoader] to use.
+         * @return this builder for convenience.
+         */
+        fun setBitmapLoader(bitmapLoader: BitmapLoader): Builder {
+            this.bitmapLoader = bitmapLoader
+            return this
+        }
+
+        /**
          * Build
          *
          * @return create a [PillarboxMediaSession].
@@ -125,9 +138,12 @@ open class PillarboxMediaSession internal constructor() {
         fun build(): PillarboxMediaSession {
             val pillarboxMediaSession = PillarboxMediaSession()
             val media3SessionCallback = MediaSessionCallbackImpl(callback, pillarboxMediaSession)
-            val mediaSession = mediaSessionBuilder
-                .setCallback(media3SessionCallback)
-                .build()
+            val mediaSession = mediaSessionBuilder.apply {
+                setCallback(media3SessionCallback)
+                bitmapLoader?.let {
+                    setBitmapLoader(it)
+                }
+            }.build()
             pillarboxMediaSession.setMediaSession(mediaSession)
             return pillarboxMediaSession
         }

--- a/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
+++ b/pillarbox-player/src/main/java/ch/srgssr/pillarbox/player/session/PillarboxMediaSessionService.kt
@@ -56,6 +56,30 @@ abstract class PillarboxMediaSessionService : MediaSessionService() {
     /**
      * Set player to use with this Service.
      * @param player [PillarboxPlayer] to link to this service.
+     * @param builder The [PillarboxMediaSession.Builder].
+     */
+    fun setPlayer(
+        player: PillarboxPlayer,
+        builder: PillarboxMediaSession.Builder.() -> Unit,
+    ) {
+        if (this.mediaSession == null) {
+            player.setHandleAudioFocus(true)
+            mediaSession = PillarboxMediaSession.Builder(this, player)
+                .apply {
+                    sessionActivity()?.let {
+                        setSessionActivity(it)
+                    }
+                }
+                .apply(builder)
+                .build()
+        } else {
+            mediaSession?.player = player
+        }
+    }
+
+    /**
+     * Set player to use with this Service.
+     * @param player [PillarboxPlayer] to link to this service.
      * @param mediaSessionCallback The [PillarboxMediaSession.Callback]
      * @param sessionId The ID. Must be unique among all sessions per package.
      */
@@ -64,19 +88,11 @@ abstract class PillarboxMediaSessionService : MediaSessionService() {
         mediaSessionCallback: PillarboxMediaSession.Callback = PillarboxMediaSession.Callback.Default,
         sessionId: String? = null,
     ) {
-        if (this.mediaSession == null) {
-            player.setHandleAudioFocus(true)
-            mediaSession = PillarboxMediaSession.Builder(this, player).apply {
-                sessionActivity()?.let {
-                    setSessionActivity(it)
-                }
-                setCallback(mediaSessionCallback)
-                sessionId?.let {
-                    setId(it)
-                }
-            }.build()
-        } else {
-            mediaSession?.player = player
+        setPlayer(player) {
+            sessionId?.let {
+                setId(it)
+            }
+            setCallback(mediaSessionCallback)
         }
     }
 


### PR DESCRIPTION
## Description

The goal of this PR is to allow integrators to inject a `BitmapLoader` when creating a `PillarboxMediaSession` or `PillarboxMediaLibrarySession`.

## Changes made

- Add `BitmapLoader` to `PillarboxMediaSession.Builder`
- Add `BitmapLoader` to `PillarboxMediaLibrarySession.Builder`.
- Improve `PillarboxMediaSessionService` and `PillarboxMediaLibraryService`

## Checklist

- [ ] APIs have been properly documented (if relevant).
- [ ] The documentation has been updated (if relevant).
- [ ] New unit tests have been written (if relevant).
- [ ] The demo has been updated (if relevant).
