### PR TITLE
Bugfix cast network detection android 17

### DIFF
--- a/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/AppConfig.kt
+++ b/build-logic/plugins/src/main/java/ch/srgssr/pillarbox/gradle/internal/AppConfig.kt
@@ -10,7 +10,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 internal object AppConfig {
     internal const val libraryMinSdk = 23
     internal const val appMinSdk = 24
-    internal const val targetSdk = 37
+    internal const val targetSdk = 36
     internal const val compileSdk = 37
 
     private const val javaVersionName = "17"

--- a/pillarbox-cast/docs/README.md
+++ b/pillarbox-cast/docs/README.md
@@ -13,6 +13,12 @@ implementation("ch.srgssr.pillarbox:pillarbox-cast:<pillarbox_version>")
 The main goal of this module is to be able to build a user interface that can be used with a [PillarboxExoPlayer][ch.srgssr.pillarbox.player.PillarboxExoPlayer] or [PillarboxCastPlayer][ch.srgssr.pillarbox.cast.PillarboxCastPlayer]. Both
 implementations are based on the [PillarboxPlayer][ch.srgssr.pillarbox.player.PillarboxPlayer] interface.
 
+> [!CAUTION]  
+> Required since Android 17 (target API 37) to discover and connect to Cast receivers on the LAN.
+>
+> [Request runtime permission](https://developer.android.com/training/permissions/requesting):
+`<uses-permission android:name="android.permission.ACCESS_LOCAL_NETWORK" />`
+
 ## Getting started
 
 ### Setup [CastContext][cast-context]


### PR DESCRIPTION
## Description

Casting is broken on Android 17 (only Android 17): clicking the cast button loads the network list, which then times out without detecting any device.

This regression was detected in 9.6.0 but first appeared in 9.4.0.

Root cause: Android 17 introduced a new [Local Network Protection permission](https://developer.android.com/about/versions/17/behavior-changes-17#local-network-protection-permission) requirement. NEARBY_DEVICES must now be explicitly requested and granted for local network/device discovery to work, which cast relies on.

## Changes made

Reverted targetSdk to 36 as a short-term fix to restore casting on Android 17
Added a [backlog task](https://github.com/SRGSSR/pillarbox-android/issues/1338) to properly request the NEARBY_DEVICES permission so we can raise targetSdk back to 17 without breaking cast

## Checklist

- [ ] Documentation updated (if relevant)
- [ ]  Verified cast works on Android 17
- [ ] Verified cast still works on other supported Android versions